### PR TITLE
[ptp4u] reload config on SIGHUP

### DIFF
--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -69,21 +69,32 @@ type Config struct {
 	clockIdentity ptp.ClockIdentity
 }
 
+// UTCOffsetSanity checks if UTC offset value has an adequate value
+func (dc *DynamicConfig) UTCOffsetSanity() error {
+	if dc.UTCOffset < 30*time.Second || dc.UTCOffset > 50*time.Second {
+		return errInsaneUTCoffset
+	}
+	return nil
+}
+
 func (c *Config) ReadDynamicConfig() error {
 	cData, err := os.ReadFile(c.ConfigFile)
 	if err != nil {
 		return err
 	}
 
-	err = yaml.Unmarshal(cData, &c.DynamicConfig)
+	d := c.DynamicConfig
+
+	err = yaml.Unmarshal(cData, &d)
 	if err != nil {
 		return err
 	}
 
-	if err := c.UTCOffsetSanity(); err != nil {
+	if err := d.UTCOffsetSanity(); err != nil {
 		return err
 	}
 
+	c.DynamicConfig = d
 	return nil
 }
 
@@ -101,14 +112,6 @@ func (c *Config) IfaceHasIP() (bool, error) {
 	}
 
 	return false, nil
-}
-
-// UTCOffsetSanity checks if UTC offset value has an adequate value
-func (c *Config) UTCOffsetSanity() error {
-	if c.UTCOffset < 30*time.Second || c.UTCOffset > 50*time.Second {
-		return errInsaneUTCoffset
-	}
-	return nil
 }
 
 // ifaceIPs gets all IPs on the specified interface

--- a/ptp/ptp4u/stats/json.go
+++ b/ptp/ptp4u/stats/json.go
@@ -67,6 +67,7 @@ func (s *JSONStats) Snapshot() {
 	s.txtsattempts.copy(&s.report.txtsattempts)
 	s.report.utcoffset = s.utcoffset
 	s.report.drain = s.drain
+	s.report.reload = s.reload
 }
 
 // handleRequest is a handler used for all http monitoring requests
@@ -115,6 +116,11 @@ func (s *JSONStats) IncTXSignaling(t ptp.MessageType) {
 // IncWorkerSubs atomically add 1 to the counter
 func (s *JSONStats) IncWorkerSubs(workerid int) {
 	s.workerSubs.inc(workerid)
+}
+
+// IncReload atomically add 1 to the counter
+func (s *JSONStats) IncReload() {
+	atomic.StoreInt64(&s.reload, 1)
 }
 
 // DecSubscription atomically removes 1 from the counter

--- a/ptp/ptp4u/stats/json_test.go
+++ b/ptp/ptp4u/stats/json_test.go
@@ -155,6 +155,7 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.SetUTCOffset(1)
 	stats.SetDrain(1)
+	stats.IncReload()
 
 	stats.Snapshot()
 
@@ -165,12 +166,14 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	expectedStats.rxSignaling.store(int(ptp.MessageDelayResp), 3)
 	expectedStats.utcoffset = 1
 	expectedStats.drain = 1
+	expectedStats.reload = 1
 
 	require.Equal(t, expectedStats.subscriptions.m, stats.report.subscriptions.m)
 	require.Equal(t, expectedStats.tx.m, stats.report.tx.m)
 	require.Equal(t, expectedStats.rxSignaling.m, stats.report.rxSignaling.m)
 	require.Equal(t, expectedStats.utcoffset, stats.report.utcoffset)
 	require.Equal(t, expectedStats.drain, stats.report.drain)
+	require.Equal(t, expectedStats.reload, stats.report.reload)
 }
 
 func TestJSONExport(t *testing.T) {
@@ -187,6 +190,7 @@ func TestJSONExport(t *testing.T) {
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.SetUTCOffset(1)
 	stats.SetDrain(1)
+	stats.IncReload()
 
 	stats.Snapshot()
 
@@ -207,6 +211,7 @@ func TestJSONExport(t *testing.T) {
 	expectedMap["rx.signaling.delay_resp"] = 3
 	expectedMap["utcoffset"] = 1
 	expectedMap["drain"] = 1
+	expectedMap["reload"] = 1
 
 	require.Equal(t, expectedMap, data)
 }

--- a/ptp/ptp4u/stats/stats.go
+++ b/ptp/ptp4u/stats/stats.go
@@ -59,6 +59,9 @@ type Stats interface {
 	// IncWorkerSubs atomically add 1 to the counter
 	IncWorkerSubs(workerid int)
 
+	// IncReload atomically add 1 to the counter
+	IncReload()
+
 	// DecSubscription atomically removes 1 from the counter
 	DecSubscription(t ptp.MessageType)
 
@@ -168,6 +171,7 @@ type counters struct {
 	workerSubs    syncMapInt64
 	utcoffset     int64
 	drain         int64
+	reload        int64
 }
 
 func (c *counters) init() {
@@ -192,6 +196,7 @@ func (c *counters) reset() {
 	c.txtsattempts.reset()
 	c.utcoffset = 0
 	c.drain = 0
+	c.reload = 0
 }
 
 // toMap converts counters to a map
@@ -245,6 +250,7 @@ func (c *counters) toMap() (export map[string]int64) {
 
 	res["utcoffset"] = c.utcoffset
 	res["drain"] = c.drain
+	res["reload"] = c.reload
 
 	return res
 }

--- a/ptp/ptp4u/stats/stats_test.go
+++ b/ptp/ptp4u/stats/stats_test.go
@@ -74,6 +74,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	c.txtsattempts.store(1, 1)
 	c.utcoffset = 1
 	c.drain = 1
+	c.reload = 1
 
 	require.Equal(t, int64(1), c.subscriptions.load(1))
 	require.Equal(t, int64(1), c.rx.load(1))
@@ -85,6 +86,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(1), c.txtsattempts.load(1))
 	require.Equal(t, int64(1), c.utcoffset)
 	require.Equal(t, int64(1), c.drain)
+	require.Equal(t, int64(1), c.reload)
 
 	c.reset()
 
@@ -98,6 +100,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(0), c.txtsattempts.load(1))
 	require.Equal(t, int64(0), c.utcoffset)
 	require.Equal(t, int64(0), c.drain)
+	require.Equal(t, int64(0), c.reload)
 }
 
 func TestCountersToMap(t *testing.T) {
@@ -109,6 +112,7 @@ func TestCountersToMap(t *testing.T) {
 	c.rxSignaling.store(int(ptp.MessageDelayResp), 3)
 	c.utcoffset = 1
 	c.drain = 1
+	c.reload = 2
 
 	result := c.toMap()
 
@@ -118,6 +122,7 @@ func TestCountersToMap(t *testing.T) {
 	expectedMap["rx.signaling.delay_resp"] = 3
 	expectedMap["utcoffset"] = 1
 	expectedMap["drain"] = 1
+	expectedMap["reload"] = 2
 
 	require.Equal(t, expectedMap, result)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Reload dynamic portion of the config on SIGHUP
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Take a default config:
```
$ cat /etc/ptp4u.yaml
clockaccuracy: 0x21
clockclass: 6
draininterval : "30s"
maxsubduration: "1h"
metricinterval : "1m"
minsubinterval: "1s"
utcoffset     : "37s"
```
Run ptp4u with config option specified:
```
/usr/local/bin/ptp4u -config /etc/ptp4u.yaml
```
See all good.
Change utcoffset to 38s:
```
$ cat /etc/ptp4u.yaml
clockaccuracy: 0x21
clockclass: 6
draininterval : "30s"
maxsubduration: "1h"
metricinterval : "1m"
minsubinterval: "1s"
utcoffset     : "38s"
```
Send SIGHUP:
```
$ kill -1 563181
```
Profit:
![image](https://user-images.githubusercontent.com/4749052/161603880-a774c75e-6d02-49c2-86c3-8b99e2258fb1.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
