### PR TITLE
[c4u] better math for clockAccuracy

### DIFF
--- a/cmd/c4u/main.go
+++ b/cmd/c4u/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/facebook/time/ptp/c4u"
 	"github.com/facebook/time/ptp/c4u/clock"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -29,6 +30,7 @@ func main() {
 		once     bool
 		interval time.Duration
 		sample   int
+		logLevel string
 	)
 	c := &c4u.Config{}
 
@@ -36,18 +38,37 @@ func main() {
 	flag.BoolVar(&once, "once", false, "Run once and exit")
 	flag.StringVar(&c.Path, "path", "/etc/ptp4u.yaml", "Path to a config file")
 	flag.StringVar(&c.Pid, "ptp4u", "/var/run/ptp4u.pid", "Path to a ptp4u pid file")
+	flag.StringVar(&c.AccuracyExpr, "accuracyExpr", "max(abs(mean(phcoffset)) + 3 * stddev(phcoffset), abs(mean(oscillatoroffset)))", "Math to calculate clock accuracy")
 	flag.IntVar(&sample, "sample", 600, "Sliding window size (samples) for clock data calculations")
 	flag.DurationVar(&interval, "interval", time.Second, "Data cata collection interval")
+	flag.StringVar(&logLevel, "loglevel", "info", "Set a log level. Can be: debug, info, warning, error")
 	flag.Parse()
+
+	switch logLevel {
+	case "debug":
+		log.SetLevel(log.DebugLevel)
+	case "info":
+		log.SetLevel(log.InfoLevel)
+	case "warning":
+		log.SetLevel(log.WarnLevel)
+	case "error":
+		log.SetLevel(log.ErrorLevel)
+	default:
+		log.Fatalf("Unrecognized log level: %v", logLevel)
+	}
 
 	if once {
 		sample = 1
 	}
 
 	rb := clock.NewRingBuffer(sample)
-	c4u.Run(c, rb)
+	if err := c4u.Run(c, rb); err != nil {
+		log.Fatal(err)
+	}
 
 	for it := time.NewTicker(interval); !once; <-it.C {
-		c4u.Run(c, rb)
+		if err := c4u.Run(c, rb); err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/facebook/time
 go 1.16
 
 require (
+	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1
+	github.com/eclesh/welford v0.0.0-20150116075914-eec62615b1f0 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/go-ini/ini v1.66.2
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
+github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -64,6 +66,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eclesh/welford v0.0.0-20150116075914-eec62615b1f0 h1:kQ0PoUSzoqBCdOXbrrZtBGHZOs46U8Aj0BG1Xa+tq7w=
+github.com/eclesh/welford v0.0.0-20150116075914-eec62615b1f0/go.mod h1:Lt9Nv8E2/1kmk2nD0nTZTae7qFRCXPJV6q7Debf1An8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/ptp/c4u/c4u_test.go
+++ b/ptp/c4u/c4u_test.go
@@ -48,12 +48,14 @@ func TestRun(t *testing.T) {
 	defer os.Remove(cfg.Name())
 
 	c := &Config{
-		Path:   cfg.Name(),
-		Sample: 3,
-		Apply:  true,
+		Path:         cfg.Name(),
+		Sample:       3,
+		Apply:        true,
+		AccuracyExpr: "1",
 	}
 
-	Run(c, clock.NewRingBuffer(1))
+	err = Run(c, clock.NewRingBuffer(1))
+	require.NoError(t, err)
 
 	dc, err := server.ReadDynamicConfig(c.Path)
 	require.NoError(t, err)

--- a/ptp/c4u/clock/clock_test.go
+++ b/ptp/c4u/clock/clock_test.go
@@ -18,63 +18,117 @@ package clock
 
 import (
 	"testing"
+	"time"
 
 	ptp "github.com/facebook/time/ptp/protocol"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWorst(t *testing.T) {
-	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
+	expr := "max(abs(mean(phcoffset)) + 1 * stddev(phcoffset), abs(mean(oscillatoroffset)))"
+	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
 
-	clocks := []*ptp.ClockQuality{
-		&ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100},
-		&ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond1},
-		&ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyNanosecond250},
+	clocks := []*DataPoint{
+		&DataPoint{
+			PHCOffset:            100 * time.Nanosecond,
+			OscillatorOffset:     100 * time.Nanosecond,
+			OscillatorClockClass: ClockClassLocked,
+		},
+		&DataPoint{
+			PHCOffset:            time.Microsecond,
+			OscillatorOffset:     100 * time.Nanosecond,
+			OscillatorClockClass: ClockClassLocked,
+		},
+		&DataPoint{
+			PHCOffset:            250 * time.Nanosecond,
+			OscillatorOffset:     100 * time.Nanosecond,
+			OscillatorClockClass: ClockClassLocked,
+		},
 	}
 
-	w := Worst(clocks)
+	w, err := Worst(clocks, expr)
+	require.NoError(t, err)
 	require.Equal(t, expected, w)
 
-	clocks = []*ptp.ClockQuality{
-		&ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1},
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond25}
+	clocks = []*DataPoint{
+		&DataPoint{
+			PHCOffset:            12 * time.Microsecond,
+			OscillatorOffset:     time.Microsecond,
+			OscillatorClockClass: ClockClassHoldover,
+		},
+		&DataPoint{
+			PHCOffset:            10 * time.Nanosecond,
+			OscillatorOffset:     100 * time.Nanosecond,
+			OscillatorClockClass: ClockClassLocked,
+		},
 		nil,
 	}
 
-	w = Worst(clocks)
+	w, err = Worst(clocks, expr)
+	require.NoError(t, err)
 	require.Equal(t, expected, w)
 
-	clocks = []*ptp.ClockQuality{nil, nil}
+	clocks = []*DataPoint{nil, nil}
 
-	w = Worst(clocks)
+	w, err = Worst(clocks, expr)
+	require.NoError(t, err)
 	require.Nil(t, w)
+}
+
+func TestWorstBig(t *testing.T) {
+	expr := "abs(mean(phcoffset)) + stddev(phcoffset)" // p95 for normal distribution, see three-sigma rule of thumb
+	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond100}
+
+	clocks := []*DataPoint{}
+	for i := 0; i < 594; i++ {
+		clocks = append(clocks, &DataPoint{OscillatorClockClass: ptp.ClockClass6, PHCOffset: 80 * time.Nanosecond})
+	}
+	for i := 0; i < 6; i++ {
+		clocks = append(clocks, &DataPoint{OscillatorClockClass: ptp.ClockClass7, PHCOffset: 250 * time.Nanosecond})
+	}
+
+	w, err := Worst(clocks, expr)
+	require.NoError(t, err)
+	require.Equal(t, expected, w)
+
+	// Changing 1 element to sway over the border
+	clocks[592] = &DataPoint{OscillatorClockClass: ptp.ClockClass7, PHCOffset: 250 * time.Nanosecond}
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}
+	w, err = Worst(clocks, expr)
+	require.NoError(t, err)
+	require.Equal(t, expected, w)
 }
 
 func TestBufferRing(t *testing.T) {
 	sample := 2
 	rb := NewRingBuffer(sample)
 	require.Equal(t, sample, rb.size)
+	cc100 := &DataPoint{PHCOffset: 100 * time.Nanosecond, OscillatorOffset: 100 * time.Nanosecond, OscillatorClockClass: ClockClassLocked}
+	cc250 := &DataPoint{PHCOffset: 250 * time.Nanosecond, OscillatorOffset: 250 * time.Nanosecond, OscillatorClockClass: ClockClassCalibrating}
+	cc1u := &DataPoint{PHCOffset: time.Microsecond, OscillatorOffset: time.Microsecond, OscillatorClockClass: ClockClassHoldover}
 	// Write 1
-	rb.Write(&ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100})
+	rb.Write(cc100)
 	require.Equal(t, 1, rb.index)
-	require.Equal(t, []*ptp.ClockQuality{&ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100}, nil}, rb.Data())
+	require.Equal(t, []*DataPoint{cc100, nil}, rb.Data())
 
 	// Write 2
-	rb.Write(&ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250})
+	rb.Write(cc250)
 	require.Equal(t, 2, rb.index)
-	require.Equal(t, []*ptp.ClockQuality{&ptp.ClockQuality{ClockClass: ptp.ClockClass6, ClockAccuracy: ptp.ClockAccuracyNanosecond100}, &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}}, rb.Data())
+	require.Equal(t, []*DataPoint{cc100, cc250}, rb.Data())
 
 	// Write 3
-	rb.Write(&ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1})
+	rb.Write(cc1u)
 	require.Equal(t, 1, rb.index)
-	require.Equal(t, []*ptp.ClockQuality{&ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}, &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}}, rb.Data())
+	require.Equal(t, []*DataPoint{cc1u, cc250}, rb.Data())
 
 	// Write 4
 	rb.Write(nil)
 	require.Equal(t, 2, rb.index)
-	require.Equal(t, []*ptp.ClockQuality{&ptp.ClockQuality{ClockClass: ptp.ClockClass13, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}, nil}, rb.Data())
+	require.Equal(t, []*DataPoint{cc1u, nil}, rb.Data())
 
 	// Write 5
 	rb.Write(nil)
 	require.Equal(t, 1, rb.index)
-	require.Equal(t, []*ptp.ClockQuality{nil, nil}, rb.Data())
+	require.Equal(t, []*DataPoint{nil, nil}, rb.Data())
 }

--- a/ptp/c4u/clock/math.go
+++ b/ptp/c4u/clock/math.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/Knetic/govaluate"
+	"github.com/eclesh/welford"
+)
+
+func mean(input []float64) float64 {
+	s := welford.New()
+	for _, v := range input {
+		s.Add(v)
+	}
+	return s.Mean()
+}
+
+func variance(input []float64) float64 {
+	s := welford.New()
+	for _, v := range input {
+		s.Add(v)
+	}
+	return s.Variance()
+}
+
+func stddev(input []float64) float64 {
+	s := welford.New()
+	for _, v := range input {
+		s.Add(v)
+	}
+	return s.Stddev()
+}
+
+// once oscillatord supports reporting offset we can add it here
+var supportedVariables = []string{
+	"phcoffset",
+	"oscillatoroffset",
+}
+
+func isSupportedVar(varName string) bool {
+	for _, v := range supportedVariables {
+		if v == varName {
+			return true
+		}
+	}
+	return false
+}
+
+// all the functions we support in expressions
+var functions = map[string]govaluate.ExpressionFunction{
+	"abs": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("abs: wrong number of arguments: want 1, got %d", len(args))
+		}
+		val := args[0].(float64)
+		return math.Abs(val), nil
+	},
+	"max": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("max: wrong number of arguments: want 2, got %d", len(args))
+		}
+		val1 := args[0].(float64)
+		val2 := args[1].(float64)
+		return math.Max(val1, val2), nil
+	},
+	"mean": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("mean: wrong number of arguments: want 1, got %d", len(args))
+		}
+		vals := args[0].([]float64)
+		return mean(vals), nil
+	},
+	"variance": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("variance: wrong number of arguments: want 1, got %d", len(args))
+		}
+		vals := args[0].([]float64)
+		return variance(vals), nil
+	},
+	"stddev": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("stddev: wrong number of arguments: want 1, got %d", len(args))
+		}
+		vals := args[0].([]float64)
+		return stddev(vals), nil
+	},
+}
+
+func prepareExpression(exprStr string) (*govaluate.EvaluableExpression, error) {
+	expr, err := govaluate.NewEvaluableExpressionWithFunctions(exprStr, functions)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range expr.Vars() {
+		if !isSupportedVar(v) {
+			return nil, fmt.Errorf("unsupported variable %q", v)
+		}
+	}
+	return expr, nil
+}

--- a/ptp/c4u/clock/math_test.go
+++ b/ptp/c4u/clock/math_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareExpression(t *testing.T) {
+	_, err := prepareExpression("lkjdfkj")
+	require.Error(t, err)
+	_, err = prepareExpression("2 + 2")
+	require.NoError(t, err)
+
+	_, err = prepareExpression("mean(phcoffset)")
+	require.NoError(t, err)
+
+	_, err = prepareExpression("mean(missing)")
+	require.Error(t, err)
+}
+
+func TestMath(t *testing.T) {
+	e, err := prepareExpression("2 + 2")
+	require.NoError(t, err)
+	result, err := e.Evaluate(nil)
+	require.NoError(t, err)
+	require.Equal(t, 4.0, result.(float64))
+
+	e, err = prepareExpression("max(2, 3)")
+	require.NoError(t, err)
+	result, err = e.Evaluate(nil)
+	require.NoError(t, err)
+	require.Equal(t, 3.0, result.(float64))
+
+	e, err = prepareExpression("abs(-3)")
+	require.NoError(t, err)
+	result, err = e.Evaluate(nil)
+	require.NoError(t, err)
+	require.Equal(t, 3.0, result.(float64))
+
+	e, err = prepareExpression("mean(phcoffset)")
+	require.NoError(t, err)
+	result, err = e.Evaluate(map[string]interface{}{"phcoffset": []float64{1, 2, 3, 4, 5}})
+	require.NoError(t, err)
+	require.Equal(t, 3.0, result.(float64))
+
+	e, err = prepareExpression("stddev(phcoffset)")
+	require.NoError(t, err)
+	result, err = e.Evaluate(map[string]interface{}{"phcoffset": []float64{1, 2, 3, 4, 5}})
+	require.NoError(t, err)
+	require.InDelta(t, 1.5811, result.(float64), 0.001)
+
+	e, err = prepareExpression("variance(phcoffset)")
+	require.NoError(t, err)
+	result, err = e.Evaluate(map[string]interface{}{"phcoffset": []float64{1, 2, 3, 4, 5}})
+	require.NoError(t, err)
+	require.Equal(t, 2.5, result.(float64))
+}

--- a/ptp/c4u/clock/oscillatord_test.go
+++ b/ptp/c4u/clock/oscillatord_test.go
@@ -18,9 +18,9 @@ package clock
 
 import (
 	"testing"
+	"time"
 
 	osc "github.com/facebook/time/oscillatord"
-	ptp "github.com/facebook/time/ptp/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,17 +33,17 @@ func TestClockQualityFromOscillatord(t *testing.T) {
 			Lock: true,
 		},
 	}
-	expectedLock := &ptp.ClockQuality{
-		ClockClass:    ClockClassLocked,
-		ClockAccuracy: ptp.ClockAccuracyNanosecond100,
+	expectedLock := &oscillatorState{
+		ClockClass: ClockClassLocked,
+		Offset:     100 * time.Nanosecond,
 	}
-	expectedHoldover := &ptp.ClockQuality{
-		ClockClass:    ClockClassHoldover,
-		ClockAccuracy: ptp.ClockAccuracyMicrosecond1,
+	expectedHoldover := &oscillatorState{
+		ClockClass: ClockClassHoldover,
+		Offset:     time.Microsecond,
 	}
-	expectedFailed := &ptp.ClockQuality{
-		ClockClass:    ClockClassUncalibrated,
-		ClockAccuracy: ptp.ClockAccuracyUnknown,
+	expectedFailed := &oscillatorState{
+		ClockClass: ClockClassUncalibrated,
+		Offset:     0,
 	}
 	require.Equal(t, expectedLock, clockQualityFromOscillatord(status))
 	status.GNSS.FixOK = false

--- a/ptp/c4u/clock/ts2phc.go
+++ b/ptp/c4u/clock/ts2phc.go
@@ -18,7 +18,7 @@ package clock
 
 import (
 	"github.com/facebook/time/phc"
-	ptp "github.com/facebook/time/ptp/protocol"
+	"time"
 )
 
 const (
@@ -26,24 +26,20 @@ const (
 	phcNICPath      = "/dev/ptp0"
 )
 
-func ts2phc() (*ptp.ClockQuality, error) {
-	c := &ptp.ClockQuality{}
-
+func ts2phc() (time.Duration, error) {
 	tcard, err := phc.TimeAndOffsetFromDevice(phcTimeCardPath, phc.MethodIoctlSysOffsetExtended)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	tnic, err := phc.TimeAndOffsetFromDevice(phcNICPath, phc.MethodIoctlSysOffsetExtended)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	sysOffset := tcard.SysTime.Sub(tnic.SysTime)
 	phcOffset := tcard.PHCTime.Sub(tnic.PHCTime)
 	phcOffset -= sysOffset
 
-	c.ClockAccuracy = ptp.ClockAccuracyFromOffset(phcOffset)
-
-	return c, nil
+	return phcOffset, nil
 }


### PR DESCRIPTION
## Summary

We want to smooth out/filter the spikes in the phc offsets. This change introduces configurable math for clock accuracy calculation based on phc offset.

## Test Plan

unittests, local runs