### PR TITLE
Make golint happy

### DIFF
--- a/calnex/cmd/cmd.go
+++ b/calnex/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RootCmd is a main entry point. It's exported so ntpcheck could be easily extended without touching core functionality.
 var RootCmd = &cobra.Command{
 	Use:   "calnex",
 	Short: "collection of calnex utilities",

--- a/cmd/ntpcheck/checker/chrony.go
+++ b/cmd/ntpcheck/checker/chrony.go
@@ -34,8 +34,8 @@ type chronyConn struct {
 	local string
 }
 
-// DialUnix opens a unixgram connection with chrony
-func DialUnix(address string) (*chronyConn, error) {
+// dialUnix opens a unixgram connection with chrony
+func dialUnix(address string) (*chronyConn, error) {
 	base, _ := path.Split(address)
 	local := path.Join(base, fmt.Sprintf("chronyc.%d.sock", os.Getpid()))
 	conn, err := net.DialUnix("unixgram",

--- a/cmd/ntpcheck/checker/runner.go
+++ b/cmd/ntpcheck/checker/runner.go
@@ -118,7 +118,7 @@ func RunNTPData(address string) (*NTPCheckResult, error) {
 	if address == "" {
 		address = getPrivateServer(flavour)
 	}
-	conn, err := DialUnix(address)
+	conn, err := dialUnix(address)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func RunServerStats(address string) (*ServerStats, error) {
 		address = getPrivateServer(flavour)
 	}
 	if flavour == flavourChrony {
-		conn, err = DialUnix(address)
+		conn, err = dialUnix(address)
 	} else {
 		conn, err = net.DialTimeout("udp", address, timeout)
 	}

--- a/cmd/ntpcheck/checker/system.go
+++ b/cmd/ntpcheck/checker/system.go
@@ -59,6 +59,7 @@ func sanityCheckSysVars(sysVars *SystemVariables) error {
 	return nil
 }
 
+// NewSystemVariablesFromChrony returns initialized instance of SystemVariables
 func NewSystemVariablesFromChrony(p *chrony.ReplyTracking) *SystemVariables {
 	return &SystemVariables{
 		Leap:      int(p.LeapStatus),

--- a/leapsectz/leapsectz.go
+++ b/leapsectz/leapsectz.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 // Package leapsectz is a utility package for obtaining leap second
 // information from the system timezone database
-
 package leapsectz
 
 import (

--- a/ntp/chrony/packet.go
+++ b/ntp/chrony/packet.go
@@ -447,6 +447,7 @@ type replySourceStatsContent struct {
 	EstimatedOffsetErr chronyFloat
 }
 
+// SourceStats contains stats about the source
 type SourceStats struct {
 	RefID              uint32
 	IPAddr             net.IP

--- a/ntp/protocol/ntp.go
+++ b/ntp/protocol/ntp.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /*
-Package ntp implementns ntp packet and basic functions to work with.
+Package protocol implementns ntp packet and basic functions to work with.
 It provides quick and transparent translation between 48 bytes and
 simply accessible struct in the most efficient way.
 */

--- a/ntp/shm/ntpshm.go
+++ b/ntp/shm/ntpshm.go
@@ -30,14 +30,14 @@ import (
 // http://doc.ntp.org/current-stable/drivers/driver28.html
 const SHMKEY = 0x4e545030
 
-// IPC_CREAT create if key is nonexistent
+// IPCCREAT create if key is nonexistent
 // https://man7.org/linux/man-pages/man0/sys_ipc.h.0p.html
-const IPC_CREAT = 00001000
+const IPCCREAT = 00001000
 
 // NTPSHMSize is a size of NTPSHM struct
 const NTPSHMSize = 96
 
-/* NTPSHM Declaration of the SHM segment from ntp (ntpd/refclock_shm.c) */
+// NTPSHM Declaration of the SHM segment from ntp (ntpd/refclock_shm.c)
 type NTPSHM struct {
 	Mode                 int32
 	Count                int32
@@ -56,7 +56,7 @@ type NTPSHM struct {
 
 // Create a segment in SHM and return the ID
 func Create() (uintptr, error) {
-	shmID, _, errno := unix.Syscall(unix.SYS_SHMGET, uintptr(SHMKEY), 0, uintptr(IPC_CREAT|0600))
+	shmID, _, errno := unix.Syscall(unix.SYS_SHMGET, uintptr(SHMKEY), 0, uintptr(IPCCREAT|0600))
 	if errno != 0 {
 		return 0, fmt.Errorf("failed get shm: %s", unix.ErrnoName(errno))
 	}

--- a/ptp/protocol/protocol.go
+++ b/ptp/protocol/protocol.go
@@ -166,6 +166,7 @@ type Announce struct {
 	AnnounceBody
 }
 
+// MarshalBinaryTo marshals bytes to Announce
 func (p *Announce) MarshalBinaryTo(b []byte) (int, error) {
 	if len(b) < headerSize+30 {
 		return 0, fmt.Errorf("not enough buffer to write Announce")
@@ -204,6 +205,7 @@ type SyncDelayReq struct {
 	SyncDelayReqBody
 }
 
+// MarshalBinaryTo marshals bytes to SyncDelayReq
 func (p *SyncDelayReq) MarshalBinaryTo(b []byte) (int, error) {
 	if len(b) < headerSize+10 {
 		return 0, fmt.Errorf("not enough buffer to write SyncDelayReq")
@@ -221,6 +223,7 @@ func (p *SyncDelayReq) MarshalBinary() ([]byte, error) {
 	return buf[:n], err
 }
 
+// UnmarshalBinary unmarshals bytes to SyncDelayReq
 func (p *SyncDelayReq) UnmarshalBinary(b []byte) error {
 	if len(b) < headerSize+10 {
 		return fmt.Errorf("not enough data to decode SyncDelayReq")
@@ -242,6 +245,7 @@ type FollowUp struct {
 	FollowUpBody
 }
 
+// MarshalBinaryTo marshals bytes to FollowUp
 func (p *FollowUp) MarshalBinaryTo(b []byte) (int, error) {
 	if len(b) < headerSize+10 {
 		return 0, fmt.Errorf("not enough buffer to write FollowUp")
@@ -259,6 +263,7 @@ func (p *FollowUp) MarshalBinary() ([]byte, error) {
 	return buf[:n], err
 }
 
+// UnmarshalBinary unmarshals bytes to FollowUp
 func (p *FollowUp) UnmarshalBinary(b []byte) error {
 	if len(b) < headerSize+10 {
 		return fmt.Errorf("not enough data to decode FollowUp")
@@ -281,6 +286,7 @@ type DelayResp struct {
 	DelayRespBody
 }
 
+// MarshalBinaryTo marshals bytes to DelayResp
 func (p *DelayResp) MarshalBinaryTo(b []byte) (int, error) {
 	if len(b) < headerSize+20 {
 		return 0, fmt.Errorf("not enough buffer to write DelayResp")
@@ -300,6 +306,7 @@ func (p *DelayResp) MarshalBinary() ([]byte, error) {
 	return buf[:n], err
 }
 
+// UnmarshalBinary unmarshals bytes to DelayResp
 func (p *DelayResp) UnmarshalBinary(b []byte) error {
 	if len(b) < headerSize+20 {
 		return fmt.Errorf("not enough data to decode DelayResp")

--- a/ptp/protocol/unicast.go
+++ b/ptp/protocol/unicast.go
@@ -42,6 +42,7 @@ type Signaling struct {
 	TLVs               []TLV
 }
 
+// MarshalBinaryTo marshals bytes to Signaling
 func (p *Signaling) MarshalBinaryTo(b []byte) (int, error) {
 	if len(p.TLVs) == 0 {
 		return 0, fmt.Errorf("no TLVs in Signaling message, at least one required")
@@ -160,6 +161,7 @@ type RequestUnicastTransmissionTLV struct {
 	DurationField         uint32
 }
 
+// MarshalBinaryTo marshals bytes to RequestUnicastTransmissionTLV
 func (t *RequestUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
 	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
 	b[tlvHeadSize] = byte(t.MsgTypeAndReserved)
@@ -189,6 +191,7 @@ type GrantUnicastTransmissionTLV struct {
 	Renewal               uint8
 }
 
+// MarshalBinaryTo marshals bytes to GrantUnicastTransmissionTLV
 func (t *GrantUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
 	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
 	b[tlvHeadSize] = byte(t.MsgTypeAndReserved)
@@ -219,6 +222,7 @@ type CancelUnicastTransmissionTLV struct {
 	Reserved        uint8
 }
 
+// MarshalBinaryTo marshals bytes to CancelUnicastTransmissionTLV
 func (t *CancelUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
 	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
 	b[tlvHeadSize] = byte(t.MsgTypeAndFlags)
@@ -243,6 +247,7 @@ type AcknowledgeCancelUnicastTransmissionTLV struct {
 	Reserved        uint8
 }
 
+// MarshalBinaryTo marshals bytes to AcknowledgeCancelUnicastTransmissionTLV
 func (t *AcknowledgeCancelUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
 	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
 	b[tlvHeadSize] = byte(t.MsgTypeAndFlags)

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -18,7 +18,6 @@ limitations under the License.
 Package server implements simple UDP server to work with NTP packets.
 In addition, it run checker, announce and stats implementations
 */
-
 package server
 
 import (
@@ -68,7 +67,7 @@ func (s *Server) Start() error {
 	s.sw = make([]*sendWorker, s.Config.SendWorkers)
 	for i := 0; i < s.Config.SendWorkers; i++ {
 		// Each worker to monitor own queue
-		s.sw[i] = NewSendWorker(i, s.Config, s.Stats)
+		s.sw[i] = newSendWorker(i, s.Config, s.Stats)
 		go func(i int) {
 			defer wg.Done()
 			s.sw[i].Start()

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -41,7 +41,7 @@ func TestFindWorker(t *testing.T) {
 	}
 
 	for i := 0; i < s.Config.SendWorkers; i++ {
-		s.sw[i] = NewSendWorker(i, c, s.Stats)
+		s.sw[i] = newSendWorker(i, c, s.Stats)
 	}
 
 	clipi1 := ptp.PortIdentity{

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -13,6 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+/*
+Package server implements simple UDP server to work with NTP packets.
+In addition, it run checker, announce and stats implementations
+*/
 package server
 
 import (

--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -53,7 +53,7 @@ type sendWorker struct {
 	clients map[ptp.MessageType]map[ptp.PortIdentity]*SubscriptionClient
 }
 
-func NewSendWorker(i int, c *Config, st stats.Stats) *sendWorker {
+func newSendWorker(i int, c *Config, st stats.Stats) *sendWorker {
 	s := &sendWorker{
 		id:     i,
 		config: c,

--- a/ptp/ptp4u/server/worker_test.go
+++ b/ptp/ptp4u/server/worker_test.go
@@ -103,7 +103,7 @@ func TestInventoryClients(t *testing.T) {
 	go st.Start(0)
 	time.Sleep(time.Millisecond)
 
-	w := NewSendWorker(0, c, st)
+	w := newSendWorker(0, c, st)
 
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	scS1 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSync, c, 10*time.Millisecond, time.Now().Add(time.Minute))

--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -37,11 +37,11 @@ const (
 )
 
 const (
-	// Control is a socket control message containing TX/RX timestamp
+	// ControlSizeBytes is a socket control message containing TX/RX timestamp
 	// If the read fails we may endup with multiple timestamps in the buffer
 	// which is best to read right away
 	ControlSizeBytes = 128
-	// ptp packets usually up to 66 bytes
+	// PayloadSizeBytes is a size of maximum ptp packet which is usually up to 66 bytes
 	PayloadSizeBytes = 128
 	// look only for X sequential TS
 	maxTXTS = 100
@@ -113,11 +113,10 @@ func IPToSockaddr(ip net.IP, port int) unix.Sockaddr {
 		sa := &unix.SockaddrInet4{Port: port}
 		copy(sa.Addr[:], ip.To4())
 		return sa
-	} else {
-		sa := &unix.SockaddrInet6{Port: port}
-		copy(sa.Addr[:], ip.To16())
-		return sa
 	}
+	sa := &unix.SockaddrInet6{Port: port}
+	copy(sa.Addr[:], ip.To16())
+	return sa
 }
 
 // SockaddrToIP converts socket address to an IP


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
It used to be:
```
go run golang.org/x/lint/golint ./...

calnex/cmd/cmd.go:24:5: exported var RootCmd should have comment or be unexported
cmd/ntpcheck/checker/chrony.go:38:32: exported func DialUnix returns unexported type *checker.chronyConn, which can be annoying to use
cmd/ntpcheck/checker/system.go:62:1: exported function NewSystemVariablesFromChrony should have comment or be unexported
leapsectz/leapsectz.go:19:1: package comment is detached; there should be no blank lines between it and the package statement
ntp/chrony/packet.go:450:6: exported type SourceStats should have comment or be unexported
ntp/protocol/ntp.go:17:1: package comment should be of the form "Package protocol ..."
ntp/shm/ntpshm.go:35:7: don't use ALL_CAPS in Go names; use CamelCase
ntp/shm/ntpshm.go:40:1: comment on exported type NTPSHM should be of the form "NTPSHM ..." (with optional leading article)
ptp/protocol/protocol.go:169:1: exported method Announce.MarshalBinaryTo should have comment or be unexported
ptp/protocol/protocol.go:207:1: exported method SyncDelayReq.MarshalBinaryTo should have comment or be unexported
ptp/protocol/protocol.go:224:1: exported method SyncDelayReq.UnmarshalBinary should have comment or be unexported
ptp/protocol/protocol.go:245:1: exported method FollowUp.MarshalBinaryTo should have comment or be unexported
ptp/protocol/protocol.go:262:1: exported method FollowUp.UnmarshalBinary should have comment or be unexported
ptp/protocol/protocol.go:284:1: exported method DelayResp.MarshalBinaryTo should have comment or be unexported
ptp/protocol/protocol.go:303:1: exported method DelayResp.UnmarshalBinary should have comment or be unexported
ptp/protocol/unicast.go:45:1: exported method Signaling.MarshalBinaryTo should have comment or be unexported
ptp/protocol/unicast.go:163:1: exported method RequestUnicastTransmissionTLV.MarshalBinaryTo should have comment or be unexported
ptp/protocol/unicast.go:192:1: exported method GrantUnicastTransmissionTLV.MarshalBinaryTo should have comment or be unexported
ptp/protocol/unicast.go:222:1: exported method CancelUnicastTransmissionTLV.MarshalBinaryTo should have comment or be unexported
ptp/protocol/unicast.go:246:1: exported method AcknowledgeCancelUnicastTransmissionTLV.MarshalBinaryTo should have comment or be unexported
ptp/ptp4u/server/server.go:21:1: package comment is detached; there should be no blank lines between it and the package statement
ptp/ptp4u/server/subscription.go:1:1: package comment should be of the form "Package server ..."
ptp/ptp4u/server/worker.go:56:1: exported function NewSendWorker should have comment or be unexported
ptp/ptp4u/server/worker.go:56:54: exported func NewSendWorker returns unexported type *server.sendWorker, which can be annoying to use
timestamp/timestamp.go:40:2: comment on exported const ControlSizeBytes should be of the form "ControlSizeBytes ..."
timestamp/timestamp.go:44:2: comment on exported const PayloadSizeBytes should be of the form "PayloadSizeBytes ..."
timestamp/timestamp.go:116:9: if block ends with a return statement, so drop this else and outdent its block
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Now the output is completely empty.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
