### PR TITLE
Use dedicated copr for packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,8 @@ jobs:
 - job: copr_build
   trigger: commit
   metadata:
+    owner: "@meta"
+    project: time
     targets:
       - fedora-latest-stable-aarch64
       # https://github.com/facebook/time/pull/101#issuecomment-1062295307
@@ -27,6 +29,8 @@ jobs:
 - job: copr_build
   trigger: pull_request
   metadata:
+    owner: "@meta"
+    project: time
     targets:
       - fedora-latest-stable-aarch64
       # https://github.com/facebook/time/pull/101#issuecomment-1062295307


### PR DESCRIPTION
Builds will show up under https://copr.fedorainfracloud.org/coprs/g/meta/time/