### PR TITLE
Added PTP PORT_SERVICE_STATS_NP TLV and ptpcheck subcommand

### DIFF
--- a/cmd/ptpcheck/cmd/servicestats.go
+++ b/cmd/ptpcheck/cmd/servicestats.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/facebook/time/cmd/ptpcheck/checker"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(serviceStatsCmd)
+	serviceStatsCmd.Flags().StringVarP(&rootServerFlag, "server", "S", "/var/run/ptp4l", "server to connect to")
+}
+
+func serviceStatsRun(server string) error {
+	c, cleanup, err := checker.PrepareClient(server)
+	defer cleanup()
+	if err != nil {
+		return fmt.Errorf("preparing connection: %w", err)
+	}
+	tlv, err := c.PortServiceStatsNP()
+	if err != nil {
+		return fmt.Errorf("talking to ptp4l: %w", err)
+	}
+	str, err := json.Marshal(tlv.PortServiceStats)
+	if err != nil {
+		return fmt.Errorf("marshaling json: %w", err)
+	}
+	fmt.Printf("%s\n", string(str))
+	return nil
+}
+
+var serviceStatsCmd = &cobra.Command{
+	Use:   "servicestats",
+	Short: "Print PTP port service stats in JSON format",
+	Run: func(c *cobra.Command, args []string) {
+		ConfigureVerbosity()
+
+		if err := serviceStatsRun(rootServerFlag); err != nil {
+			log.Fatal(err)
+		}
+
+	},
+}

--- a/ptp/protocol/management.go
+++ b/ptp/protocol/management.go
@@ -18,6 +18,7 @@ package protocol
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -130,6 +131,14 @@ func (p *Management) UnmarshalBinary(rawBytes []byte) error {
 func (p *Management) MarshalBinaryTo(bytes io.Writer) error {
 	if err := binary.Write(bytes, binary.BigEndian, p.ManagementMsgHead); err != nil {
 		return err
+	}
+	// interface smuggling
+	if pp, ok := p.TLV.(encoding.BinaryMarshaler); ok {
+		b, err := pp.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		return binary.Write(bytes, binary.BigEndian, b)
 	}
 	if err := binary.Write(bytes, binary.BigEndian, p.TLV); err != nil {
 		return err

--- a/ptp/protocol/management_tlvs.go
+++ b/ptp/protocol/management_tlvs.go
@@ -101,6 +101,21 @@ var mgmtTLVDecoder = map[ManagementID]MgmtTLVDecoderFunc{
 		}
 		return tlv, nil
 	},
+	IDPortServiceStatsNP: func(data []byte) (ManagementTLV, error) {
+		r := bytes.NewReader(data)
+		tlv := &PortServiceStatsNPTLV{}
+		if err := binary.Read(r, binary.BigEndian, &tlv.ManagementTLVHead); err != nil {
+			return nil, err
+		}
+		if err := binary.Read(r, binary.BigEndian, &tlv.PortIdentity); err != nil {
+			return nil, err
+		}
+		// LittlEndian, just like with PortStatsNP
+		if err := binary.Read(r, binary.LittleEndian, &tlv.PortServiceStats); err != nil {
+			return nil, err
+		}
+		return tlv, nil
+	},
 }
 
 // RegisterMgmtTLVDecoder registers function we'll use to decode particular custom management TLV.

--- a/ptp/protocol/ptp4l_test.go
+++ b/ptp/protocol/ptp4l_test.go
@@ -86,3 +86,119 @@ func Test_parseTimeStatusNP(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, raw, b)
 }
+
+func Test_parsePortStatsNP(t *testing.T) {
+	raw := []uint8("\x0d\x12\x01\x40\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x04\x7f\x00\x00\x00\x00\x00\x00\x00\x00\x0b\x8a\x00\x00\x02\x00\x00\x01\x01\x0c\xc0\x05\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x51\x0f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x51\x0f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xaa\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	packet := new(Management)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := Management{
+		ManagementMsgHead: ManagementMsgHead{
+			Header: Header{
+				SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageManagement, 0),
+				Version:             Version,
+				MessageLength:       uint16(len(raw) - 2),
+				DomainNumber:        0,
+				MinorSdoID:          0,
+				FlagField:           0,
+				CorrectionField:     0,
+				MessageTypeSpecific: 0,
+				SourcePortIdentity: PortIdentity{
+					PortNumber:    1,
+					ClockIdentity: 5212879185253405146,
+				},
+				SequenceID:         0,
+				ControlField:       4,
+				LogMessageInterval: 0x7f,
+			},
+			TargetPortIdentity: PortIdentity{
+				PortNumber:    2954,
+				ClockIdentity: 0,
+			},
+			ActionField: RESPONSE,
+		},
+		TLV: &PortStatsNPTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: 268,
+				},
+				ManagementID: IDPortStatsNP,
+			},
+			PortIdentity: PortIdentity{ // 4857dd.fffe.0e91da-1
+				ClockIdentity: 5212879185253405146,
+				PortNumber:    1,
+			},
+			PortStats: PortStats{
+				RXMsgType: [16]uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				TXMsgType: [16]uint64{3921, 0, 0, 0, 0, 0, 0, 0, 3921, 0, 0, 1962, 0, 0, 0, 0},
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+}
+
+func Test_parsePortServiceStatsNP(t *testing.T) {
+	raw := []uint8("\x0d\x12\x00\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x04\x7f\x00\x00\x00\x00\x00\x00\x00\x00\x0e\xad\x00\x00\x02\x00\x00\x01\x00\x5c\xc0\x07\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x92\x05\x00\x00\x00\x00\x00\x00\x21\x0b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	packet := new(Management)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := Management{
+		ManagementMsgHead: ManagementMsgHead{
+			Header: Header{
+				SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageManagement, 0),
+				Version:             Version,
+				MessageLength:       uint16(len(raw) - 2),
+				DomainNumber:        0,
+				MinorSdoID:          0,
+				FlagField:           0,
+				CorrectionField:     0,
+				MessageTypeSpecific: 0,
+				SourcePortIdentity: PortIdentity{
+					PortNumber:    1,
+					ClockIdentity: 5212879185253405146,
+				},
+				SequenceID:         0,
+				ControlField:       4,
+				LogMessageInterval: 0x7f,
+			},
+			TargetPortIdentity: PortIdentity{
+				PortNumber:    3757,
+				ClockIdentity: 0,
+			},
+			ActionField: RESPONSE,
+		},
+		TLV: &PortServiceStatsNPTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: 92,
+				},
+				ManagementID: IDPortServiceStatsNP,
+			},
+			PortIdentity: PortIdentity{ // 4857dd.fffe.0e91da-1
+				ClockIdentity: 5212879185253405146,
+				PortNumber:    1,
+			},
+			PortServiceStats: PortServiceStats{
+				AnnounceTimeout:       1,
+				SyncTimeout:           0,
+				DelayTimeout:          0,
+				UnicastServiceTimeout: 0,
+				UnicastRequestTimeout: 0,
+				MasterAnnounceTimeout: 1426,
+				MasterSyncTimeout:     2849,
+				QualificationTimeout:  0,
+				SyncMismatch:          0,
+				FollowupMismatch:      0,
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+}


### PR DESCRIPTION
## Summary

We recently [contributed PORT_SERVICE_STATS_NP management TLV to linuxptp](https://github.com/richardcochran/linuxptp/commit/cfbb8bdb50f5a38687fcddccbe6a264c6a078bbd),
which allows to open-source related code.

Also, added unittest and fixed marshalling for PortStatsNP along the way.

## Test Plan

unittests
```
> ptpcheck servicestats | jq .
{
  "ptp.servicestats.announce_timeout": 1,
  "ptp.servicestats.sync_timeout": 0,
  "ptp.servicestats.delay_timeout": 0,
  "ptp.servicestats.unicast_service_timeout": 0,
  "ptp.servicestats.unicast_request_timeout": 0,
  "ptp.servicestats.master_announce_timeout": 2809,
  "ptp.servicestats.master_sync_timeout": 5616,
  "ptp.servicestats.qualification_timeout": 0,
  "ptp.servicestats.sync_mismatch": 0,
  "ptp.servicestats.followup_mismatch": 0
}
```