### PR TITLE
[ptp4u] make clockAccuracy and clockClass configurable

### DIFF
--- a/cmd/ptp4u/main.go
+++ b/cmd/ptp4u/main.go
@@ -54,6 +54,8 @@ func main() {
 	flag.IntVar(&c.QueueSize, "queue", 0, "Size of the queue to send out packets")
 	flag.DurationVar(&c.MetricInterval, "metricinterval", 1*time.Minute, "Interval of resetting metrics")
 	flag.DurationVar(&c.DrainInterval, "draininterval", 30*time.Second, "Interval for drain checks")
+	flag.UintVar(&c.ClockClass, "classclass", 6, "Clock class to report via announce messages. 6 - Locked with Primary Reference Clock")
+	flag.UintVar(&c.ClockAccuracy, "clockaccuracy", 0x21, "Clock accuracy to report via announce messages. // 0x21 - Time Accurate within 100ns")
 
 	flag.Parse()
 

--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	RecvWorkers    int
 	QueueSize      int
 	DrainInterval  time.Duration
+	ClockClass     uint
+	ClockAccuracy  uint
 
 	clockIdentity ptp.ClockIdentity
 }

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -260,8 +260,8 @@ func (sc *SubscriptionClient) initAnnounce() {
 			Reserved:             0,
 			GrandmasterPriority1: 128,
 			GrandmasterClockQuality: ptp.ClockQuality{
-				ClockClass:              6,
-				ClockAccuracy:           33, // 0x21 - Time Accurate within 100ns
+				ClockClass:              0,
+				ClockAccuracy:           0,
 				OffsetScaledLogVariance: 23008,
 			},
 			GrandmasterPriority2: 128,
@@ -278,6 +278,8 @@ func (sc *SubscriptionClient) UpdateAnnounce() {
 	sc.announceP.SequenceID = sc.sequenceID
 	sc.announceP.LogMessageInterval = i
 	sc.announceP.CurrentUTCOffset = int16(sc.serverConfig.UTCOffset.Seconds())
+	sc.announceP.GrandmasterClockQuality.ClockClass = uint8(sc.serverConfig.ClockClass)
+	sc.announceP.GrandmasterClockQuality.ClockAccuracy = uint8(sc.serverConfig.ClockAccuracy)
 }
 
 // Announce returns ptp Announce packet

--- a/ptp/ptp4u/server/subscription_test.go
+++ b/ptp/ptp4u/server/subscription_test.go
@@ -170,9 +170,11 @@ func TestAnnouncePacket(t *testing.T) {
 	UTCOffset := 3 * time.Second
 	sequenceID := uint16(42)
 	interval := 3 * time.Second
+	clockClass := uint(8)
+	clockAccuracy := uint(42)
 
 	w := &sendWorker{}
-	c := &Config{clockIdentity: ptp.ClockIdentity(1234), UTCOffset: UTCOffset}
+	c := &Config{clockIdentity: ptp.ClockIdentity(1234), ClockClass: clockClass, ClockAccuracy: clockAccuracy, UTCOffset: UTCOffset}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID
@@ -192,6 +194,8 @@ func TestAnnouncePacket(t *testing.T) {
 	require.Equal(t, sequenceID+1, sc.Announce().Header.SequenceID)
 	require.Equal(t, sp, sc.Announce().Header.SourcePortIdentity)
 	require.Equal(t, i, sc.Announce().Header.LogMessageInterval)
+	require.Equal(t, uint8(clockClass), sc.Announce().AnnounceBody.GrandmasterClockQuality.ClockClass)
+	require.Equal(t, uint8(clockAccuracy), sc.Announce().AnnounceBody.GrandmasterClockQuality.ClockAccuracy)
 	require.Equal(t, int16(UTCOffset.Seconds()), sc.Announce().AnnounceBody.CurrentUTCOffset)
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Introduce 2 new configuration options ClockClass and ClockAccuracy.
Use these 2 values in announce packet instead of hardcode values.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Run server
Tcpdump announce message
Look inside with wireshark
Values are set to "defaults"
![image](https://user-images.githubusercontent.com/4749052/161118831-5ba4239d-b3d1-421a-9714-f7730ae22c63.png)

Also unit tests!
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
