### PR TITLE
Build for different platforms

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Building for Linux"
+env GOOS=linux go build ./...
+
+echo "Building for FreeBSD"
+env GOOS=freebsd go build ./...
+
+echo "Building for Mac"
+env GOOS=darwin go build ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,15 @@ jobs:
       - checkout
       - run: go get -v -t ./...
       - run: .circleci/linters.sh
+  build:
+    working_directory: /go/src/github.com/facebookincubator/ntp
+    executor:
+      name: go/default
+      tag: '1.14'
+    steps:
+      - checkout
+      - run: go get -v -t ./...
+      - run: .circleci/build.sh
   tests:
     working_directory: /go/src/github.com/facebookincubator/ntp
     executor:
@@ -31,4 +40,5 @@ workflows:
   main:
    jobs:
      - linters
+     - build
      - tests


### PR DESCRIPTION
## Summary

We want our libs also work for freebsd and darwin. This will add linter checking go build success

## Test Plan
```
$ env GOOS=linux go build ./...

$ env GOOS=freebsd go build ./...
# github.com/facebookincubator/ntp/ntpcheck/cmd
ntpcheck/cmd/utils.go:148:19: undefined: syscall.Adjtimex
ntpcheck/cmd/utils.go:148:37: undefined: syscall.Timex
ntpcheck/cmd/utils.go:161:10: undefined: syscall.Timex
ntpcheck/cmd/utils.go:162:19: undefined: syscall.Adjtimex

$ env GOOS=darwin go build ./...
# github.com/facebookincubator/ntp/ntpcheck/cmd
ntpcheck/cmd/utils.go:60:28: undefined: syscall.SYS_CLOCK_GETTIME
ntpcheck/cmd/utils.go:148:19: undefined: syscall.Adjtimex
ntpcheck/cmd/utils.go:148:37: undefined: syscall.Timex
ntpcheck/cmd/utils.go:161:10: undefined: syscall.Timex
ntpcheck/cmd/utils.go:162:19: undefined: syscall.Adjtimex
```

