### PR TITLE
[CI] Added tests and linters via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: go
+env:
+  jobs:
+    - TEST_SUITE=tests
+    - TEST_SUITE=linters
+
+before_install:
+  - go get -v -t ./...
+
+script: |
+  set -x
+  case $TEST_SUITE in
+  tests)
+      ./.travis/tests.sh
+      ;;
+  linters)
+      ./.travis/linters.sh
+      ;;
+  *)
+      echo "[!] Unknown test suite: ${TEST_SUITE}. Exiting."
+      exit 1
+  esac
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis/config.json
+++ b/.travis/config.json
@@ -1,0 +1,25 @@
+{
+    "gopkg": "github.com/facebookincubator/ntp",
+    "licenses": [
+        [
+            "^/\\*",
+            "Copyright \\(c\\) Facebook, Inc\\. and its affiliates\\.",
+            "",
+            "Licensed under the Apache License, Version 2\\.0 \\(the \"License\"\\);",
+            "you may not use this file except in compliance with the License\\.",
+            "You may obtain a copy of the License at",
+            "",
+            "    http://www\\.apache\\.org/licenses/LICENSE-2\\.0",
+            "",
+            "Unless required by applicable law or agreed to in writing, software",
+            "distributed under the License is distributed on an \"AS IS\" BASIS,",
+            "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\\.",
+            "See the License for the specific language governing permissions and",
+            "limitations under the License\\.",
+            "\\*/"
+        ]
+    ],
+    "accept": [
+        ".*\\.go"
+    ]
+}

--- a/.travis/linters.sh
+++ b/.travis/linters.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -exu
+
+go get -v -u github.com/golangci/golangci-lint/cmd/golangci-lint
+go install github.com/golangci/golangci-lint/cmd/golangci-lint
+cd "${TRAVIS_BUILD_DIR}"
+golangci-lint run --enable deadcode --enable varcheck --enable staticcheck
+
+# check license headers
+# this needs to be run from the top level directory, because it uses
+# `git ls-files` under the hood.
+go get -v -u github.com/u-root/u-root/tools/checklicenses
+go install github.com/u-root/u-root/tools/checklicenses
+cd "${TRAVIS_BUILD_DIR}"
+echo "[*] Running checklicenses"
+go run github.com/u-root/u-root/tools/checklicenses -c .travis/config.json


### PR DESCRIPTION
Added tests and linters, adapted from facebookincubator/contest . FB projects require license checks, included in the `linters.sh` script, and I thought you may benefit from not redoing the work. The linters include golangci-lint and license header checks, and there is a generic `go test ./...` in the .yml. Feel free to reject if you plan to do this differently.

In order to run, this needs enabling facebookincubator/ntp in Travis-CI, which is done by asking our OSS team.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>