### PR TITLE
[ptp4u] move signal handling logic to server

### DIFF
--- a/cmd/ptp4u/main.go
+++ b/cmd/ptp4u/main.go
@@ -22,8 +22,6 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
-	"os/signal"
 	"time"
 
 	"github.com/facebook/time/ptp/ptp4u/drain"
@@ -31,7 +29,6 @@ import (
 	"github.com/facebook/time/ptp/ptp4u/stats"
 	"github.com/facebook/time/timestamp"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 func main() {
@@ -76,20 +73,6 @@ func main() {
 	default:
 		log.Fatalf("Unrecognized log level: %v", c.LogLevel)
 	}
-
-	if err := c.CreatePidFile(); err != nil {
-		log.Fatal(err)
-	}
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, unix.SIGTERM, unix.SIGINT)
-	go func() {
-		<-sig
-		log.Warning("Shutting down ptp4u")
-		if err := c.DeletePidFile(); err != nil {
-			log.Fatalf("Failed to remove pid file: %v", err)
-		}
-		os.Exit(0)
-	}()
 
 	if c.ConfigFile != "" {
 		if err := c.ReadDynamicConfig(); err != nil {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Move logic inside of the server package (next to already implemented SIGHUP logic)
* Simplify main
* Add unit test
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ cat /var/run/ptp4u.pid
2554230
$ kill -1 2554230
<reload works>
$ systemctl stop ptp4u
$ cat /var/run/ptp4u.pid
cat: /var/run/ptp4u.pid: No such file or directory
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
