### PR TITLE
[calnex] change PPS export datatype

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -70,7 +70,7 @@ const (
 	ENABLED  = "Enabled"
 	DISABLED = "Disabled"
 	STATIC   = "Static"
-	TIE      = "tie"
+	TE       = "te"
 	TWOWAYTE = "2wayte"
 )
 
@@ -122,12 +122,12 @@ const (
 // MeasureChannelDatatypeMap is a Map of the measurement channels to the data type.
 // Only channels used for measurements defined here
 var MeasureChannelDatatypeMap = map[Channel]string{
-	ChannelA:    TIE,
-	ChannelB:    TIE,
-	ChannelC:    TIE,
-	ChannelD:    TIE,
-	ChannelE:    TIE,
-	ChannelF:    TIE,
+	ChannelA:    TE,
+	ChannelB:    TE,
+	ChannelC:    TE,
+	ChannelD:    TE,
+	ChannelE:    TE,
+	ChannelF:    TE,
 	ChannelVP1:  TWOWAYTE,
 	ChannelVP2:  TWOWAYTE,
 	ChannelVP3:  TWOWAYTE,
@@ -467,7 +467,7 @@ func (a *API) FetchCsv(channel Channel) ([][]string, error) {
 // FetchChannelProbe returns monitored protocol of the channel
 func (a *API) FetchChannelProbe(channel Channel) (*Probe, error) {
 	pth := path.Join(channel.CalnexAPI(), "ptp_synce", "mode", "probe_type")
-	if MeasureChannelDatatypeMap[channel] == TIE {
+	if MeasureChannelDatatypeMap[channel] == TE {
 		pth = path.Join(channel.CalnexAPI(), "signal_type")
 	}
 	url := fmt.Sprintf(measureURL, a.source, pth)
@@ -498,7 +498,7 @@ func (a *API) FetchChannelProbe(channel Channel) (*Probe, error) {
 // FetchChannelTarget returns the measure target of the server monitored on the channel
 func (a *API) FetchChannelTarget(channel Channel, probe Probe) (string, error) {
 	pth := path.Join(channel.CalnexAPI(), "ptp_synce", probe.String(), probe.ServerType())
-	if MeasureChannelDatatypeMap[channel] == TIE {
+	if MeasureChannelDatatypeMap[channel] == TE {
 		pth = path.Join(channel.CalnexAPI(), probe.ServerType())
 	}
 	url := fmt.Sprintf(measureURL, a.source, pth)

--- a/calnex/api/api_test.go
+++ b/calnex/api/api_test.go
@@ -565,7 +565,7 @@ func TestParseResponse(t *testing.T) {
 
 func TestMeasureChannelDatatypeMap(t *testing.T) {
 	for i := 0; i <= 5; i++ {
-		require.Equal(t, TIE, MeasureChannelDatatypeMap[Channel(i)])
+		require.Equal(t, TE, MeasureChannelDatatypeMap[Channel(i)])
 	}
 
 	for i := 6; i <= 8; i++ {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
PPS export is done via `datatype=te` not datatype=tie
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
```
$ curl "https://calnex01.example.com/api/getdata?channel=c&datatype=te"
1647612864.021067,-1729.652058119275
1647612864.930176,-1729.561166749330
1647612865.839285,-1729.470275380428
```