### PR TITLE
Fix linter warnings

### DIFF
--- a/protocol/control/client.go
+++ b/protocol/control/client.go
@@ -34,8 +34,7 @@ type NTPClient struct {
 func (n *NTPClient) Communicate(packet *NTPControlMsgHead) (*NTPControlMsg, error) {
 	packet.Sequence = n.Sequence
 	n.Sequence++
-	var err error
-	err = binary.Write(n.Connection, binary.BigEndian, packet)
+	err := binary.Write(n.Connection, binary.BigEndian, packet)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/ntp/ntp_test.go
+++ b/protocol/ntp/ntp_test.go
@@ -302,13 +302,13 @@ func Test_ReadPacketWithKernelTimestamp(t *testing.T) {
 
 func Benchmark_PacketToBytesConversion(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ntpResponse.Bytes()
+		_, _ = ntpResponse.Bytes()
 	}
 }
 
 func Benchmark_BytesToPacketConversion(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		BytesToPacket(ntpResponseBytes)
+		_, _ = BytesToPacket(ntpResponseBytes)
 	}
 }
 
@@ -326,8 +326,8 @@ func Benchmark_ServerWithoutHWTimestamps(b *testing.B) {
 	defer cconn.Close()
 
 	for i := 0; i < b.N; i++ {
-		cconn.Write(ntpRequestBytes)
-		ReadNTPPacket(conn)
+		_, _ = cconn.Write(ntpRequestBytes)
+		_, _, _ = ReadNTPPacket(conn)
 	}
 }
 
@@ -349,8 +349,8 @@ func Benchmark_ServerWithHWTimestamps(b *testing.B) {
 	defer cconn.Close()
 
 	for i := 0; i < b.N; i++ {
-		cconn.Write(ntpRequestBytes)
-		ReadNTPPacket(conn)
+		_, _ = cconn.Write(ntpRequestBytes)
+		_, _, _ = ReadNTPPacket(conn)
 	}
 }
 
@@ -372,7 +372,7 @@ func Benchmark_ServerWithHWTimestampsRead(b *testing.B) {
 	defer cconn.Close()
 
 	for i := 0; i < b.N; i++ {
-		cconn.Write(ntpRequestBytes)
-		ReadPacketWithKernelTimestamp(conn)
+		_, _ = cconn.Write(ntpRequestBytes)
+		_, _, _, _ = ReadPacketWithKernelTimestamp(conn)
 	}
 }

--- a/responder/server/config_test.go
+++ b/responder/server/config_test.go
@@ -28,8 +28,8 @@ func Test_ConfigSet(t *testing.T) {
 	testIP := "1.2.3.4"
 
 	m := MultiIPs{}
-	m.Set(testIP)
-
+	err := m.Set(testIP)
+	assert.Nil(t, err)
 	assert.Equal(t, net.ParseIP(testIP), m[0])
 }
 
@@ -37,8 +37,8 @@ func Test_ConfigSetInvalid(t *testing.T) {
 	testIP := "invalid"
 
 	m := MultiIPs{}
-	m.Set(testIP)
-
+        err := m.Set(testIP)
+        assert.NotNil(t, err)
 	assert.Empty(t, m)
 }
 
@@ -47,8 +47,10 @@ func Test_ConfigString(t *testing.T) {
 	testIP2 := "5.6.7.8"
 
 	m := MultiIPs{}
-	m.Set(testIP1)
-	m.Set(testIP2)
+	err := m.Set(testIP1)
+	assert.Nil(t, err)
+	err = m.Set(testIP2)
+	assert.Nil(t, err)
 
 	assert.Equal(t, m.String(), fmt.Sprintf("%s, %s", testIP1, testIP2))
 }

--- a/responder/stats/json.go
+++ b/responder/stats/json.go
@@ -61,7 +61,9 @@ func (j *JSONStats) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err = w.Write(js); err != nil {
+		log.Errorf("Failed to reply: %v", err)
+	}
 }
 
 // Start with launch 303 thrift and report ODS metrics periodically
@@ -69,7 +71,10 @@ func (j *JSONStats) Start(port int) {
 	http.HandleFunc("/", j.handleRequest)
 	addr := fmt.Sprintf(":%d", port)
 	log.Debugf("Starting http json server on %s", addr)
-	http.ListenAndServe(addr, nil)
+	err := http.ListenAndServe(addr, nil)
+	if err != nil {
+		log.Errorf("Failed to start listener: %v", err)
+	}
 }
 
 // SetPrefix is implementing SetPrefix function of interface


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Running `golangci-lint run --enable deadcode --enable varcheck --enable staticcheck -v` revealed some linter errors we were not aware of before.

## Test Plan

```
$ go test -v ./...
=== RUN   TestCommunicateEOF
--- PASS: TestCommunicateEOF (0.00s)
=== RUN   TestCommunicateSingle
--- PASS: TestCommunicateSingle (0.00s)
=== RUN   TestCommunicateMulti
--- PASS: TestCommunicateMulti (0.00s)
=== RUN   TestNormalizeData
--- PASS: TestNormalizeData (0.00s)
=== RUN   TestNormalizeDataCorrupted
--- PASS: TestNormalizeDataCorrupted (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/protocol/control	(cached)
=== RUN   Test_RequestConversion
--- PASS: Test_RequestConversion (0.00s)
=== RUN   Test_ResponseConersion
--- PASS: Test_ResponseConersion (0.00s)
=== RUN   Test_BytesToPacket
--- PASS: Test_BytesToPacket (0.00s)
=== RUN   Test_BytesToPacketError
--- PASS: Test_BytesToPacketError (0.00s)
=== RUN   Test_PacketConversionFailure
--- PASS: Test_PacketConversionFailure (0.00s)
=== RUN   Test_RequestSize
--- PASS: Test_RequestSize (0.00s)
=== RUN   Test_ResponseSize
--- PASS: Test_ResponseSize (0.00s)
=== RUN   Test_ValidSettingsFormat
--- PASS: Test_ValidSettingsFormat (0.00s)
=== RUN   Test_invalidSettingsFormat
--- PASS: Test_invalidSettingsFormat (0.00s)
=== RUN   Test_Time
--- PASS: Test_Time (0.00s)
=== RUN   Test_Unix
--- PASS: Test_Unix (0.00s)
=== RUN   Test_abs
--- PASS: Test_abs (0.00s)
=== RUN   Test_AvgNetworkDelay
--- PASS: Test_AvgNetworkDelay (0.00s)
=== RUN   Test_AvgNetworkDelayPositive
--- PASS: Test_AvgNetworkDelayPositive (0.00s)
=== RUN   Test_AvgNetworkDelayNegative
--- PASS: Test_AvgNetworkDelayNegative (0.00s)
=== RUN   Test_CurrentRealTime
--- PASS: Test_CurrentRealTime (0.00s)
=== RUN   Test_CalculateOffset
--- PASS: Test_CalculateOffset (0.00s)
=== RUN   Test_connFd
--- PASS: Test_connFd (0.00s)
=== RUN   Test_EnableKernelTimestampsSocket
--- PASS: Test_EnableKernelTimestampsSocket (0.00s)
=== RUN   Test_ReadNTPPacket
--- PASS: Test_ReadNTPPacket (0.00s)
=== RUN   Test_ReadPacketWithKernelTimestamp
--- PASS: Test_ReadPacketWithKernelTimestamp (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/protocol/ntp	(cached)
?   	github.com/facebookincubator/ntp/responder	[no test files]
?   	github.com/facebookincubator/ntp/responder/announce	[no test files]
=== RUN   Test_SimpleCheckerListeners
--- PASS: Test_SimpleCheckerListeners (0.00s)
=== RUN   Test_SimpleCheckerWorkers
--- PASS: Test_SimpleCheckerWorkers (0.00s)
=== RUN   Test_SimpleCheckListeners
--- PASS: Test_SimpleCheckListeners (0.00s)
=== RUN   Test_CheckListenersFail
--- PASS: Test_CheckListenersFail (0.00s)
=== RUN   Test_SimpleCheckerCheckWorkers
--- PASS: Test_SimpleCheckerCheckWorkers (0.00s)
=== RUN   Test_SimpleCheckerCheckWorkersFail
--- PASS: Test_SimpleCheckerCheckWorkersFail (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/responder/checker	(cached)
=== RUN   Test_ConfigSet
--- PASS: Test_ConfigSet (0.00s)
=== RUN   Test_ConfigSetInvalid
--- PASS: Test_ConfigSetInvalid (0.00s)
=== RUN   Test_ConfigString
--- PASS: Test_ConfigString (0.00s)
=== RUN   Test_ConfigSetDefault
--- PASS: Test_ConfigSetDefault (0.00s)
=== RUN   Test_checkIP
--- PASS: Test_checkIP (0.00s)
=== RUN   Test_checkIPFalse
--- PASS: Test_checkIPFalse (0.00s)
=== RUN   Test_addIPToInterfaceError
--- PASS: Test_addIPToInterfaceError (0.00s)
=== RUN   Test_deleteIPFromInterfaceError
--- PASS: Test_deleteIPFromInterfaceError (0.00s)
=== RUN   Test_fillStaticHeadersStratum
--- PASS: Test_fillStaticHeadersStratum (0.00s)
=== RUN   Test_fillStaticHeadersReferenceID
--- PASS: Test_fillStaticHeadersReferenceID (0.00s)
=== RUN   Test_fillStaticHeadersRootDelay
--- PASS: Test_fillStaticHeadersRootDelay (0.00s)
=== RUN   Test_fillStaticHeadersRootDispersion
--- PASS: Test_fillStaticHeadersRootDispersion (0.00s)
=== RUN   Test_generateResponsePoll
--- PASS: Test_generateResponsePoll (0.00s)
=== RUN   Test_generateResponseTimestamps
--- PASS: Test_generateResponseTimestamps (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/responder/server	(cached)
=== RUN   Test_JSONStatsInvalidFormat
--- PASS: Test_JSONStatsInvalidFormat (0.00s)
=== RUN   Test_JSONStatsRequests
--- PASS: Test_JSONStatsRequests (0.00s)
=== RUN   Test_JSONStatsResponses
--- PASS: Test_JSONStatsResponses (0.00s)
=== RUN   Test_JSONStatsListeners
--- PASS: Test_JSONStatsListeners (0.00s)
=== RUN   Test_JSONStatsWorkers
--- PASS: Test_JSONStatsWorkers (0.00s)
=== RUN   Test_JSONStatsAnnounce
--- PASS: Test_JSONStatsAnnounce (0.00s)
=== RUN   Test_JSONStatsSetPrefix
--- PASS: Test_JSONStatsSetPrefix (0.00s)
=== RUN   Test_JSONStatsToMap
--- PASS: Test_JSONStatsToMap (0.00s)
PASS
ok  	github.com/facebookincubator/ntp/responder/stats	(cached)
```
```
$ golangci-lint run --enable deadcode --enable varcheck --enable staticcheck -v
INFO [config_reader] Config search paths: [./ /root/go/src/github.com/facebookincubator/ntp /root/go/src/github.com/facebookincubator /root/go/src/github.com /root/go/src /root/go /root /]
INFO [lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]
INFO [lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|imports|name|types_sizes|deps|files) took 660.171995ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 9.120133ms
INFO [runner/unused/goanalysis] analyzers took 36.023597ms with top 10 stages: buildir: 29.634885ms, U1000: 6.388712ms
INFO [runner/goanalysis_metalinter/goanalysis] analyzers took 81.901034ms with top 10 stages: buildir: 45.009943ms, ineffassign: 3.606399ms, S1038: 1.813032ms, printf: 1.31009ms, ctrlflow: 1.086107ms, varcheck: 933.422µs, errcheck: 864.493µs, deadcode: 822.873µs, S1039: 815.57µs, SA1012: 794.083µs
INFO [runner] Issues before processing: 16, after processing: 0
INFO [runner] Processors filtering stat (out/in): path_prettifier: 16/16, autogenerated_exclude: 16/16, skip_dirs: 16/16, exclude: 0/16, cgo: 16/16, filename_unadjuster: 16/16, skip_files: 16/16, identifier_marker: 16/16
INFO [runner] processing took 2.816533ms with stages: exclude: 2.15719ms, identifier_marker: 390.635µs, path_prettifier: 116.603µs, autogenerated_exclude: 62.379µs, skip_dirs: 41.529µs, cgo: 12.947µs, nolint: 11.515µs, filename_unadjuster: 11.033µs, max_same_issues: 7.784µs, skip_files: 815ns, uniq_by_line: 779ns, diff: 632ns, max_from_linter: 619ns, exclude-rules: 598ns, source_code: 593ns, path_shortener: 517ns, max_per_file_from_linter: 365ns
INFO [runner] linters took 1.392996434s with stages: unused: 804.410204ms, goanalysis_metalinter: 585.266254ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 22 samples, avg is 78.5MB, max is 136.0MB
INFO Execution took 2.119278681s
```
