### PR TITLE
[oscillatord] process clock data

### DIFF
--- a/cmd/ptpcheck/cmd/oscillatord.go
+++ b/cmd/ptpcheck/cmd/oscillatord.go
@@ -59,6 +59,8 @@ func printOscillatordJSON(status *oscillatord.Status) error {
 		GNSSLSChange        int64 `json:"ptp.timecard.gnss.leap_second_change"`
 		GNSSLeapSeconds     int64 `json:"ptp.timecard.gnss.leap_seconds"`
 		GNSSSatellitesCount int64 `json:"ptp.timecard.gnss.satellites_count"`
+		ClockClass          int64 `json:"ptp.timecard.clock.class"`
+		ClockOffset         int64 `json:"ptp.timecard.clock.offset"`
 	}{
 		Temperature:         int64(status.Oscillator.Temperature),
 		Lock:                bool2int(status.Oscillator.Lock),
@@ -69,6 +71,8 @@ func printOscillatordJSON(status *oscillatord.Status) error {
 		GNSSLSChange:        int64(status.GNSS.LSChange),
 		GNSSLeapSeconds:     int64(status.GNSS.LeapSeconds),
 		GNSSSatellitesCount: int64(status.GNSS.SatellitesCount),
+		ClockClass:          int64(status.Clock.Class),
+		ClockOffset:         int64(status.Clock.Offset),
 	}
 	toPrint, err := json.Marshal(output)
 	if err != nil {
@@ -94,6 +98,10 @@ func printOscillatord(status *oscillatord.Status) {
 	fmt.Printf("\tleap_second_change: %s (%d)\n", status.GNSS.LSChange, status.GNSS.LSChange)
 	fmt.Printf("\tleap_seconds: %d\n", status.GNSS.LeapSeconds)
 	fmt.Printf("\tsatellites_count: %d\n", status.GNSS.SatellitesCount)
+
+	fmt.Println("Clock:")
+	fmt.Printf("\tclass: %s (%d)\n", status.Clock.Class, status.Clock.Class)
+	fmt.Printf("\toffset: %d\n", status.Clock.Offset)
 }
 
 func oscillatordRun(address string, jsonOut bool) error {

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package oscillatord
 
 import (
+	"errors"
 	"net"
 	"testing"
 
+	ptp "github.com/facebook/time/ptp/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +35,7 @@ func TestOscillatordRead(t *testing.T) {
 		_, err := server.Read(b)
 		require.Nil(t, err)
 		// write response
-		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18, "satellites_count": 10 } }`
+		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18, "satellites_count": 10 }, "clock": { "class": "Holdover", "offset": -265095 } }`
 		_, err = server.Write([]byte(data))
 		require.Nil(t, err)
 	}()
@@ -55,6 +57,10 @@ func TestOscillatordRead(t *testing.T) {
 			LSChange:        LeapNoWarning,
 			LeapSeconds:     18,
 			SatellitesCount: 10,
+		},
+		Clock: Clock{
+			Class:  ClockClassHoldover,
+			Offset: -265095,
 		},
 	}
 	require.Equal(t, want, status)
@@ -126,4 +132,38 @@ func TestLeapSecondChange(t *testing.T) {
 
 	l = 42
 	require.Equal(t, "UNSUPPORTED VALUE", l.String())
+}
+
+func TestClockClass(t *testing.T) {
+	require.Equal(t, ClockClass(ptp.ClockClass6), ClockClassLock)
+	require.Equal(t, ClockClass(ptp.ClockClass7), ClockClassHoldover)
+	require.Equal(t, ClockClass(ptp.ClockClass13), ClockClassCalibrating)
+	require.Equal(t, ClockClass(ptp.ClockClass52), ClockClassUncalibrated)
+	require.Equal(t, clockClassToString[ClockClassLock], ClockClassLock.String())
+	require.Equal(t, clockClassToString[ClockClassHoldover], ClockClassHoldover.String())
+	require.Equal(t, clockClassToString[ClockClassCalibrating], ClockClassCalibrating.String())
+	require.Equal(t, clockClassToString[ClockClassUncalibrated], ClockClassUncalibrated.String())
+	require.Equal(t, "UNSUPPORTED VALUE", ClockClass(42).String())
+}
+
+func TestClockClassUnmarshalText(t *testing.T) {
+	c := ClockClass(42)
+	err := c.UnmarshalText([]byte("Lock"))
+	require.NoError(t, err)
+	require.Equal(t, ClockClassLock, c)
+
+	err = c.UnmarshalText([]byte("Holdover"))
+	require.NoError(t, err)
+	require.Equal(t, ClockClassHoldover, c)
+
+	err = c.UnmarshalText([]byte("Calibrating"))
+	require.NoError(t, err)
+	require.Equal(t, ClockClassCalibrating, c)
+
+	err = c.UnmarshalText([]byte("Uncalibrated"))
+	require.NoError(t, err)
+	require.Equal(t, ClockClassUncalibrated, c)
+
+	err = c.UnmarshalText([]byte("blah"))
+	require.Equal(t, errors.New("clock class blah not supported"), err)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ ./ptpcheck oscillatord
Oscillator:
	model: mRO50
	fine_ctrl: 0
	coarse_ctrl: 0
	lock: false
	temperature: 32.00C
GNSS:
	fix: 3D (5)
	fixOk: true
	antenna_power: ON (1)
	antenna_status: OPEN (4)
	leap_second_change: NO WARNING (0)
	leap_seconds: 18
	satellites_count: 23
Clock:
	class: Holdover (7)
	offset: 5450
```

```
$ ./ptpcheck_oleg oscillatord --json
{"ptp.timecard.temperature":31,"ptp.timecard.lock":0,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":24,"ptp.timecard.clock.class":7,"ptp.timecard.clock.offset":6655}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
