### PR TITLE
[c4u] initial version

### DIFF
--- a/cmd/c4u/main.go
+++ b/cmd/c4u/main.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"time"
+
+	"github.com/facebook/time/ptp/c4u/clock"
+	"github.com/facebook/time/ptp/c4u/utcoffset"
+	"github.com/facebook/time/ptp/ptp4u/server"
+	log "github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var (
+	save bool
+	path string
+)
+
+func main() {
+	flag.BoolVar(&save, "save", false, "Save config to the path instead of reading it")
+	flag.StringVar(&path, "path", "/etc/ptp4u.yaml", "Path to a config file")
+	flag.Parse()
+
+	current := &server.DynamicConfig{}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = yaml.Unmarshal(data, &current)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Generate
+	config := &server.DynamicConfig{
+		DrainInterval:  30 * time.Second,
+		MaxSubDuration: 1 * time.Hour,
+		MetricInterval: 1 * time.Minute,
+		MinSubInterval: 1 * time.Second,
+	}
+
+	c, err := clock.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+	config.ClockClass = c.ClockClass
+	config.ClockAccuracy = c.ClockAccuracy
+
+	u, err := utcoffset.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+	config.UTCOffset = u
+
+	if save {
+		d, err := yaml.Marshal(&config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = os.WriteFile(path, d, 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		log.Printf("Current: %+v", current)
+		log.Printf("Pending: %+v", config)
+	}
+}

--- a/cmd/ptpcheck/cmd/oscillatord.go
+++ b/cmd/ptpcheck/cmd/oscillatord.go
@@ -37,7 +37,7 @@ var (
 func init() {
 	RootCmd.AddCommand(oscillatordCmd)
 	oscillatordCmd.Flags().StringVarP(&oscillatordAddressFlag, "address", "a", "127.0.0.1", "address to connect to")
-	oscillatordCmd.Flags().IntVarP(&oscillatordPortFlag, "port", "p", 2958, "port to connect to")
+	oscillatordCmd.Flags().IntVarP(&oscillatordPortFlag, "port", "p", oscillatord.MonitoringPort, "port to connect to")
 	oscillatordCmd.Flags().BoolVarP(&oscillatorJSONFlag, "json", "j", false, "JSON output")
 }
 

--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -28,6 +28,9 @@ import (
 	"io"
 )
 
+// MonitoringPort is an oscillatord monitoring socket port
+const MonitoringPort = 2958
+
 // AntennaStatus is an enum describing antenna status as reported by oscillatord
 type AntennaStatus int
 

--- a/ptp/c4u/clock/clock.go
+++ b/ptp/c4u/clock/clock.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+const (
+	ClockClassLocked       ptp.ClockClass = ptp.ClockClass6
+	ClockClassHoldover     ptp.ClockClass = ptp.ClockClass7
+	ClockClassCalibrating  ptp.ClockClass = ptp.ClockClass13
+	ClockClassUncalibrated ptp.ClockClass = ptp.ClockClass52
+)
+
+func worst(clocks []*ptp.ClockQuality) *ptp.ClockQuality {
+	w := &ptp.ClockQuality{}
+	for _, c := range clocks {
+		// Higher value of accuracy means worse
+		if c.ClockAccuracy > w.ClockAccuracy {
+			w.ClockAccuracy = c.ClockAccuracy
+		}
+
+		// Assuming higher class means worse
+		if c.ClockClass > w.ClockClass {
+			w.ClockClass = c.ClockClass
+		}
+	}
+	return w
+}
+
+func Run() (*ptp.ClockQuality, error) {
+	oscillatord, err := oscillatord()
+	if err != nil {
+		return nil, err
+	}
+
+	ts2phc, err := ts2phc()
+	if err != nil {
+		return nil, err
+	}
+
+	return worst([]*ptp.ClockQuality{oscillatord, ts2phc}), nil
+}

--- a/ptp/c4u/clock/oscillatord.go
+++ b/ptp/c4u/clock/oscillatord.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	osc "github.com/facebook/time/oscillatord"
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+const timeout = time.Second
+
+func oscillatord() (*ptp.ClockQuality, error) {
+	c := &ptp.ClockQuality{}
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", osc.MonitoringPort))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	deadline := time.Now().Add(timeout)
+	if err := conn.SetDeadline(deadline); err != nil {
+		return nil, err
+	}
+
+	status, err := osc.ReadStatus(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait for oscillatord correct monitoring socket implementation
+	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.4
+	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.5
+	if status.Oscillator.Lock {
+		c.ClockClass = ClockClassLocked
+		c.ClockAccuracy = ptp.ClockAccuracyNanosecond100
+	} else {
+		c.ClockClass = ClockClassHoldover
+		c.ClockAccuracy = ptp.ClockAccuracyMicrosecond1
+	}
+
+	return c, nil
+}

--- a/ptp/c4u/clock/ts2phc.go
+++ b/ptp/c4u/clock/ts2phc.go
@@ -1,0 +1,64 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	"github.com/facebook/time/phc"
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+const (
+	phcTimeCardPath = "/dev/ptp_tcard"
+	phcNICPath      = "/dev/ptp0"
+)
+
+func ts2phc() (*ptp.ClockQuality, error) {
+	c := &ptp.ClockQuality{}
+
+	tcard, err := phc.TimeAndOffsetFromDevice(phcTimeCardPath, phc.MethodIoctlSysOffsetExtended)
+	if err != nil {
+		return nil, err
+	}
+
+	tnic, err := phc.TimeAndOffsetFromDevice(phcNICPath, phc.MethodIoctlSysOffsetExtended)
+	if err != nil {
+		return nil, err
+	}
+
+	sysOffset := tcard.SysTime.Sub(tnic.SysTime)
+	phcOffset := tcard.PHCTime.Sub(tnic.PHCTime)
+	phcOffset -= sysOffset
+	if phcOffset < 0 {
+		phcOffset *= -1
+	}
+
+	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.4
+	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.5
+	if phcOffset < 100*time.Nanosecond {
+		c.ClockAccuracy = ptp.ClockAccuracyNanosecond100 // 100ns
+	} else if phcOffset < time.Microsecond {
+		c.ClockAccuracy = ptp.ClockAccuracyMicrosecond1 // 1us
+	} else if phcOffset < 250*time.Microsecond {
+		c.ClockAccuracy = ptp.ClockAccuracyMicrosecond250 // 250us
+	} else {
+		c.ClockAccuracy = ptp.ClockAccuracySecondGreater10 // >10 second
+	}
+
+	return c, nil
+}

--- a/ptp/c4u/utcoffset/utcoffset.go
+++ b/ptp/c4u/utcoffset/utcoffset.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utcoffset
+
+import (
+	"time"
+
+	"github.com/facebook/time/leapsectz"
+)
+
+func Run() (time.Duration, error) {
+	// TAI <-> GPS offset is 10 seconds
+	// http://leapsecond.com/java/gpsclock.htm
+	var uo int32 = 10
+
+	latestLeap, err := leapsectz.Latest("")
+	if err != nil {
+		return time.Duration(0), err
+	}
+
+	uo += latestLeap.Nleap
+
+	return time.Duration(uo) * time.Second, nil
+}

--- a/ptp/c4u/utcoffset/utcoffset_test.go
+++ b/ptp/c4u/utcoffset/utcoffset_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utcoffset
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	u, err := Run()
+	require.NoError(t, err)
+	require.Greater(t, 50*time.Second, u)
+	require.Less(t, 30*time.Second, u)
+}

--- a/ptp/protocol/ptp4l.go
+++ b/ptp/protocol/ptp4l.go
@@ -209,8 +209,8 @@ func (e *UnicastMasterEntry) UnmarshalBinary(b []byte) error {
 	}
 	e.PortIdentity.ClockIdentity = ClockIdentity(binary.BigEndian.Uint64(b[0:]))
 	e.PortIdentity.PortNumber = binary.BigEndian.Uint16(b[8:])
-	e.ClockQuality.ClockClass = b[10]
-	e.ClockQuality.ClockAccuracy = b[11]
+	e.ClockQuality.ClockClass = ClockClass(b[10])
+	e.ClockQuality.ClockAccuracy = ClockAccuracy(b[11])
 	e.ClockQuality.OffsetScaledLogVariance = binary.BigEndian.Uint16(b[12:])
 	if b[14] == 0 {
 		e.Selected = false

--- a/ptp/protocol/types.go
+++ b/ptp/protocol/types.go
@@ -284,10 +284,50 @@ func NewTimestamp(t time.Time) Timestamp {
 	return ts
 }
 
+// ClockClass represents a PTP clock class
+type ClockClass uint8
+
+// Available Clock Classes
+// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.4
+const (
+	ClockClass6  ClockClass = 6
+	ClockClass7  ClockClass = 7
+	ClockClass13 ClockClass = 13
+	ClockClass52 ClockClass = 52
+	Clockclass58 ClockClass = 58
+)
+
+// ClockAccuracy represents a PTP clock accuracy
+type ClockAccuracy uint8
+
+// Available Clock Accuracy
+// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.5
+const (
+	ClockAccuracyNanosecond25       ClockAccuracy = 0x20
+	ClockAccuracyNanosecond100      ClockAccuracy = 0x21
+	ClockAccuracyNanosecond250      ClockAccuracy = 0x22
+	ClockAccuracyMicrosecond1       ClockAccuracy = 0x23
+	ClockAccuracyMicrosecond2point5 ClockAccuracy = 0x24
+	ClockAccuracyMicrosecond10      ClockAccuracy = 0x25
+	ClockAccuracyMicrosecond25      ClockAccuracy = 0x26
+	ClockAccuracyMicrosecond100     ClockAccuracy = 0x27
+	ClockAccuracyMicrosecond250     ClockAccuracy = 0x28
+	ClockAccuracyMillisecond1       ClockAccuracy = 0x29
+	ClockAccuracyMillisecond2point5 ClockAccuracy = 0x2A
+	ClockAccuracyMillisecond10      ClockAccuracy = 0x2B
+	ClockAccuracyMillisecond25      ClockAccuracy = 0x2C
+	ClockAccuracyMillisecond100     ClockAccuracy = 0x2D
+	ClockAccuracyMillisecond250     ClockAccuracy = 0x2E
+	ClockAccuracySecond1            ClockAccuracy = 0x2F
+	ClockAccuracySecond10           ClockAccuracy = 0x30
+	ClockAccuracySecondGreater10    ClockAccuracy = 0x31
+	ClockAccuracyUnknown            ClockAccuracy = 0xFE
+)
+
 // ClockQuality represents the quality of a clock.
 type ClockQuality struct {
-	ClockClass              uint8
-	ClockAccuracy           uint8
+	ClockClass              ClockClass
+	ClockAccuracy           ClockAccuracy
 	OffsetScaledLogVariance uint16
 }
 

--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -46,9 +46,9 @@ type StaticConfig struct {
 // DynamicConfig is a set of dynamic options which don't need a server restart
 type DynamicConfig struct {
 	// ClockCccuracy to report via announce messages. Time Accurate within 100ns
-	ClockAccuracy uint8
+	ClockAccuracy ptp.ClockAccuracy
 	// ClockClass to report via announce messages. 6 - Locked with Primary Reference Clock
-	ClockClass uint8
+	ClockClass ptp.ClockClass
 	// DrainInterval is an interval for drain checks
 	DrainInterval time.Duration
 	// MaxSubDuration is a maximum sync/announce/delay_resp subscription duration

--- a/ptp/ptp4u/server/subscription_test.go
+++ b/ptp/ptp4u/server/subscription_test.go
@@ -170,8 +170,8 @@ func TestAnnouncePacket(t *testing.T) {
 	UTCOffset := 3 * time.Second
 	sequenceID := uint16(42)
 	interval := 3 * time.Second
-	clockClass := uint8(8)
-	clockAccuracy := uint8(42)
+	clockClass := ptp.ClockClass7
+	clockAccuracy := ptp.ClockAccuracyMicrosecond1
 
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234), DynamicConfig: DynamicConfig{ClockClass: clockClass, ClockAccuracy: clockAccuracy, UTCOffset: UTCOffset}}
@@ -194,8 +194,8 @@ func TestAnnouncePacket(t *testing.T) {
 	require.Equal(t, sequenceID+1, sc.Announce().Header.SequenceID)
 	require.Equal(t, sp, sc.Announce().Header.SourcePortIdentity)
 	require.Equal(t, i, sc.Announce().Header.LogMessageInterval)
-	require.Equal(t, uint8(clockClass), sc.Announce().AnnounceBody.GrandmasterClockQuality.ClockClass)
-	require.Equal(t, uint8(clockAccuracy), sc.Announce().AnnounceBody.GrandmasterClockQuality.ClockAccuracy)
+	require.Equal(t, ptp.ClockClass7, sc.Announce().AnnounceBody.GrandmasterClockQuality.ClockClass)
+	require.Equal(t, ptp.ClockAccuracyMicrosecond1, sc.Announce().AnnounceBody.GrandmasterClockQuality.ClockAccuracy)
 	require.Equal(t, int16(UTCOffset.Seconds()), sc.Announce().AnnounceBody.CurrentUTCOffset)
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Create a new cli tool (initial version) which can override the ptp4u config generated from different sources:
* UTC offset from leapsectz
* ClockQuality from oscillatord and ts2phc
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### Print
```
$ ./c4u_oleg
INFO[0000] Current: &{ClockAccuracy:254 ClockClass:7 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:1m40s}
INFO[0000] Pending: &{ClockAccuracy:33 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
```
### Override
```
$ ./c4u_oleg -save
```
### Validate
```
cat /etc/ptp4u.yaml
clockaccuracy: 33
clockclass: 6
draininterval: 30s
maxsubduration: 1h0m0s
metricinterval: 1m0s
minsubinterval: 1s
utcoffset: 37s
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
