### PR TITLE
[cmd/ntpcheck] ntpdate: fix delay calculation, sanity check

### DIFF
--- a/cmd/ntpcheck/cmd/utils.go
+++ b/cmd/ntpcheck/cmd/utils.go
@@ -161,7 +161,12 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int) err
 		log.Debugf("Server TX timestamp: %v", serverTransmitTime)
 		log.Debugf("Client RX timestamp: %v", clientReceiveTime)
 
-		avgNetworkDelay := ntp.AvgNetworkDelay(clientTransmitTime, serverReceiveTime, serverTransmitTime, clientReceiveTime)
+		// sanity check: origin time must be same as our transmit time
+		if response.OrigTimeSec != sec || response.OrigTimeFrac != frac {
+			log.Errorf("Client TX timestamp %v not equal to Origin TX timestamp %v", clientTransmitTime, clientOriginTime)
+		}
+
+		avgNetworkDelay := ntp.AvgNetworkDelay(clientOriginTime, serverReceiveTime, serverTransmitTime, clientReceiveTime)
 		currentRealTime := ntp.CurrentRealTime(serverTransmitTime, avgNetworkDelay)
 		offset := ntp.CalculateOffset(currentRealTime, time.Now())
 


### PR DESCRIPTION
## Summary

Per standard, we need to use Origin timestamp returned by the server for the calculation.

Also, log error if origin timestamp is not equal to what we sent as Transmit timestamp (one of the basic sanity checks prescribed by the standard).

## Test Plan

```
> ./ntpcheck utils ntpdate -s time.facebook.com
Server: time.facebook.com:123, Requests: 3
Last:
Stratum: 1, Current time: 2022-02-11 04:15:23.8979715 -0800 PST
Offset: 0.018336s (18.336179ms), Network delay: 0.164745s (164.745060ms)
Average:
Offset: 0.018281s (18.281252ms), Network delay: 0.164744s (164.743510ms)
```