### PR TITLE
[c4u] implement p99 logic inside Worst()

### DIFF
--- a/ptp/c4u/clock/clock_test.go
+++ b/ptp/c4u/clock/clock_test.go
@@ -49,6 +49,27 @@ func TestWorst(t *testing.T) {
 	require.Nil(t, w)
 }
 
+func TestWorstP99(t *testing.T) {
+	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100}
+
+	clocks := []*ptp.ClockQuality{}
+	for i := 0; i < 594; i++ {
+		clocks = append(clocks, &ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100})
+	}
+	for i := 0; i < 6; i++ {
+		clocks = append(clocks, &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250})
+	}
+
+	w := Worst(clocks)
+	require.Equal(t, expected, w)
+
+	// Changing 1 element to sway P99 over the border
+	clocks[592] = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}
+	w = Worst(clocks)
+	require.Equal(t, expected, w)
+}
+
 func TestBufferRing(t *testing.T) {
 	sample := 2
 	rb := NewRingBuffer(sample)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Using always the worst case is not a very good idea because of a single spike (1 out of 600 values) will lead to 2 reloads (when its `put` and when it `pushed` out). This leads to a client shifts for no good reason.
This diff introduces a p99 logic which greatly reduces the number of reloads.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/163023601-fdc83064-812d-42f2-9712-9ca221768c23.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
