### PR TITLE
[ntpdate] verbose logging

### DIFF
--- a/cmd/ntpcheck/cmd/utils.go
+++ b/cmd/ntpcheck/cmd/utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/facebook/time/leapsectz"
 	ntp "github.com/facebook/time/ntp/protocol"
 	"github.com/facebook/time/timestamp"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 )
@@ -153,6 +154,12 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int) err
 
 		serverReceiveTime := ntp.Unix(response.RxTimeSec, response.RxTimeFrac)
 		serverTransmitTime := ntp.Unix(response.TxTimeSec, response.TxTimeFrac)
+		clientOriginTime := ntp.Unix(response.OrigTimeSec, response.OrigTimeFrac)
+
+		log.Debugf("Client TX timestamp: %v, Origin TX timestamp: %v", clientTransmitTime, clientOriginTime)
+		log.Debugf("Server RX timestamp: %v", serverReceiveTime)
+		log.Debugf("Server TX timestamp: %v", serverTransmitTime)
+		log.Debugf("Client RX timestamp: %v", clientReceiveTime)
 
 		avgNetworkDelay := ntp.AvgNetworkDelay(clientTransmitTime, serverReceiveTime, serverTransmitTime, clientReceiveTime)
 		currentRealTime := ntp.CurrentRealTime(serverTransmitTime, avgNetworkDelay)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Add debug logging to the ntpcheck utils ntpdate to print all 4 timestamps
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ go run github.com/facebook/time/cmd/ntpcheck utils ntpdate -s time1.facebook.com -v
Server: time1.facebook.com:123, Requests: 3
DEBU[0000] Client TX timestamp: 2022-02-05 00:39:14.769815 +0000 GMT m=+0.045096321, Origin TX timestamp: 2022-02-05 00:39:14.769814999 +0000 GMT
DEBU[0000] Server RX timestamp: 2022-02-05 00:39:14.85949871 +0000 GMT
DEBU[0000] Server TX timestamp: 2022-02-05 00:39:14.859621254 +0000 GMT
DEBU[0000] Client RX timestamp: 2022-02-05 00:39:14.795314 +0000 GMT
DEBU[0000] Client TX timestamp: 2022-02-05 00:39:14.79637 +0000 GMT m=+0.071651730, Origin TX timestamp: 2022-02-05 00:39:14.796369999 +0000 GMT
DEBU[0000] Server RX timestamp: 2022-02-05 00:39:14.883073097 +0000 GMT
DEBU[0000] Server TX timestamp: 2022-02-05 00:39:14.883154793 +0000 GMT
DEBU[0000] Client RX timestamp: 2022-02-05 00:39:14.818765 +0000 GMT
DEBU[0000] Client TX timestamp: 2022-02-05 00:39:14.81888 +0000 GMT m=+0.094162636, Origin TX timestamp: 2022-02-05 00:39:14.818879999 +0000 GMT
DEBU[0000] Server RX timestamp: 2022-02-05 00:39:14.906083901 +0000 GMT
DEBU[0000] Server TX timestamp: 2022-02-05 00:39:14.906193238 +0000 GMT
DEBU[0000] Client RX timestamp: 2022-02-05 00:39:14.841661 +0000 GMT
Last:
Stratum: 1, Current time: 2022-02-05 00:39:14.917529069 +0000 GMT
Offset: 0.075691s (75.691069ms), Network delay: 0.011336s (11.335831ms)
Average:
Offset: 0.075688s (75.687665ms), Network delay: 0.011727s (11.726904ms)
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
