### PR TITLE
[ptp4u] use leapsectz lib to determine leapsecond

### DIFF
--- a/ptp/ptp4u/server/config_test.go
+++ b/ptp/ptp4u/server/config_test.go
@@ -69,3 +69,18 @@ func TestConfigSetUTCOffsetFromSHM(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, utcoffset, c.UTCOffset)
 }
+
+func TestConfigSetUTCOffsetFromLeapsectz(t *testing.T) {
+	utcoffset := 42 * time.Second
+	c := Config{UTCOffset: utcoffset}
+	err := c.SetUTCOffsetFromLeapsectz()
+	require.NoError(t, err)
+	require.Greater(t, 50*time.Second, c.UTCOffset)
+	require.Less(t, 30*time.Second, c.UTCOffset)
+}
+
+func TestLeapSanity(t *testing.T) {
+	require.False(t, leapSanity(10))
+	require.False(t, leapSanity(60))
+	require.True(t, leapSanity(37))
+}

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -103,7 +103,11 @@ func (s *Server) Start() error {
 		defer wg.Done()
 		for {
 			<-time.After(1 * time.Minute)
-			if s.Config.SHM {
+			if s.Config.Leapsectz {
+				if err := s.Config.SetUTCOffsetFromLeapsectz(); err != nil {
+					log.Errorf("Failed to update UTC offset: %v. Keeping the last known: %s", err, s.Config.UTCOffset)
+				}
+			} else if s.Config.SHM {
 				if err := s.Config.SetUTCOffsetFromSHM(); err != nil {
 					log.Errorf("Failed to update UTC offset: %v. Keeping the last known: %s", err, s.Config.UTCOffset)
 				}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Option to use leapsectz lib
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ /usr/local/bin/ptp4u -workers 200 -timestamptype hardware -loglevel error -leapsectz
```
![image](https://user-images.githubusercontent.com/4749052/152218294-240fec97-63c6-4a2a-bc59-fead9348755d.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
