### PR TITLE
Add project status badges to README and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Excluded files
 .idea/
+
+# Test output
+profile.out
+couverage.out

--- a/README.md
+++ b/README.md
@@ -1,32 +1,46 @@
-# Time [![CircleCI](https://circleci.com/gh/facebook/time/tree/main.svg?style=svg)](https://circleci.com/gh/facebook/time/tree/main)
+# Time 
+
+[![CircleCI](https://circleci.com/gh/facebook/time/tree/main.svg?style=svg)](https://circleci.com/gh/facebook/time/tree/main)
+[![codecov](https://codecov.io/gh/facebook/time/branch/main/graph/badge.svg?token=QC44PEpHRi)](https://codecov.io/gh/facebook/time)
+[![Go Report Card](https://goreportcard.com/badge/github.com/facebook/time)](https://goreportcard.com/report/github.com/facebook/time)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/facebook/time)
+[![GoDoc](https://pkg.go.dev/badge/github.com/facebook/time?status.svg)](https://pkg.go.dev/github.com/facebook/time?tab=doc)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+# Contents
+
+- [Documentation](#Documentation)
+- [License](#License)
+
+## Documentation
 
 Collection of Meta's Time Libraries such as NTP and PTP
 
-## cmd
+### cmd
 All executables provided by this repo.
 
-## NTP
+### NTP
 NTP-specific libraries, including protocol implementation.
 
-## PTP
+### PTP
 PTP-specific libraries, including protocol implementation.
 
-## Leaphash
+### Leaphash
 Utility package for computing the hash value of the official leap-second.list document
 
-## leapsectz
+### leapsectz
 Utility package for obtaining leap second information from the system timezone database
 
-## PHC
+### PHC
 Library to work with PTP Hardware Clock (PHC).
 
-## Timestamp
+### Timestamp
 Library to work with NIC hardware/software timestamps.
 
-## oscillatord
+### oscillatord
 Implementation of monitoring protocol used by Orolia [oscillatord](https://github.com/Orolia2s/oscillatord).
 
-## Calnex
+### Calnex
 Command line tool and library for a Calnex Sentinel device.
 
 # License


### PR DESCRIPTION
Updated `README.md` and `.gitignore` with the following features:

- Add project status badges to `READE.md`
- Refactor `README.md` format
- Add tests output files to `.gitignore`