### PR TITLE
[ptp] add UNICAST_MASTER_TABLE_NP and ptpcheck sources

### DIFF
--- a/cmd/ptpcheck/cmd/sources.go
+++ b/cmd/ptpcheck/cmd/sources.go
@@ -1,0 +1,139 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/facebook/time/cmd/ptpcheck/checker"
+	"github.com/facebook/time/phc"
+	ptp "github.com/facebook/time/ptp/protocol"
+
+	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sourcesNoDNSFlag bool
+)
+
+func init() {
+	RootCmd.AddCommand(sourcesCmd)
+	sourcesCmd.Flags().StringVarP(&rootServerFlag, "server", "S", "/var/run/ptp4l", "server to connect to")
+	sourcesCmd.Flags().BoolVarP(&sourcesNoDNSFlag, "no-resolving", "n", false, "disable resolving of IP addresses to hostnames")
+}
+
+func sourcesRun(server string, noDNS bool) error {
+	c, cleanup, err := checker.PrepareClient(server)
+	defer cleanup()
+	if err != nil {
+		return fmt.Errorf("preparing connection: %w", err)
+	}
+	ppn, err := c.PortPropertiesNP()
+	if err != nil {
+		return fmt.Errorf("getting PORT_PROPERTIES_NP from ptp4l: %w", err)
+	}
+	cds, err := c.CurrentDataSet()
+	if err != nil {
+		return fmt.Errorf("getting CURRENT_DATA_SET from ptp4l: %w", err)
+	}
+	tsn, err := c.TimeStatusNP()
+	if err != nil {
+		return fmt.Errorf("getting TIME_STATUS_NP from ptp4l: %w", err)
+	}
+	tlv, err := c.UnicastMasterTableNP()
+	if err != nil {
+		return fmt.Errorf("getting UNICAST_MASTER_TABLE_NP from ptp4l: %w", err)
+	}
+	// obtain time from clock that ptp4l uses
+	var currentTime time.Time
+	if ppn.Timestamping == ptp.TimestampingHardware {
+		currentTime, err = phc.Time(string(ppn.Interface), phc.MethodIoctlSysOffsetExtended)
+		if err != nil {
+			log.Errorf("No PHC time data available: %v", err)
+		}
+	} else {
+		currentTime = time.Now()
+	}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetColWidth(20)
+	table.SetHeader([]string{
+		"selected", "identity", "address", "state", "clock", "variance", "p1:p2", "offset(ns)", "delay(ns)", "last sync",
+	})
+	for _, entry := range tlv.UnicastMasterTable.UnicastMasters {
+		address := entry.Address.String()
+		if !noDNS {
+			names, err := net.LookupAddr(address)
+			if err == nil && len(names) > 0 {
+				address = names[0]
+			}
+		}
+
+		val := []string{
+			fmt.Sprintf("%v", entry.Selected),
+			entry.PortIdentity.String(),
+			address,
+			entry.PortState.String(),
+		}
+		if entry.PortState != ptp.UnicastMasterStateWait {
+			val = append(val, []string{
+				fmt.Sprintf("%d:0x%x", entry.ClockQuality.ClockClass, entry.ClockQuality.ClockAccuracy),
+				fmt.Sprintf("0x%x", entry.ClockQuality.OffsetScaledLogVariance),
+				fmt.Sprintf("%d:%d", entry.Priority1, entry.Priority2),
+			}...)
+		} else {
+			val = append(val, []string{"", "", ""}...)
+		}
+		if entry.Selected {
+			lastSync := "unknown"
+			if tsn.IngressTimeNS == 0 {
+				lastSync = "not syncing"
+			} else if !currentTime.IsZero() {
+				since := currentTime.Sub(time.Unix(0, tsn.IngressTimeNS))
+				lastSync = fmt.Sprintf("%v", since)
+			}
+			val = append(val, []string{
+				fmt.Sprintf("%3.f", cds.OffsetFromMaster.Nanoseconds()),
+				fmt.Sprintf("%3.f", cds.MeanPathDelay.Nanoseconds()),
+				lastSync,
+			}...)
+		} else {
+			val = append(val, []string{"", "", ""}...)
+		}
+		table.Append(val)
+	}
+	table.Render()
+	return nil
+}
+
+var sourcesCmd = &cobra.Command{
+	Use:   "sources",
+	Short: "Print PTP client unicast master table",
+	Long:  "Print PTP client unicast master table. Like `chronyc sources`, but for PTP.",
+	Run: func(c *cobra.Command, args []string) {
+		ConfigureVerbosity()
+
+		if err := sourcesRun(rootServerFlag, sourcesNoDNSFlag); err != nil {
+			log.Fatal(err)
+		}
+
+	},
+}

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,7 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43/go.mod h1:+t7E0lkKfbBsebllff1xdTmyJt8lH37niI6kwFk9OTo=
 github.com/mdlayher/ethtool v0.0.0-20211028163843-288d040e9d60 h1:tHdB+hQRHU10CfcK0furo6rSNgZ38JT8uPh70c/pFD8=
@@ -263,6 +264,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/ptp/protocol/ptp4l_test.go
+++ b/ptp/protocol/ptp4l_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package protocol
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_parseTimeStatusNP(t *testing.T) {
+func TestParseTimeStatusNP(t *testing.T) {
 	raw := []uint8{
 		13, 2, 0, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		72, 87, 221, 255, 254, 8, 100, 136, 0, 0, 0, 5, 4, 127, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -87,7 +88,21 @@ func Test_parseTimeStatusNP(t *testing.T) {
 	assert.Equal(t, raw, b)
 }
 
-func Test_parsePortStatsNP(t *testing.T) {
+func TestTimeStatusNPRequest(t *testing.T) {
+	req := TimeStatusNPRequest()
+	// it's normally generated from PID, set to know value
+	req.ManagementMsgHead.Header.SourcePortIdentity.PortNumber = 12345
+
+	raw, err := Bytes(req)
+	want := []byte{
+		0xd, 0x12, 0x0, 0x36, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x30, 0x39, 0x0, 0x0, 0x0, 0x7f, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x2, 0xc0, 0x0, 0x0, 0x0}
+	require.Nil(t, err)
+	require.Equal(t, want, raw)
+}
+
+func TestParsePortStatsNP(t *testing.T) {
 	raw := []uint8("\x0d\x12\x01\x40\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x04\x7f\x00\x00\x00\x00\x00\x00\x00\x00\x0b\x8a\x00\x00\x02\x00\x00\x01\x01\x0c\xc0\x05\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x51\x0f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x51\x0f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xaa\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
 	packet := new(Management)
 	err := FromBytes(raw, packet)
@@ -141,7 +156,21 @@ func Test_parsePortStatsNP(t *testing.T) {
 	assert.Equal(t, raw, b)
 }
 
-func Test_parsePortServiceStatsNP(t *testing.T) {
+func TestPortStatsNPRequest(t *testing.T) {
+	req := PortStatsNPRequest()
+	// it's normally generated from PID, set to know value
+	req.ManagementMsgHead.Header.SourcePortIdentity.PortNumber = 12345
+
+	raw, err := Bytes(req)
+	want := []byte{
+		0xd, 0x12, 0x0, 0x36, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x30, 0x39, 0x0, 0x0, 0x0, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x2, 0xc0, 0x5, 0x0, 0x0}
+	require.Nil(t, err)
+	require.Equal(t, want, raw)
+}
+
+func TestParsePortServiceStatsNP(t *testing.T) {
 	raw := []uint8("\x0d\x12\x00\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x04\x7f\x00\x00\x00\x00\x00\x00\x00\x00\x0e\xad\x00\x00\x02\x00\x00\x01\x00\x5c\xc0\x07\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x92\x05\x00\x00\x00\x00\x00\x00\x21\x0b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
 	packet := new(Management)
 	err := FromBytes(raw, packet)
@@ -203,7 +232,21 @@ func Test_parsePortServiceStatsNP(t *testing.T) {
 	assert.Equal(t, raw, b)
 }
 
-func Test_parsePortPropertiesNP(t *testing.T) {
+func TestPortServiceStatsNPRequest(t *testing.T) {
+	req := PortServiceStatsNPRequest()
+	// it's normally generated from PID, set to know value
+	req.ManagementMsgHead.Header.SourcePortIdentity.PortNumber = 12345
+
+	raw, err := Bytes(req)
+	want := []byte{
+		0xd, 0x12, 0x0, 0x36, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x30, 0x39, 0x0, 0x0, 0x0, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x2, 0xc0, 0x7, 0x0, 0x0}
+	require.Nil(t, err)
+	require.Equal(t, want, raw)
+}
+
+func TestParsePortPropertiesNP(t *testing.T) {
 	raw := []uint8("\x0d\x12\x00\x48\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x04\x7f\x00\x00\x00\x00\x00\x00\x00\x00\x1f\xf2\x00\x00\x02\x00\x00\x01\x00\x14\xc0\x04\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x09\x00\x04\x65\x74\x68\x30\x00\x00")
 	packet := new(Management)
 	err := FromBytes(raw, packet)
@@ -254,4 +297,227 @@ func Test_parsePortPropertiesNP(t *testing.T) {
 	b, err := Bytes(packet)
 	require.Nil(t, err)
 	assert.Equal(t, raw, b)
+}
+
+func TestPortPropertiesNPRequest(t *testing.T) {
+	req := PortPropertiesNPRequest()
+	// it's normally generated from PID, set to know value
+	req.ManagementMsgHead.Header.SourcePortIdentity.PortNumber = 12345
+
+	raw, err := Bytes(req)
+	want := []byte{
+		0xd, 0x12, 0x0, 0x36, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x30, 0x39, 0x0, 0x0, 0x0, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x2, 0xc0, 0x4, 0x0, 0x0}
+	require.Nil(t, err)
+	require.Equal(t, want, raw)
+}
+
+func TestParseUnicastMasterTableNP(t *testing.T) {
+	raw := []uint8("\x0d\x12\x01\x82\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x48\x57\xdd\xff\xfe\x0e\x91\xda\x00\x01\x00\x00\x04\x7f\x00\x00\x00\x00\x00\x00\x00\x00\xf7\xb0\x00\x00\x02\x00\x00\x01\x01\x4e\xc0\x08\x00\x09\xb8\xce\xf6\xff\xfe\x73\x49\xd4\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x01\xfa\xce\x00\x00\x02\xa3\x00\x00\xb8\xce\xf6\xff\xfe\x02\x10\xe4\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x01\xfa\xce\x00\x00\x03\xd1\x00\x00\xb8\xce\xf6\xff\xfe\x05\x7e\x20\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x01\xfa\xce\x00\x00\x03\xfa\x00\x00\xb8\xce\xf6\xff\xfe\x73\x49\xdc\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x01\xfa\xce\x00\x00\x00\xda\x00\x00\xb8\xce\xf6\xff\xfe\x02\x10\xdc\x00\x01\x06\x21\x59\xe0\x01\x02\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x02\xfa\xce\x00\x00\x01\x1b\x00\x00\xb8\xce\xf6\xff\xfe\x73\x49\xc4\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x02\xfa\xce\x00\x00\x01\xec\x00\x00\xb8\xce\xf6\xff\xfe\x73\x49\xcc\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x02\xfa\xce\x00\x00\x00\x94\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x04\xc0\xa8\x00\x01\xb8\xce\xf6\xff\xfe\x73\x49\xc8\x00\x01\x06\x21\x59\xe0\x00\x01\x80\x80\x00\x02\x00\x10\x24\x01\xdb\x00\x25\x15\xf0\x02\xfa\xce\x00\x00\x00\xb7\x00\x00\x00\x00")
+	packet := new(Management)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := Management{
+		ManagementMsgHead: ManagementMsgHead{
+			Header: Header{
+				SdoIDAndMsgType:     NewSdoIDAndMsgType(MessageManagement, 0),
+				Version:             Version,
+				MessageLength:       uint16(len(raw) - 2),
+				DomainNumber:        0,
+				MinorSdoID:          0,
+				FlagField:           0,
+				CorrectionField:     0,
+				MessageTypeSpecific: 0,
+				SourcePortIdentity: PortIdentity{
+					PortNumber:    1,
+					ClockIdentity: 5212879185253405146,
+				},
+				SequenceID:         0,
+				ControlField:       4,
+				LogMessageInterval: 0x7f,
+			},
+			TargetPortIdentity: PortIdentity{
+				PortNumber:    63408,
+				ClockIdentity: 0,
+			},
+			ActionField: RESPONSE,
+		},
+		TLV: &UnicastMasterTableNPTLV{
+			ManagementTLVHead: ManagementTLVHead{
+				TLVHead: TLVHead{
+					TLVType:     TLVManagement,
+					LengthField: 334,
+				},
+				ManagementID: IDUnicastMasterTableNP,
+			},
+			UnicastMasterTable: UnicastMasterTable{
+				ActualTableSize: 9,
+				UnicastMasters: []UnicastMasterEntry{
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727527197140,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f001:face:0:2a3:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727519776996,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f001:face:0:3d1:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727520001568,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f001:face:0:3fa:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727527197148,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f001:face:0:da:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727519776988,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  true,
+						PortState: UnicastMasterStateNeedSYDY,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f002:face:0:11b:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727527197124,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f002:face:0:1ec:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727527197132,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f002:face:0:94:0"),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 18446744073709551615,
+							PortNumber:    65535,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              0,
+							ClockAccuracy:           0,
+							OffsetScaledLogVariance: 0,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateWait,
+						Priority1: 0,
+						Priority2: 0,
+						Address:   net.ParseIP("192.168.0.1").To4(),
+					},
+					{
+						PortIdentity: PortIdentity{
+							ClockIdentity: 13316852727527197128,
+							PortNumber:    1,
+						},
+						ClockQuality: ClockQuality{
+							ClockClass:              6,
+							ClockAccuracy:           33,
+							OffsetScaledLogVariance: 23008,
+						},
+						Selected:  false,
+						PortState: UnicastMasterStateHaveAnnounce,
+						Priority1: 128,
+						Priority2: 128,
+						Address:   net.ParseIP("2401:db00:2515:f002:face:0:b7:0"),
+					},
+				},
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	require.Equal(t, raw, b)
+}
+
+func TestUnicastMasterTableNPRequest(t *testing.T) {
+	req := UnicastMasterTableNPRequest()
+	// it's normally generated from PID, set to know value
+	req.ManagementMsgHead.Header.SourcePortIdentity.PortNumber = 12345
+
+	raw, err := Bytes(req)
+	want := []byte{
+		0xd, 0x12, 0x0, 0x36, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x30, 0x39, 0x0, 0x0, 0x0, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x2, 0xc0, 0x8, 0x0, 0x0}
+	require.Nil(t, err)
+	require.Equal(t, want, raw)
 }


### PR DESCRIPTION
## Summary

New UNICAST_MASTER_TABLE_NP management TLV was just [merged to linuxptp](https://github.com/richardcochran/linuxptp/commit/c63d1fca3f47ea22eae076114ce263bc4f30725a), this PR adds Go protocol support for it.

And of course the `ptpcheck sources` subcommand that uses this new TLV.

## Test Plan

unittests

```
> ./ptpcheck sources
+----------+----------------------+----------------------------------+-----------+--------+----------+---------+------------+-----------+--------------+
| SELECTED |       IDENTITY       |       ADDRESS      |   STATE   | CLOCK  | VARIANCE |  P1:P2  | OFFSET(NS) | DELAY(NS) |  LAST SYNC   |
+----------+----------------------+--------------------+-----------+--------+----------+---------+------------+-----------+--------------+
| false    | b8cef6.fffe.7349d4-1 | time01.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
| true     | b8cef6.fffe.0210e4-1 | time02.example.com | HAVE_SYDY | 6:0x21 | 0x59e0   | 128:128 |        -90 |      3980 | 368.986609ms |
| false    | b8cef6.fffe.057e20-1 | time03.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
| false    | b8cef6.fffe.7349dc-1 | time04.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
| false    | b8cef6.fffe.0210dc-1 | time05.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
| false    | b8cef6.fffe.7349c4-1 | time06.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
| false    | b8cef6.fffe.7349cc-1 | time07.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
| false    | b8cef6.fffe.7349c8-1 | time08.example.com | HAVE_ANN  | 6:0x21 | 0x59e0   | 128:128 |            |           |              |
+----------+----------------------+--------------------+-----------+--------+----------+---------+------------+-----------+--------------+
```
