### PR TITLE
[ptpcheck] display satellites_count in oscillatord output

### DIFF
--- a/cmd/ptpcheck/cmd/oscillatord.go
+++ b/cmd/ptpcheck/cmd/oscillatord.go
@@ -50,23 +50,25 @@ func bool2int(b bool) int64 {
 
 func printOscillatordJSON(status *oscillatord.Status) error {
 	output := struct {
-		Temperature       int64 `json:"ptp.timecard.temperature"`
-		Lock              int64 `json:"ptp.timecard.lock"`
-		GNSSFixNum        int64 `json:"ptp.timecard.gnss.fix_num"`
-		GNSSFixOk         int64 `json:"ptp.timecard.gnss.fix_ok"`
-		GNSSAntennaPower  int64 `json:"ptp.timecard.gnss.antenna_power"`
-		GNSSAntennaStatus int64 `json:"ptp.timecard.gnss.antenna_status"`
-		GNSSLSChange      int64 `json:"ptp.timecard.gnss.leap_second_change"`
-		GNSSLeapSeconds   int64 `json:"ptp.timecard.gnss.leap_seconds"`
+		Temperature         int64 `json:"ptp.timecard.temperature"`
+		Lock                int64 `json:"ptp.timecard.lock"`
+		GNSSFixNum          int64 `json:"ptp.timecard.gnss.fix_num"`
+		GNSSFixOk           int64 `json:"ptp.timecard.gnss.fix_ok"`
+		GNSSAntennaPower    int64 `json:"ptp.timecard.gnss.antenna_power"`
+		GNSSAntennaStatus   int64 `json:"ptp.timecard.gnss.antenna_status"`
+		GNSSLSChange        int64 `json:"ptp.timecard.gnss.leap_second_change"`
+		GNSSLeapSeconds     int64 `json:"ptp.timecard.gnss.leap_seconds"`
+		GNSSSatellitesCount int64 `json:"ptp.timecard.gnss.satellites_count"`
 	}{
-		Temperature:       int64(status.Oscillator.Temperature),
-		Lock:              bool2int(status.Oscillator.Lock),
-		GNSSFixNum:        int64(status.GNSS.Fix),
-		GNSSFixOk:         bool2int(status.GNSS.FixOK),
-		GNSSAntennaPower:  int64(status.GNSS.AntennaPower),
-		GNSSAntennaStatus: int64(status.GNSS.AntennaStatus),
-		GNSSLSChange:      int64(status.GNSS.LSChange),
-		GNSSLeapSeconds:   int64(status.GNSS.LeapSeconds),
+		Temperature:         int64(status.Oscillator.Temperature),
+		Lock:                bool2int(status.Oscillator.Lock),
+		GNSSFixNum:          int64(status.GNSS.Fix),
+		GNSSFixOk:           bool2int(status.GNSS.FixOK),
+		GNSSAntennaPower:    int64(status.GNSS.AntennaPower),
+		GNSSAntennaStatus:   int64(status.GNSS.AntennaStatus),
+		GNSSLSChange:        int64(status.GNSS.LSChange),
+		GNSSLeapSeconds:     int64(status.GNSS.LeapSeconds),
+		GNSSSatellitesCount: int64(status.GNSS.SatellitesCount),
 	}
 	toPrint, err := json.Marshal(output)
 	if err != nil {
@@ -91,6 +93,7 @@ func printOscillatord(status *oscillatord.Status) {
 	fmt.Printf("\tantenna_status: %s (%d)\n", status.GNSS.AntennaStatus, status.GNSS.AntennaStatus)
 	fmt.Printf("\tleap_second_change: %s (%d)\n", status.GNSS.LSChange, status.GNSS.LSChange)
 	fmt.Printf("\tleap_seconds: %d\n", status.GNSS.LeapSeconds)
+	fmt.Printf("\tsatellites_count: %d\n", status.GNSS.SatellitesCount)
 }
 
 func oscillatordRun(address string, jsonOut bool) error {

--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -161,12 +161,13 @@ type Oscillator struct {
 
 // GNSS describes structure that oscillatord returns for gnss
 type GNSS struct {
-	Fix           GNSSFix          `json:"fix"`
-	FixOK         bool             `json:"fixOk"`
-	AntennaPower  AntennaPower     `json:"antenna_power"`
-	AntennaStatus AntennaStatus    `json:"antenna_status"`
-	LSChange      LeapSecondChange `json:"lsChange"`
-	LeapSeconds   int              `json:"leap_seconds"`
+	Fix             GNSSFix          `json:"fix"`
+	FixOK           bool             `json:"fixOk"`
+	AntennaPower    AntennaPower     `json:"antenna_power"`
+	AntennaStatus   AntennaStatus    `json:"antenna_status"`
+	LSChange        LeapSecondChange `json:"lsChange"`
+	LeapSeconds     int              `json:"leap_seconds"`
+	SatellitesCount int              `json:"satellites_count"`
 }
 
 // Status is whole structure that oscillatord returns for monitoring

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -33,7 +33,7 @@ func TestOscillatordRead(t *testing.T) {
 		_, err := server.Read(b)
 		require.Nil(t, err)
 		// write response
-		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18 } }`
+		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18, "satellites_count": 10 } }`
 		_, err = server.Write([]byte(data))
 		require.Nil(t, err)
 	}()
@@ -48,12 +48,13 @@ func TestOscillatordRead(t *testing.T) {
 			Temperature: 45.944,
 		},
 		GNSS: GNSS{
-			Fix:           Fix3D,
-			FixOK:         true,
-			AntennaPower:  AntPowerOn,
-			AntennaStatus: AntStatusOpen,
-			LSChange:      LeapNoWarning,
-			LeapSeconds:   18,
+			Fix:             Fix3D,
+			FixOK:           true,
+			AntennaPower:    AntPowerOn,
+			AntennaStatus:   AntStatusOpen,
+			LSChange:        LeapNoWarning,
+			LeapSeconds:     18,
+			SatellitesCount: 10,
 		},
 	}
 	require.Equal(t, want, status)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Expose read `satellites_count` from oscillatord socket and expose it via `ptpcheck oscillatord`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
./ptpcheck_oleg oscillatord
Oscillator:
	model: mRO50
	fine_ctrl: 2761
	coarse_ctrl: 4186407
	lock: true
	temperature: 32.51C
GNSS:
	fix: 3D (5)
	fixOk: true
	antenna_power: ON (1)
	antenna_status: OPEN (4)
	leap_second_change: NO WARNING (0)
	leap_seconds: 18
	satellites_count: 9
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
