### PR TITLE
[Calnex] eliminate DNS dependency

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"path"
@@ -378,21 +377,6 @@ func (a *API) FetchUsedChannels() ([]Channel, error) {
 		}
 	}
 	return channels, err
-}
-
-// FetchChannelTargetName returns the hostname of the server monitored on the channel
-func (a *API) FetchChannelTargetName(channel Channel, probe Probe) (string, error) {
-	ip, err := a.FetchChannelTargetIP(channel, probe)
-	if err != nil {
-		return ip, err
-	}
-
-	hostnames, err := net.LookupAddr(ip)
-	if err != nil {
-		return "", err
-	}
-
-	return hostnames[0], nil
 }
 
 // FetchSettings returns the calnex settings

--- a/calnex/api/api_test.go
+++ b/calnex/api/api_test.go
@@ -236,23 +236,6 @@ func TestFetchUsedChannels(t *testing.T) {
 	require.ElementsMatch(t, expected, used)
 }
 
-func TestFetchChannelTargetName(t *testing.T) {
-	sampleResp := "measure/ch7/ptp_synce/ptp/master_ip=127.0.0.1"
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
-		r *http.Request) {
-		fmt.Fprintln(w, sampleResp)
-	}))
-	defer ts.Close()
-
-	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
-	calnexAPI.Client = ts.Client()
-
-	ip, err := calnexAPI.FetchChannelTargetName(ChannelTWO, ProbePTP)
-	require.NoError(t, err)
-	require.Equal(t, "localhost", ip)
-}
-
 func TestFetchSettings(t *testing.T) {
 	sampleResp := "[measure]\nch0\\synce_enabled=Off\n"
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,

--- a/calnex/export/export.go
+++ b/calnex/export/export.go
@@ -50,7 +50,7 @@ func Export(source string, insecureTLS bool, channels []api.Channel, output io.W
 			continue
 		}
 
-		target, err := calnexAPI.FetchChannelTargetName(channel, *probe)
+		target, err := calnexAPI.FetchChannelTargetIP(channel, *probe)
 		if err != nil {
 			log.Errorf("Failed to fetch target from the channel %s: %v", channel, err)
 			success = success || false

--- a/calnex/export/export_test.go
+++ b/calnex/export/export_test.go
@@ -65,7 +65,7 @@ func TestExport(t *testing.T) {
 	calnexAPI := api.NewAPI(parsed.Host, true)
 	calnexAPI.Client = ts.Client()
 
-	expected := fmt.Sprintf("{\"float\":{\"value\":-2.50501e-7},\"int\":{\"time\":1607961193},\"normal\":{\"channel\":\"1\",\"target\":\"localhost\",\"protocol\":\"ntp\",\"source\":\"%s\"}}\n", parsed.Host)
+	expected := fmt.Sprintf("{\"float\":{\"value\":-2.50501e-7},\"int\":{\"time\":1607961193},\"normal\":{\"channel\":\"1\",\"target\":\"127.0.0.1\",\"protocol\":\"ntp\",\"source\":\"%s\"}}\n", parsed.Host)
 	err := Export(parsed.Host, true, []api.Channel{}, w)
 	require.NoError(t, err)
 	require.Equal(t, expected, w.data)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Let's not rely on DNS.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Unittests
```
$ calnex export --source calnex03.example.com
...
{"float":{"value":-0.0000138495},"int":{"time":1643368864},"normal":{"channel":"2","target":"1.2.3.4","protocol":"ntp","source":"calnex03.example.com"}}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
