### PR TITLE
[calnex] implement cert subcommand

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -244,8 +244,9 @@ const (
 	clearDeviceURL = "https://%s/api/cleardevice?action=cleardevice"
 	rebootURL      = "https://%s/api/reboot?action=reboot"
 
-	versionURL  = "https://%s/api/version"
-	firmwareURL = "https://%s/api/updatefirmware"
+	versionURL     = "https://%s/api/version"
+	firmwareURL    = "https://%s/api/updatefirmware"
+	certificateURL = "https://%s/api/installcertificate"
 )
 
 // Calnex Status contants
@@ -496,6 +497,15 @@ func (a *API) PushVersion(path string) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	r, err := a.post(url, buf)
+	return r, err
+}
+
+// PushCert uploads a new Certificate to the device
+func (a *API) PushCert(cert []byte) (*Result, error) {
+	url := fmt.Sprintf(certificateURL, a.source)
+	buf := bytes.NewBuffer(cert)
 
 	r, err := a.post(url, buf)
 	return r, err

--- a/calnex/cmd/cert.go
+++ b/calnex/cmd/cert.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/facebook/time/calnex/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(certCmd)
+	certCmd.Flags().BoolVar(&apply, "apply", false, "apply the config changes")
+	certCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
+	certCmd.Flags().StringVar(&target, "target", "", "device to configure")
+	certCmd.Flags().StringVar(&source, "file", "", "certificate file path")
+
+	if err := certCmd.MarkFlagRequired("target"); err != nil {
+		log.Fatal(err)
+	}
+	if err := certCmd.MarkFlagRequired("file"); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func cert() error {
+	api := api.NewAPI(target, insecureTLS)
+	cert, err := os.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	if !apply {
+		log.Infof("dry run. Exiting")
+		return nil
+	}
+
+	r, err := api.PushCert(cert)
+	log.Infof(r.Message)
+	return err
+}
+
+var certCmd = &cobra.Command{
+	Use:   "cert",
+	Short: "install device certificate",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := cert(); err != nil {
+			log.Fatal(err)
+		}
+	},
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Implement a basic certificate update function.
API is designed to accept `[]byte`.
Open source implementation takes cert from the file. Private implementations can take it straight from APIs.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ openssl s_client -connect calnex01.example.com:443 2>/dev/null | openssl x509 -noout -dates
notAfter=Aug 14 13:06:09 2022 GMT
```
```
$ ./calnex -- cert --target calnex01.example.com --file /tmp/calnex.pem --apply
```
```
$ openssl s_client -connect calnex01.example.com:443 2>/dev/null | openssl x509 -noout -dates
notAfter=Sep 12 15:08:38 2022 GMT
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
