### PR TITLE
[c4u] send SIGHUP to ptp4u

### DIFF
--- a/cmd/c4u/main.go
+++ b/cmd/c4u/main.go
@@ -25,7 +25,7 @@ import (
 func main() {
 	c := &c4u.Config{}
 
-	flag.BoolVar(&c.Save, "save", false, "Save config to the path instead of reading it")
+	flag.BoolVar(&c.Apply, "apply", false, "Save the ptp4u config to the path and send the SIGHUP to ptp4u")
 	flag.StringVar(&c.Path, "path", "/etc/ptp4u.yaml", "Path to a config file")
 	flag.StringVar(&c.Pid, "ptp4u", "/var/run/ptp4u.pid", "Path to a ptp4u pid file")
 	flag.IntVar(&c.TAU, "tau", 60, "Sliding window size (seconds) for clock data calculations")

--- a/ptp/c4u/clock/oscillatord.go
+++ b/ptp/c4u/clock/oscillatord.go
@@ -50,7 +50,7 @@ func oscillatord() (*ptp.ClockQuality, error) {
 	// Wait for oscillatord correct monitoring socket implementation
 	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.4
 	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.5
-	if status.Oscillator.Lock {
+	if status.Oscillator.Lock && status.GNSS.FixOK {
 		c.ClockClass = ClockClassLocked
 		c.ClockAccuracy = ptp.ClockAccuracyNanosecond100
 	} else {

--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -137,6 +139,16 @@ func (c *Config) CreatePidFile() error {
 // DeletePidFile deletes a pid file from a defined location
 func (c *Config) DeletePidFile() error {
 	return os.Remove(c.PidFile)
+}
+
+// ReadPidFile read a pid file from a path location and returns a pid
+func ReadPidFile(path string) (int, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.Atoi(strings.Replace(string(content), "\n", "", -1))
 }
 
 // ifaceIPs gets all IPs on the specified interface

--- a/ptp/ptp4u/server/subscription_test.go
+++ b/ptp/ptp4u/server/subscription_test.go
@@ -99,18 +99,18 @@ func TestSubscriptionEnd(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	interval := 10 * time.Millisecond
-	expire := time.Now().Add(200 * time.Millisecond)
+	expire := time.Now().Add(300 * time.Millisecond)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go sc.Start(ctx)
 
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	require.True(t, sc.Running())
 
 	cancel()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	require.False(t, sc.Running())
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
When `c4u` generates a config which is different from a current config it will ask `ptp4u` to reload via `SIGHUP`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
$ ./c4u_oleg -save
INFO[0000] Current: &{ClockAccuracy:33 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0000] Pending: &{ClockAccuracy:48 ClockClass:7 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0000] Saving a pending config to /etc/ptp4u.yaml
INFO[0000] SIGHUP is sent to ptp4u pid: 1412588
^C
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
