### PR TITLE
Fix chrony license header

### DIFF
--- a/protocol/chrony/client.go
+++ b/protocol/chrony/client.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/protocol/chrony/client_test.go
+++ b/protocol/chrony/client_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/protocol/chrony/helpers.go
+++ b/protocol/chrony/helpers.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/protocol/chrony/helpers_test.go
+++ b/protocol/chrony/helpers_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/protocol/chrony/packet.go
+++ b/protocol/chrony/packet.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
## Summary

Make linter happy by fixing spacing in license header

## Test Plan

`go run github.com/u-root/u-root/tools/checklicenses -c .circleci/config.json` produces no errors
