### PR TITLE
[leapsec] exclude 'future' leap seconds from Latest() list

### DIFF
--- a/leapsectz/leapsectz.go
+++ b/leapsectz/leapsectz.go
@@ -79,19 +79,19 @@ func Parse(srcfile string) ([]LeapSecond, error) {
 
 // Latest returns the latest leap second from srcfile. Pass "" to use default file
 func Latest(srcfile string) (*LeapSecond, error) {
-	res := &LeapSecond{}
+	res := LeapSecond{}
 	leapSeconds, err := Parse(srcfile)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, leapSecond := range leapSeconds {
-		if leapSecond.Time().After(res.Time()) {
-			res = &leapSecond
+		if leapSecond.Time().After(res.Time()) && leapSecond.Time().Before(time.Now()) {
+			res = leapSecond
 		}
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 func parseVx(r io.Reader) ([]LeapSecond, error) {

--- a/leapsectz/leapsectz_test.go
+++ b/leapsectz/leapsectz_test.go
@@ -179,6 +179,27 @@ func TestLatest(t *testing.T) {
 	require.Equal(t, expected, ls)
 }
 
+func TestLatestFuture(t *testing.T) {
+	expected := &LeapSecond{1649346026, 2}
+
+	ls := []LeapSecond{
+		{1649346016, 1},
+		{1649346026, 2},
+		{2649346018, 3},
+	}
+
+	f, err := ioutil.TempFile(os.TempDir(), "leaptest-")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	err = Write(f, '2', ls, "UTC")
+	require.NoError(t, err)
+
+	latest, err := Latest(f.Name())
+	require.NoError(t, err)
+	require.Equal(t, expected, latest)
+}
+
 func TestPrepareHeader(t *testing.T) {
 	byteData := []byte{
 		'T', 'Z', 'i', 'f', // magic

--- a/ptp/c4u/utcoffset/utcoffset.go
+++ b/ptp/c4u/utcoffset/utcoffset.go
@@ -23,8 +23,8 @@ import (
 )
 
 func Run() (time.Duration, error) {
-	// TAI <-> GPS offset is 10 seconds
-	// http://leapsecond.com/java/gpsclock.htm
+	// TAI <-> UTC offset was 10 seconds before introduction of leap seconds.
+	// https://en.wikipedia.org/wiki/Leap_second
 	var uo int32 = 10
 
 	latestLeap, err := leapsectz.Latest("")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Leap second file `/usr/share/zoneinfo/right/UTC` is coming with `tzdata` and distributed in advance.
If leap second is added it will be added in advance.
This diff adds a check inside the `Latest()` so we don't return a leap second which will only happen in couple of months.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/162255715-e6bf6757-64e9-4b79-9fcf-f7ad2c5f597b.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
