### PR TITLE
[ptp4u] fix drain check delay on startup

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -111,9 +111,9 @@ func (s *Server) Start() error {
 	// Drain check
 	go func() {
 		defer wg.Done()
-		for {
-			<-time.After(s.Config.DrainInterval)
-
+		ticker := time.NewTicker(s.Config.DrainInterval)
+		defer ticker.Stop()
+		for ; true; <-ticker.C {
 			var drain bool
 			for _, check := range s.Checks {
 				if check.Check() {


### PR DESCRIPTION
## Summary

Fix drain check so we immediately check for draining conditions. Currently there is a delay when ptp4u serves traffic on startup, even if drain file is already present when it was started.

## Test Plan

```
> sudo ./ptp4u --timestamptype software
WARN[0000] Software timestamps greatly reduce the precision
WARN[0030] *drain.FileDrain engaged shifting traffic ## we planted the drain file
^C

> sudo ./ptp4u --timestamptype software
WARN[0000] Software timestamps greatly reduce the precision
WARN[0000] *drain.FileDrain engaged shifting traffic
```