### PR TITLE
[ntp][responder] fix error formatting

### DIFF
--- a/responder/server/ip.go
+++ b/responder/server/ip.go
@@ -45,7 +45,7 @@ func (s *Server) addIPToInterface(vip net.IP) error {
 	// Add IPs to the interface
 	iface, err := net.InterfaceByName(s.ListenConfig.Iface)
 	if err != nil {
-		return fmt.Errorf("failed to add IP to the %s interface: %w", iface, err)
+		return fmt.Errorf("failed to add IP to the %s interface: %v", s.ListenConfig.Iface, err)
 	}
 
 	return addIfaceIP(iface, &vip)

--- a/responder/server/server.go
+++ b/responder/server/server.go
@@ -182,7 +182,7 @@ func (t *task) serve(response *ntp.Packet, extraoffset time.Duration) {
 		generateResponse(time.Now().Add(extraoffset), t.received.Add(extraoffset), t.request, response)
 		responseBytes, err := response.Bytes()
 		if err != nil {
-			log.Errorf("Failed to convert ntp.%v to bytes %v: %w", response, responseBytes, err)
+			log.Errorf("Failed to convert ntp.%v to bytes %v: %v", response, responseBytes, err)
 			return
 		}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix for new linters
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
go test -v ./...
=== RUN   TestCommunicateEOF
--- PASS: TestCommunicateEOF (0.00s)
=== RUN   TestCommunicateSingle
--- PASS: TestCommunicateSingle (0.00s)
=== RUN   TestCommunicateMulti
--- PASS: TestCommunicateMulti (0.00s)
=== RUN   TestNormalizeData
--- PASS: TestNormalizeData (0.00s)
=== RUN   TestNormalizeDataCorrupted
--- PASS: TestNormalizeDataCorrupted (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/protocol/control	(cached)
=== RUN   Test_RequestConversion
--- PASS: Test_RequestConversion (0.00s)
=== RUN   Test_ResponseConersion
--- PASS: Test_ResponseConersion (0.00s)
=== RUN   Test_BytesToPacket
--- PASS: Test_BytesToPacket (0.00s)
=== RUN   Test_BytesToPacketError
--- PASS: Test_BytesToPacketError (0.00s)
=== RUN   Test_PacketConversionFailure
--- PASS: Test_PacketConversionFailure (0.00s)
=== RUN   Test_RequestSize
--- PASS: Test_RequestSize (0.00s)
=== RUN   Test_ResponseSize
--- PASS: Test_ResponseSize (0.00s)
=== RUN   Test_ValidSettingsFormat
--- PASS: Test_ValidSettingsFormat (0.00s)
=== RUN   Test_invalidSettingsFormat
--- PASS: Test_invalidSettingsFormat (0.00s)
=== RUN   Test_Time
--- PASS: Test_Time (0.00s)
=== RUN   Test_Unix
--- PASS: Test_Unix (0.00s)
=== RUN   Test_abs
--- PASS: Test_abs (0.00s)
=== RUN   Test_AvgNetworkDelay
--- PASS: Test_AvgNetworkDelay (0.00s)
=== RUN   Test_AvgNetworkDelayPositive
--- PASS: Test_AvgNetworkDelayPositive (0.00s)
=== RUN   Test_AvgNetworkDelayNegative
--- PASS: Test_AvgNetworkDelayNegative (0.00s)
=== RUN   Test_CurrentRealTime
--- PASS: Test_CurrentRealTime (0.00s)
=== RUN   Test_CalculateOffset
--- PASS: Test_CalculateOffset (0.00s)
=== RUN   Test_connFd
--- PASS: Test_connFd (0.00s)
=== RUN   Test_EnableKernelTimestampsSocket
--- PASS: Test_EnableKernelTimestampsSocket (0.00s)
=== RUN   Test_ReadNTPPacket
--- PASS: Test_ReadNTPPacket (0.00s)
=== RUN   Test_ReadPacketWithKernelTimestamp
--- PASS: Test_ReadPacketWithKernelTimestamp (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/protocol/ntp	(cached)
?   	github.com/facebookincubator/ntp/responder	[no test files]
?   	github.com/facebookincubator/ntp/responder/announce	[no test files]
=== RUN   Test_SimpleCheckerListeners
--- PASS: Test_SimpleCheckerListeners (0.00s)
=== RUN   Test_SimpleCheckerWorkers
--- PASS: Test_SimpleCheckerWorkers (0.00s)
=== RUN   Test_SimpleCheckListeners
--- PASS: Test_SimpleCheckListeners (0.00s)
=== RUN   Test_CheckListenersFail
--- PASS: Test_CheckListenersFail (0.00s)
=== RUN   Test_SimpleCheckerCheckWorkers
--- PASS: Test_SimpleCheckerCheckWorkers (0.00s)
=== RUN   Test_SimpleCheckerCheckWorkersFail
--- PASS: Test_SimpleCheckerCheckWorkersFail (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/responder/checker	(cached)
=== RUN   Test_ConfigSet
--- PASS: Test_ConfigSet (0.00s)
=== RUN   Test_ConfigSetInvalid
--- PASS: Test_ConfigSetInvalid (0.00s)
=== RUN   Test_ConfigString
--- PASS: Test_ConfigString (0.00s)
=== RUN   Test_ConfigSetDefault
--- PASS: Test_ConfigSetDefault (0.00s)
=== RUN   Test_checkIP
--- PASS: Test_checkIP (0.00s)
=== RUN   Test_checkIPFalse
--- PASS: Test_checkIPFalse (0.00s)
=== RUN   Test_addIPToInterfaceError
--- PASS: Test_addIPToInterfaceError (0.00s)
=== RUN   Test_deleteIPFromInterfaceError
--- PASS: Test_deleteIPFromInterfaceError (0.00s)
=== RUN   Test_fillStaticHeadersStratum
--- PASS: Test_fillStaticHeadersStratum (0.00s)
=== RUN   Test_fillStaticHeadersReferenceID
--- PASS: Test_fillStaticHeadersReferenceID (0.00s)
=== RUN   Test_fillStaticHeadersRootDelay
--- PASS: Test_fillStaticHeadersRootDelay (0.00s)
=== RUN   Test_fillStaticHeadersRootDispersion
--- PASS: Test_fillStaticHeadersRootDispersion (0.00s)
=== RUN   Test_generateResponsePoll
--- PASS: Test_generateResponsePoll (0.00s)
=== RUN   Test_generateResponseTimestamps
--- PASS: Test_generateResponseTimestamps (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/responder/server	(cached)
=== RUN   Test_JSONStatsInvalidFormat
--- PASS: Test_JSONStatsInvalidFormat (0.00s)
=== RUN   Test_JSONStatsRequests
--- PASS: Test_JSONStatsRequests (0.00s)
=== RUN   Test_JSONStatsResponses
--- PASS: Test_JSONStatsResponses (0.00s)
=== RUN   Test_JSONStatsListeners
--- PASS: Test_JSONStatsListeners (0.00s)
=== RUN   Test_JSONStatsWorkers
--- PASS: Test_JSONStatsWorkers (0.00s)
=== RUN   Test_JSONStatsAnnounce
--- PASS: Test_JSONStatsAnnounce (0.00s)
=== RUN   Test_JSONStatsSetPrefix
--- PASS: Test_JSONStatsSetPrefix (0.00s)
=== RUN   Test_JSONStatsToMap
--- PASS: Test_JSONStatsToMap (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/responder/stats	(cached)
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
