### PR TITLE
[c4u] implement sliding monitoring window (TAU)

### DIFF
--- a/cmd/ptp4u/main.go
+++ b/cmd/ptp4u/main.go
@@ -75,9 +75,11 @@ func main() {
 	}
 
 	if c.ConfigFile != "" {
-		if err := c.ReadDynamicConfig(); err != nil {
+		dc, err := server.ReadDynamicConfig(c.ConfigFile)
+		if err != nil {
 			log.Fatal(err)
 		}
+		c.DynamicConfig = *dc
 	}
 
 	if c.DSCP < 0 || c.DSCP > 63 {

--- a/ptp/c4u/c4u.go
+++ b/ptp/c4u/c4u.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package c4u
+
+import (
+	"time"
+
+	"github.com/facebook/time/ptp/c4u/clock"
+	"github.com/facebook/time/ptp/c4u/utcoffset"
+	ptp "github.com/facebook/time/ptp/protocol"
+	"github.com/facebook/time/ptp/ptp4u/server"
+	log "github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	Save bool
+	Path string
+	Pid  string
+	TAU  int
+}
+
+type ringBuffer struct {
+	data  []ptp.ClockQuality
+	index int
+	size  int
+}
+
+func NewRingBuffer(size int) *ringBuffer {
+	return &ringBuffer{size: size, data: make([]ptp.ClockQuality, size)}
+}
+
+func (rb *ringBuffer) Write(c ptp.ClockQuality) {
+	if rb.index >= rb.size {
+		rb.index = 0
+	}
+	rb.data[rb.index] = c
+	rb.index++
+}
+
+func (rb *ringBuffer) Data() []ptp.ClockQuality {
+	return rb.data
+}
+
+var defaultConfig = &server.DynamicConfig{
+	DrainInterval:  30 * time.Second,
+	MaxSubDuration: 1 * time.Hour,
+	MetricInterval: 1 * time.Minute,
+	MinSubInterval: 1 * time.Second,
+}
+
+func Run(config *Config) {
+	rb := NewRingBuffer(config.TAU)
+
+	for it := time.NewTicker(time.Second); true; <-it.C {
+		// Clock data
+		c, err := clock.Run()
+		if err != nil {
+			log.Errorf("Failed to collect clock data: %v", err)
+			continue
+		}
+		rb.Write(*c)
+		w := clock.Worst(rb.Data())
+
+		// UTC data
+		u, err := utcoffset.Run()
+		if err != nil {
+			log.Errorf("Failed to collect UTC offset data: %v", err)
+			continue
+		}
+
+		current, err := server.ReadDynamicConfig(config.Path)
+		if err != nil {
+			log.Errorf("Failed read current ptp4u config: %v. Using defaults", err)
+			current = defaultConfig
+		}
+		pending := &server.DynamicConfig{}
+		*pending = *current
+
+		pending.ClockClass = w.ClockClass
+		pending.ClockAccuracy = w.ClockAccuracy
+		pending.UTCOffset = u
+
+		if *current != *pending {
+			log.Infof("Current: %+v", current)
+			log.Infof("Pending: %+v", pending)
+
+			if config.Save {
+				log.Infof("Saving a pending config to %s", config.Path)
+				err := pending.Write(config.Path)
+				if err != nil {
+					log.Errorf("Failed save the ptp4u config: %v", err)
+				}
+			}
+		}
+	}
+}

--- a/ptp/c4u/c4u_test.go
+++ b/ptp/c4u/c4u_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package c4u
+
+import (
+	"testing"
+
+	ptp "github.com/facebook/time/ptp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferRing(t *testing.T) {
+	tau := 2
+	rb := NewRingBuffer(tau)
+	require.Equal(t, tau, rb.size)
+	// Write 1
+	rb.Write(ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100})
+	require.Equal(t, 1, rb.index)
+	require.Equal(t, []ptp.ClockQuality{ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100}, ptp.ClockQuality{}}, rb.Data())
+
+	// Write 2
+	rb.Write(ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250})
+	require.Equal(t, 2, rb.index)
+	require.Equal(t, []ptp.ClockQuality{ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100}, ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}}, rb.Data())
+
+	// Write 3
+	rb.Write(ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1})
+	require.Equal(t, 1, rb.index)
+	require.Equal(t, []ptp.ClockQuality{ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}, ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}}, rb.Data())
+}

--- a/ptp/c4u/clock/clock.go
+++ b/ptp/c4u/clock/clock.go
@@ -27,8 +27,8 @@ const (
 	ClockClassUncalibrated ptp.ClockClass = ptp.ClockClass52
 )
 
-func worst(clocks []*ptp.ClockQuality) *ptp.ClockQuality {
-	w := &ptp.ClockQuality{}
+func Worst(clocks []ptp.ClockQuality) *ptp.ClockQuality {
+	w := ptp.ClockQuality{}
 	for _, c := range clocks {
 		// Higher value of accuracy means worse
 		if c.ClockAccuracy > w.ClockAccuracy {
@@ -40,7 +40,7 @@ func worst(clocks []*ptp.ClockQuality) *ptp.ClockQuality {
 			w.ClockClass = c.ClockClass
 		}
 	}
-	return w
+	return &w
 }
 
 func Run() (*ptp.ClockQuality, error) {
@@ -54,5 +54,5 @@ func Run() (*ptp.ClockQuality, error) {
 		return nil, err
 	}
 
-	return worst([]*ptp.ClockQuality{oscillatord, ts2phc}), nil
+	return Worst([]ptp.ClockQuality{*oscillatord, *ts2phc}), nil
 }

--- a/ptp/c4u/clock/clock_test.go
+++ b/ptp/c4u/clock/clock_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"testing"
+
+	ptp "github.com/facebook/time/ptp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorst(t *testing.T) {
+	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
+
+	clocks := []ptp.ClockQuality{
+		ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100},
+		ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond1},
+		ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyNanosecond250},
+	}
+
+	w := Worst(clocks)
+	require.Equal(t, expected, w)
+}

--- a/ptp/c4u/clock/oscillatord.go
+++ b/ptp/c4u/clock/oscillatord.go
@@ -28,7 +28,10 @@ import (
 const timeout = time.Second
 
 func oscillatord() (*ptp.ClockQuality, error) {
-	c := &ptp.ClockQuality{}
+	c := &ptp.ClockQuality{
+		ClockClass:    ClockClassHoldover,
+		ClockAccuracy: ptp.ClockAccuracyUnknown,
+	}
 	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", osc.MonitoringPort))
 	if err != nil {
 		return nil, err

--- a/ptp/protocol/types.go
+++ b/ptp/protocol/types.go
@@ -324,6 +324,52 @@ const (
 	ClockAccuracyUnknown            ClockAccuracy = 0xFE
 )
 
+// ClockAccuracyFromOffset returns PTP Clock Accuracy covering the time.Duration
+func ClockAccuracyFromOffset(offset time.Duration) ClockAccuracy {
+	if offset < 0 {
+		offset *= -1
+	}
+
+	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.4
+	if offset < 25*time.Nanosecond {
+		return ClockAccuracyNanosecond25
+	} else if offset < 100*time.Nanosecond {
+		return ClockAccuracyNanosecond100
+	} else if offset < 250*time.Nanosecond {
+		return ClockAccuracyNanosecond250
+	} else if offset < time.Microsecond {
+		return ClockAccuracyMicrosecond1
+	} else if offset < 2500*time.Nanosecond {
+		return ClockAccuracyMicrosecond2point5
+	} else if offset < 10*time.Microsecond {
+		return ClockAccuracyMicrosecond10
+	} else if offset < 25*time.Microsecond {
+		return ClockAccuracyMicrosecond25
+	} else if offset < 100*time.Microsecond {
+		return ClockAccuracyMicrosecond100
+	} else if offset < 250*time.Microsecond {
+		return ClockAccuracyMicrosecond250
+	} else if offset < time.Millisecond {
+		return ClockAccuracyMillisecond1
+	} else if offset < 2500*time.Microsecond {
+		return ClockAccuracyMillisecond2point5
+	} else if offset < 10*time.Millisecond {
+		return ClockAccuracyMillisecond10
+	} else if offset < 25*time.Millisecond {
+		return ClockAccuracyMillisecond25
+	} else if offset < 100*time.Millisecond {
+		return ClockAccuracyMillisecond100
+	} else if offset < 250*time.Millisecond {
+		return ClockAccuracyMillisecond250
+	} else if offset < time.Second {
+		return ClockAccuracySecond1
+	} else if offset < 10*time.Second {
+		return ClockAccuracySecond10
+	}
+
+	return ClockAccuracySecondGreater10
+}
+
 // ClockQuality represents the quality of a clock.
 type ClockQuality struct {
 	ClockClass              ClockClass

--- a/ptp/protocol/types_test.go
+++ b/ptp/protocol/types_test.go
@@ -258,3 +258,24 @@ func TestPortAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestClockAccuracyFromOffset(t *testing.T) {
+	require.Equal(t, ClockAccuracyNanosecond25, ClockAccuracyFromOffset(-8*time.Nanosecond))
+	require.Equal(t, ClockAccuracyNanosecond100, ClockAccuracyFromOffset(42*time.Nanosecond))
+	require.Equal(t, ClockAccuracyNanosecond250, ClockAccuracyFromOffset(-242*time.Nanosecond))
+	require.Equal(t, ClockAccuracyMicrosecond1, ClockAccuracyFromOffset(567*time.Nanosecond))
+	require.Equal(t, ClockAccuracyMicrosecond2point5, ClockAccuracyFromOffset(2*time.Microsecond))
+	require.Equal(t, ClockAccuracyMicrosecond10, ClockAccuracyFromOffset(8*time.Microsecond))
+	require.Equal(t, ClockAccuracyMicrosecond25, ClockAccuracyFromOffset(10*time.Microsecond))
+	require.Equal(t, ClockAccuracyMicrosecond100, ClockAccuracyFromOffset(-42*time.Microsecond))
+	require.Equal(t, ClockAccuracyMicrosecond250, ClockAccuracyFromOffset(123*time.Microsecond))
+	require.Equal(t, ClockAccuracyMillisecond1, ClockAccuracyFromOffset(678*time.Microsecond))
+	require.Equal(t, ClockAccuracyMillisecond2point5, ClockAccuracyFromOffset(2499*time.Microsecond))
+	require.Equal(t, ClockAccuracyMillisecond10, ClockAccuracyFromOffset(-8*time.Millisecond))
+	require.Equal(t, ClockAccuracyMillisecond25, ClockAccuracyFromOffset(24*time.Millisecond))
+	require.Equal(t, ClockAccuracyMillisecond100, ClockAccuracyFromOffset(69*time.Millisecond))
+	require.Equal(t, ClockAccuracyMillisecond250, ClockAccuracyFromOffset(222*time.Millisecond))
+	require.Equal(t, ClockAccuracySecond1, ClockAccuracyFromOffset(-999*time.Millisecond))
+	require.Equal(t, ClockAccuracySecond10, ClockAccuracyFromOffset(8*time.Second))
+	require.Equal(t, ClockAccuracySecondGreater10, ClockAccuracyFromOffset(9*time.Minute))
+}

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -438,10 +438,14 @@ func (s *Server) handleSighup() {
 	signal.Notify(sigchan, unix.SIGHUP)
 	for range sigchan {
 		log.Info("SIGHUP received, reloading config")
-		err := s.Config.ReadDynamicConfig()
+		dc, err := ReadDynamicConfig(s.Config.ConfigFile)
 		if err != nil {
 			log.Errorf("Failed to reload config: %v. Moving on", err)
+			continue
 		}
+		dcMux.Lock()
+		s.Config.DynamicConfig = *dc
+		dcMux.Unlock()
 		s.Stats.IncReload()
 	}
 }

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -204,9 +204,9 @@ utcoffset: "37s"
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 
-	c.Lock()
-	defer c.Unlock()
+	dcMux.Lock()
 	require.Equal(t, expected.DynamicConfig, c.DynamicConfig)
+	dcMux.Unlock()
 }
 
 func TestHandleSigterm(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Implement a TAU support in c4u. We will now observe last N (default is 60) values and generate config based on worst data during this window. Data is collected once a second.
* Duration to ptp.ClockAccuracy conversion
* More unit tests
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### Observe difference without saving it
```
./c4u_oleg
INFO[0000] Current: &{ClockAccuracy:33 ClockClass:7 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0000] Pending: &{ClockAccuracy:33 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0001] Current: &{ClockAccuracy:33 ClockClass:7 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0001] Pending: &{ClockAccuracy:33 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
```
### Apply
```
$ ./c4u_oleg -save
INFO[0000] Current: &{ClockAccuracy:33 ClockClass:7 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0000] Pending: &{ClockAccuracy:33 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0000] Saving a pending config to /etc/ptp4u.yaml
^C
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
