### PR TITLE
Make ntpcheck work on freebsd and darwin

### DIFF
--- a/.circleci/config.json
+++ b/.circleci/config.json
@@ -2,7 +2,7 @@
     "gopkg": "github.com/facebookincubator/ntp",
     "licenses": [
         [
-            "^/\\*",
+            "^(// \\+build.+\n\n)?/\\*",
             "Copyright \\(c\\) Facebook, Inc\\. and its affiliates\\.",
             "",
             "Licensed under the Apache License, Version 2\\.0 \\(the \"License\"\\);",

--- a/ntpcheck/cmd/utils_linux.go
+++ b/ntpcheck/cmd/utils_linux.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+// clockState report system clock state via adjtimex syscall
+func clockState() {
+	if state, err := syscall.Adjtimex(&syscall.Timex{}); err != nil {
+		fmt.Printf("Error calling adjtimex(2): %s", err)
+	} else {
+		if desc, ok := timexToDesc[state]; ok {
+			fmt.Println(desc)
+		} else {
+			fmt.Printf("Error: %v state is not recognized\n", state)
+		}
+	}
+}
+
+// ntpTime prints data similar to 'ntptime' command output
+func ntpTime() {
+	var buf syscall.Timex
+	if state, err := syscall.Adjtimex(&buf); err != nil {
+		fmt.Printf("Error calling adjtimex(2): %s", err)
+	} else {
+		if desc, ok := timexToDesc[state]; ok {
+			fmt.Printf("adjtimex() returns code %d (%s)\n", state, desc)
+		} else {
+			fmt.Printf("Error: %v state is not recognized\n", state)
+		}
+
+		var offset float64
+		// 0x2000 is STA_NANO
+		if buf.Status&0x2000 != 0 {
+			offset = float64(buf.Offset) / 1000.0 // ns -> us
+		} else {
+			offset = float64(buf.Offset)
+		}
+
+		fmt.Printf("  modes 0x%x,\n", buf.Modes)
+		fmt.Printf("  offset %.3f us, frequency %.3f ppm, interval %d s\n", offset, float64(buf.Freq)/65536.0, buf.Shift)
+		fmt.Printf("  maximum error %d us, estimated error %d us,\n", buf.Maxerror, buf.Esterror)
+		fmt.Printf("  status 0x%x,\n", buf.Status)
+		fmt.Printf("  time constant %d, precision %d.000 us, tolerance %d ppm,\n", buf.Constant, buf.Precision, buf.Tolerance/65535)
+	}
+}
+
+func init() {
+	// clockstate
+	utilsCmd.AddCommand(clockStateCmd)
+	// ntptime
+	utilsCmd.AddCommand(ntpTimeCmd)
+}
+
+var clockStateCmd = &cobra.Command{
+	Use:   "clockstate",
+	Short: "Print kernel clock state with description.",
+	Long: `Print kernel clock state with description.
+Useful for checking if kernel noticed leap second. Uses adjtimex(2) to get info.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigureVerbosity()
+		clockState()
+	},
+}
+
+var ntpTimeCmd = &cobra.Command{
+	Use:   "ntptime",
+	Short: "Print OS kernel output that is similar to ntp_gettime() and ntp_adjtime() output of 'ntptime' utility.",
+	Long:  "'ntptime' utility is a part of ntp package. This command produces similar output.",
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigureVerbosity()
+		ntpTime()
+	},
+}

--- a/ntpcheck/cmd/utils_notdarwin.go
+++ b/ntpcheck/cmd/utils_notdarwin.go
@@ -1,0 +1,93 @@
+// +build !darwin
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/spf13/cobra"
+)
+
+func getRawMonotonic() float64 {
+	var ts syscall.Timespec
+	_, _, _ = syscall.Syscall(syscall.SYS_CLOCK_GETTIME, clockMonotonic, uintptr(unsafe.Pointer(&ts)), 0)
+	return float64(ts.Sec) + float64(ts.Nsec)/float64(1e9)
+}
+
+// track reports wall time / mono time difference on stdout
+func track(interval time.Duration) {
+	fmt.Println("Wall timestamp\t\t\tWall difference\tMono difference\tMono raw diff\tOffset mono\tOffset mono raw")
+	startTime := time.Now()
+	rawStart := getRawMonotonic()
+
+	var prevWallElapsed time.Duration
+	var prevMonoElapsed time.Duration
+	for {
+		now := time.Now()
+		nowMonotonic := getRawMonotonic()
+
+		wallElapsed := now.Truncate(0).Sub(startTime.Truncate(0))
+		monoElapsed := now.Sub(startTime)
+		wallElapsedS := float64(wallElapsed) / float64(time.Second)
+		monoElapsedS := float64(monoElapsed) / float64(time.Second)
+		monoRawElapsedS := nowMonotonic - rawStart
+		offsetMonoUs := float64(wallElapsed-monoElapsed) / float64(time.Microsecond)
+		offsetMonoRawUs := float64(wallElapsed)/float64(time.Microsecond) - monoRawElapsedS*float64(1e6)
+		fmt.Printf("[%s]\t%.7fs\t%.7fs\t%.7fs\t%.2fus\t\t%.2fus\n", now.Format(time.RFC3339), wallElapsedS, monoElapsedS, monoRawElapsedS, offsetMonoUs, offsetMonoRawUs)
+
+		if (prevWallElapsed != 0) && int64(wallElapsed-prevWallElapsed) < 1000*int64(time.Millisecond) {
+			fmt.Println("^^^ BANG! Wall time goes back")
+		}
+		if (prevMonoElapsed != 0) && int64(monoElapsed-prevMonoElapsed) < 1000*int64(time.Millisecond) {
+			fmt.Println("^^^ BANG! Monotonic time goes back")
+		}
+		prevWallElapsed = wallElapsed
+		prevMonoElapsed = monoElapsed
+
+		time.Sleep(interval)
+	}
+}
+
+var trackInterval time.Duration
+
+func init() {
+	// track
+	utilsCmd.AddCommand(trackCmd)
+	trackCmd.Flags().DurationVarP(&trackInterval, "interval", "i", time.Second, "Measurement interval")
+}
+
+var trackCmd = &cobra.Command{
+	Use:   "track",
+	Short: "Allows to compare monotonic with wall clock.",
+	Long: `Allows to compare monotonic with wall clock.
+Legend:
+  * Wall timestamp - local date and time with TZ
+  * Wall difference - wall time elapsed since the start
+  * Mono difference - monotonic time elapsed since the start
+  * Mono raw diff - monotonic raw time elapsed since the start
+  * Offset mono - offset between monotonic and wall elapsed
+  * Offset mono raw - offset between monotonic raw and wall elapsed`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigureVerbosity()
+		track(trackInterval)
+	},
+}


### PR DESCRIPTION
## Summary
Some of the syscalls we use are Linux-specific, make sure we can still build on FreeBSD and Darwin platforms.

I had to adjust license regex to allow build tags. Putting build tag *after* the license doesn't work, it's not recognized by go build anymore.

## Test Plan

builds on all platforms
```
> go build && echo $?
0
> env GOOS=freebsd  go build && echo $?
0
> ~/g/n/ntpcheck env GOOS=darwin  go build && echo $?
0
```
On linux, we have all sub-utils awailable:
```
> ./ntpcheck utils --help
Collection of NTP-related utils

Usage:
  ntpchk utils [command]

Available Commands:
  clockstate  Print kernel clock state with description.
  fakeseconds Prints some fake seconds.
  ntpdate     Query remote server. Acts like ntp. Acts like ntpdate -q
  ntptime     Print OS kernel output that is similar to ntp_gettime() and ntp_adjtime() output of 'ntptime' utility.
  refid       Converts IP address to refid
  signfile    Generate hash signature for leap-seconds.list
  track       Allows to compare monotonic with wall clock.
```
