### PR TITLE
[ptp4u] introduce the yaml config file support

### DIFF
--- a/cmd/ptp4u/testdata/ptp4u.yaml
+++ b/cmd/ptp4u/testdata/ptp4u.yaml
@@ -1,0 +1,7 @@
+clockaccuracy: 0x21
+clockclass: 6
+draininterval : "30s"
+maxsubduration: "1h"
+metricinterval : "1m"
+minsubinterval: "1s"
+utcoffset     : "37s"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/facebook/time
 go 1.16
 
 require (
-	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.13.0
 	github.com/go-ini/ini v1.66.2
@@ -11,6 +10,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/go-version v1.3.0
 	github.com/jsimonetti/rtnetlink v0.0.0-20211213041634-9dff439f7e79
+	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
@@ -20,4 +20,5 @@ require (
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
-github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -215,7 +213,6 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -270,7 +267,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
@@ -673,6 +669,7 @@ gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -27,26 +27,45 @@ import (
 	ptp "github.com/facebook/time/ptp/protocol"
 )
 
-// Config is a server config structure
-type Config struct {
+// StaticConfig is a set of static options which require a server restart
+type StaticConfig struct {
+	ConfigFile     string
+	DebugAddr      string
 	DSCP           int
 	Interface      string
 	IP             net.IP
-	LogLevel       string
-	MaxSubDuration time.Duration
-	MetricInterval time.Duration
-	MinSubInterval time.Duration
-	MonitoringPort int
-	SHM            bool
 	Leapsectz      bool
-	TimestampType  string
-	UTCOffset      time.Duration
-	SendWorkers    int
-	RecvWorkers    int
+	LogLevel       string
+	MonitoringPort int
 	QueueSize      int
-	DrainInterval  time.Duration
-	ClockClass     uint
-	ClockAccuracy  uint
+	RecvWorkers    int
+	SendWorkers    int
+	SHM            bool
+	TimestampType  string
+}
+
+// DynamicConfig is a set of dynamic options which don't need a server restart
+type DynamicConfig struct {
+	// ClockCccuracy to report via announce messages. Time Accurate within 100ns
+	ClockAccuracy uint8
+	// ClockClass to report via announce messages. 6 - Locked with Primary Reference Clock
+	ClockClass uint8
+	// DrainInterval is an interval for drain checks
+	DrainInterval time.Duration
+	// MaxSubDuration is a maximum sync/announce/delay_resp subscription duration
+	MaxSubDuration time.Duration
+	// MetricInterval is an interval of resetting metrics
+	MetricInterval time.Duration
+	// MinSubInterval is a minimum interval of the sync/announce subscription messages
+	MinSubInterval time.Duration
+	// UTCOffset is a current UTC offset.
+	UTCOffset time.Duration
+}
+
+// Config is a server config structure
+type Config struct {
+	StaticConfig
+	DynamicConfig
 
 	clockIdentity ptp.ClockIdentity
 }

--- a/ptp/ptp4u/server/config_test.go
+++ b/ptp/ptp4u/server/config_test.go
@@ -43,7 +43,7 @@ func TestConfigifaceIPs(t *testing.T) {
 }
 
 func TestConfigIfaceHasIP(t *testing.T) {
-	c := Config{Interface: "lo"}
+	c := Config{StaticConfig: StaticConfig{Interface: "lo"}}
 
 	c.IP = net.ParseIP("::")
 	found, err := c.IfaceHasIP()
@@ -55,7 +55,7 @@ func TestConfigIfaceHasIP(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, found)
 
-	c = Config{Interface: "lol-does-not-exist"}
+	c = Config{StaticConfig: StaticConfig{Interface: "lol-does-not-exist"}}
 	c.IP = net.ParseIP("::")
 	found, err = c.IfaceHasIP()
 	require.NotNil(t, err)
@@ -64,7 +64,7 @@ func TestConfigIfaceHasIP(t *testing.T) {
 
 func TestConfigSetUTCOffsetFromSHM(t *testing.T) {
 	utcoffset := 42 * time.Second
-	c := Config{UTCOffset: utcoffset}
+	c := Config{DynamicConfig: DynamicConfig{UTCOffset: utcoffset}}
 	err := c.SetUTCOffsetFromSHM()
 	require.NotNil(t, err)
 	require.Equal(t, utcoffset, c.UTCOffset)
@@ -72,7 +72,7 @@ func TestConfigSetUTCOffsetFromSHM(t *testing.T) {
 
 func TestConfigSetUTCOffsetFromLeapsectz(t *testing.T) {
 	utcoffset := 42 * time.Second
-	c := Config{UTCOffset: utcoffset}
+	c := Config{DynamicConfig: DynamicConfig{UTCOffset: utcoffset}}
 	err := c.SetUTCOffsetFromLeapsectz()
 	require.NoError(t, err)
 	require.Greater(t, 50*time.Second, c.UTCOffset)

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -33,8 +33,10 @@ func TestFindWorker(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		TimestampType: timestamp.SWTIMESTAMP,
-		SendWorkers:   10,
+		StaticConfig: StaticConfig{
+			TimestampType: timestamp.SWTIMESTAMP,
+			SendWorkers:   10,
+		},
 	}
 	s := Server{
 		Config: c,
@@ -74,10 +76,12 @@ func TestStartEventListener(t *testing.T) {
 	ptp.PortEvent = 0
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		TimestampType: timestamp.SWTIMESTAMP,
-		SendWorkers:   10,
-		RecvWorkers:   10,
-		IP:            net.ParseIP("127.0.0.1"),
+		StaticConfig: StaticConfig{
+			TimestampType: timestamp.SWTIMESTAMP,
+			SendWorkers:   10,
+			RecvWorkers:   10,
+			IP:            net.ParseIP("127.0.0.1"),
+		},
 	}
 	s := Server{
 		Config: c,
@@ -92,10 +96,12 @@ func TestStartGeneralListener(t *testing.T) {
 	ptp.PortGeneral = 0
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		TimestampType: timestamp.SWTIMESTAMP,
-		SendWorkers:   10,
-		RecvWorkers:   10,
-		IP:            net.ParseIP("127.0.0.1"),
+		StaticConfig: StaticConfig{
+			TimestampType: timestamp.SWTIMESTAMP,
+			SendWorkers:   10,
+			RecvWorkers:   10,
+			IP:            net.ParseIP("127.0.0.1"),
+		},
 	}
 	s := Server{
 		Config: c,
@@ -110,7 +116,9 @@ func TestSendGrant(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		SendWorkers:   10,
+		StaticConfig: StaticConfig{
+			SendWorkers: 10,
+		},
 	}
 	s := Server{
 		Config: c,

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -278,8 +278,8 @@ func (sc *SubscriptionClient) UpdateAnnounce() {
 	sc.announceP.SequenceID = sc.sequenceID
 	sc.announceP.LogMessageInterval = i
 	sc.announceP.CurrentUTCOffset = int16(sc.serverConfig.UTCOffset.Seconds())
-	sc.announceP.GrandmasterClockQuality.ClockClass = uint8(sc.serverConfig.ClockClass)
-	sc.announceP.GrandmasterClockQuality.ClockAccuracy = uint8(sc.serverConfig.ClockAccuracy)
+	sc.announceP.GrandmasterClockQuality.ClockClass = sc.serverConfig.ClockClass
+	sc.announceP.GrandmasterClockQuality.ClockAccuracy = sc.serverConfig.ClockAccuracy
 }
 
 // Announce returns ptp Announce packet

--- a/ptp/ptp4u/server/subscription_test.go
+++ b/ptp/ptp4u/server/subscription_test.go
@@ -170,11 +170,11 @@ func TestAnnouncePacket(t *testing.T) {
 	UTCOffset := 3 * time.Second
 	sequenceID := uint16(42)
 	interval := 3 * time.Second
-	clockClass := uint(8)
-	clockAccuracy := uint(42)
+	clockClass := uint8(8)
+	clockAccuracy := uint8(42)
 
 	w := &sendWorker{}
-	c := &Config{clockIdentity: ptp.ClockIdentity(1234), ClockClass: clockClass, ClockAccuracy: clockAccuracy, UTCOffset: UTCOffset}
+	c := &Config{clockIdentity: ptp.ClockIdentity(1234), DynamicConfig: DynamicConfig{ClockClass: clockClass, ClockAccuracy: clockAccuracy, UTCOffset: UTCOffset}}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID

--- a/ptp/ptp4u/server/worker_test.go
+++ b/ptp/ptp4u/server/worker_test.go
@@ -31,7 +31,9 @@ import (
 func TestWorkerQueue(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		TimestampType: timestamp.SWTIMESTAMP,
+		StaticConfig: StaticConfig{
+			TimestampType: timestamp.SWTIMESTAMP,
+		},
 	}
 
 	st := stats.NewJSONStats()
@@ -78,7 +80,9 @@ func TestWorkerQueue(t *testing.T) {
 func TestFindSubscription(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		TimestampType: timestamp.SWTIMESTAMP,
+		StaticConfig: StaticConfig{
+			TimestampType: timestamp.SWTIMESTAMP,
+		},
 	}
 
 	w := &sendWorker{
@@ -112,8 +116,9 @@ func TestInventoryClients(t *testing.T) {
 	}
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
-		QueueSize:     100, // Making sure subscriptions aren't blocked
-
+		StaticConfig: StaticConfig{
+			QueueSize: 100, // Making sure subscriptions aren't blocked
+		},
 	}
 
 	st := stats.NewJSONStats()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Split "config" struct in 2 parts:
  * Static - things which never change during lifetime aka IP or iface
  * Dynamic - thing that can be updated without service restart
* Allow `flags` (cmd line arguments) to configure *only* static section
* Introduce support of yaml configs *only* for dynamic section of the config

This way we are confident that entire config will be "reload" vs just part of the settings.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Deploy new binary to a test host. See UTC offset for example working.
![image](https://user-images.githubusercontent.com/4749052/161311885-97601f2f-4350-4c66-a531-dab9eea37f6d.png)

Nothing changes as provided defaults match previous behaviour:
Print options:
### Defaults
```
$ ./ptp4u
&{StaticConfig:{ConfigFile: DebugAddr: DSCP:0 Interface:eth0 IP::: Leapsectz:false LogLevel:warning MonitoringPort:8888 QueueSize:0 RecvWorkers:10 SendWorkers:100 SHM:false TimestampType:hardware} DynamicConfig:{ClockAccuracy:33 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s} clockIdentity:0}
```
### Specify config
```
$ cat /etc/ptp4u.yaml
maxsubduration: "2h"
metricinterval : "2m"
minsubinterval: "2s"
monitoringport: 28888
timestamptype : "software"
utcoffset     : "237s"
sendworkers   : 200
recvworkers   : 20
queuesize     : 20
draininterval : "20s"
```

(see DynamicConfig)
```
$ ./ptp4u -config /etc/ptp4u.yaml
&{StaticConfig:{ConfigFile:/etc/ptp4u.yaml DebugAddr: DSCP:0 Interface:eth0 IP::: Leapsectz:false LogLevel:warning MonitoringPort:8888 QueueSize:0 RecvWorkers:10 SendWorkers:100 SHM:false TimestampType:hardware} DynamicConfig:{ClockAccuracy:33 ClockClass:6 DrainInterval:20s MaxSubDuration:2h0m0s MetricInterval:2m0s MinSubInterval:2s UTCOffset:3m57s} clockIdentity:0}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
