### PR TITLE
Fix interface management for freebsd and darwin

### DIFF
--- a/responder/server/ip_darwin.go
+++ b/responder/server/ip_darwin.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+
+	errors "github.com/pkg/errors"
+)
+
+func addIfaceIP(iface *net.Interface, addr *net.IP) error {
+	// Check if IP is assigned:
+	assigned, err := checkIP(iface, addr)
+	if err != nil {
+		return err
+	}
+	if assigned {
+		return nil
+	}
+
+	var mask int
+	var proto string
+	if v4 := addr.To4(); v4 == nil {
+		proto = "inet6"
+		mask = ipv6Mask
+	} else {
+		proto = "inet"
+		mask = ipv4Mask
+	}
+
+	cmd := exec.Command("ifconfig", iface.Name, proto, "alias", fmt.Sprintf("%s/%d", addr.String(), mask))
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "can't add address")
+	}
+	return nil
+}
+
+func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
+	// Check if IP is assigned:
+	assigned, err := checkIP(iface, addr)
+	if err != nil {
+		return err
+	}
+	if !assigned {
+		return nil
+	}
+
+	var proto string
+	if v4 := addr.To4(); v4 == nil {
+		proto = "inet6"
+	} else {
+		proto = "inet"
+	}
+
+	cmd := exec.Command("ifconfig", iface.Name, proto, "-alias", addr.String())
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "can't remove address")
+	}
+
+	return nil
+}

--- a/responder/server/ip_freebsd.go
+++ b/responder/server/ip_freebsd.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+
+	errors "github.com/pkg/errors"
+)
+
+func addIfaceIP(iface *net.Interface, addr *net.IP) error {
+	// Check if IP is assigned:
+	assigned, err := checkIP(iface, addr)
+	if err != nil {
+		return err
+	}
+	if assigned {
+		return nil
+	}
+
+	var mask int
+	var proto string
+	if v4 := addr.To4(); v4 == nil {
+		proto = "inet6"
+		mask = ipv6Mask
+	} else {
+		proto = "inet"
+		mask = ipv4Mask
+	}
+
+	cmd := exec.Command("ifconfig", iface.Name, proto, "alias", fmt.Sprintf("%s/%d", addr.String(), mask))
+	fmt.Println(cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "can't add address")
+	}
+	return nil
+}
+
+func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
+	// Check if IP is assigned:
+	assigned, err := checkIP(iface, addr)
+	if err != nil {
+		return err
+	}
+	if !assigned {
+		return nil
+	}
+
+	var proto string
+	if v4 := addr.To4(); v4 == nil {
+		proto = "inet6"
+	} else {
+		proto = "inet"
+	}
+
+	cmd := exec.Command("ifconfig", iface.Name, proto, "-alias", addr.String())
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "can't remove address")
+	}
+
+	return nil
+}

--- a/responder/server/ip_linux.go
+++ b/responder/server/ip_linux.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net"
+
+	"github.com/jsimonetti/rtnetlink/rtnl"
+	errors "github.com/pkg/errors"
+)
+
+func addIfaceIP(iface *net.Interface, addr *net.IP) error {
+	// Check if IP is assigned:
+	assigned, err := checkIP(iface, addr)
+	if err != nil {
+		return err
+	}
+	if assigned {
+		return nil
+	}
+
+	conn, err := rtnl.Dial(nil)
+	if err != nil {
+		return errors.Wrap(err, "can't establish netlink connection")
+	}
+	defer conn.Close()
+
+	var mask net.IPMask
+	if v4 := addr.To4(); v4 == nil {
+		mask = net.CIDRMask(ipv6Mask, ipv6Len)
+	} else {
+		mask = net.CIDRMask(ipv4Mask, ipv4Len)
+	}
+
+	err = conn.AddrAdd(iface, &net.IPNet{IP: *addr, Mask: mask})
+	if err != nil {
+		return errors.Wrap(err, "can't add address")
+	}
+	return nil
+}
+
+func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
+	// Check if IP is assigned:
+	assigned, err := checkIP(iface, addr)
+	if err != nil {
+		return err
+	}
+	if !assigned {
+		return nil
+	}
+
+	conn, err := rtnl.Dial(nil)
+	if err != nil {
+		return errors.Wrap(err, "can't establish netlink connection")
+	}
+	defer conn.Close()
+
+	var mask net.IPMask
+	if v4 := addr.To4(); v4 == nil {
+		mask = net.CIDRMask(ipv6Mask, ipv6Len)
+	} else {
+		mask = net.CIDRMask(ipv4Mask, ipv4Len)
+	}
+
+	err = conn.AddrDel(iface, &net.IPNet{IP: *addr, Mask: mask})
+	if err != nil {
+		return errors.Wrap(err, "can't remove address")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

netlink is not supported on nether freebsd nor darwin. Using ifconfig for now.
On my Mac

## Test Plan
```
$ sudo go run github.com/facebookincubator/ntp/responder --ip 1.2.3.4 --ip 2.3.4.5 -interface lo0
WARN[0000] Creating 800 goroutine workers
WARN[0000] Starting 2 listener(s)
```

```
$ ntpcheck utils ntpdate -s 1.2.3.4
Server: 1.2.3.4:123, Requests: 3
Last:
Stratum: 1, Current time: 2020-04-27 11:55:51.880610464 +0100 IST
Offset: 0.440037s (440.037464ms), Network delay: 0.440074s (440.074465ms)
Average:
Offset: 0.439882s (439.882242ms), Network delay: 0.439939s (439.938910ms)
```
