### PR TITLE
[calnex] add apply to dangerous commands

### DIFF
--- a/calnex/cmd/clear.go
+++ b/calnex/cmd/clear.go
@@ -24,6 +24,7 @@ import (
 
 func init() {
 	RootCmd.AddCommand(clearCmd)
+	clearCmd.Flags().BoolVar(&apply, "apply", false, "apply the config changes")
 	clearCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
 	clearCmd.Flags().StringVar(&target, "target", "", "device to configure")
 	if err := clearCmd.MarkFlagRequired("target"); err != nil {
@@ -32,8 +33,12 @@ func init() {
 }
 
 func clear() error {
-	api := api.NewAPI(target, insecureTLS)
+	if !apply {
+		log.Infof("dry run. Exiting")
+		return nil
+	}
 
+	api := api.NewAPI(target, insecureTLS)
 	if err := api.ClearDevice(); err != nil {
 		return err
 	}

--- a/calnex/cmd/firmware.go
+++ b/calnex/cmd/firmware.go
@@ -24,8 +24,8 @@ import (
 
 func init() {
 	RootCmd.AddCommand(firmwareCmd)
-	firmwareCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
 	firmwareCmd.Flags().BoolVar(&apply, "apply", false, "apply the firmware upgrade")
+	firmwareCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
 	firmwareCmd.Flags().StringVar(&target, "target", "", "device to configure")
 	firmwareCmd.Flags().StringVar(&source, "file", "", "firmware file path")
 	if err := firmwareCmd.MarkFlagRequired("target"); err != nil {

--- a/calnex/cmd/reboot.go
+++ b/calnex/cmd/reboot.go
@@ -24,6 +24,7 @@ import (
 
 func init() {
 	RootCmd.AddCommand(rebootCmd)
+	rebootCmd.Flags().BoolVar(&apply, "apply", false, "apply the config changes")
 	rebootCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
 	rebootCmd.Flags().StringVar(&target, "target", "", "device to configure")
 	if err := rebootCmd.MarkFlagRequired("target"); err != nil {
@@ -32,8 +33,12 @@ func init() {
 }
 
 func reboot() error {
-	api := api.NewAPI(target, insecureTLS)
+	if !apply {
+		log.Infof("dry run. Exiting")
+		return nil
+	}
 
+	api := api.NewAPI(target, insecureTLS)
 	if err := api.Reboot(); err != nil {
 		return err
 	}

--- a/calnex/config/config.go
+++ b/calnex/config/config.go
@@ -157,7 +157,7 @@ func (c *config) baseConfig(s *ini.Section) {
 	c.set(s, "tie_mode", "TIE + 1 PPS TE")
 }
 
-// Config configures target Calnex via protocol with Network/Calnex configs if apply is specified
+// Config configures target Calnex with Network/Calnex configs if apply is specified
 func Config(target string, insecureTLS bool, n *NetworkConfig, cc CalnexConfig, apply bool) error {
 	var c config
 	api := api.NewAPI(target, insecureTLS)

--- a/calnex/export/export.go
+++ b/calnex/export/export.go
@@ -29,7 +29,7 @@ import (
 var errNoUsedChannels = errors.New("no used channels")
 var errNoTarget = errors.New("no target succeeds")
 
-// Export data from the device about specified channels via protocol to the output
+// Export data from the device about specified channels to the specified output
 func Export(source string, insecureTLS bool, channels []api.Channel, output io.WriteCloser) (err error) {
 	var success bool
 	calnexAPI := api.NewAPI(source, insecureTLS)

--- a/calnex/firmware/firmware.go
+++ b/calnex/firmware/firmware.go
@@ -32,7 +32,7 @@ type FW interface {
 	Path() (string, error)
 }
 
-// Firmware checks target Calnex firmware version via protocol and upgrades if apply is specified
+// Firmware checks target Calnex firmware version and upgrades if apply is specified
 func Firmware(target string, insecureTLS bool, fw FW, apply bool) error {
 	api := api.NewAPI(target, insecureTLS)
 	cv, err := api.FetchVersion()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Add apply to `clear` and `reboot` commands
* Fix comments after deprecating protocol

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ calnex reboot --target calnex03.lla1.fbinfra.net
INFO[0000] dry run. Exiting
```

```
$ calnex clear --target calnex03.lla1.fbinfra.net
INFO[0000] dry run. Exiting
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
