### PR TITLE
[c4u] use oscillatord output

### DIFF
--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	ptp "github.com/facebook/time/ptp/protocol"
 )
@@ -219,8 +220,8 @@ type GNSS struct {
 
 // Clock describes structure that oscillatord returns for clock
 type Clock struct {
-	Class  ClockClass `json:"class"`
-	Offset int        `json:"offset"`
+	Class  ClockClass    `json:"class"`
+	Offset time.Duration `json:"offset"`
 }
 
 // Status is whole structure that oscillatord returns for monitoring

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -102,6 +102,9 @@ func TestAntennaStatus(t *testing.T) {
 	var a AntennaStatus
 	require.Equal(t, AntStatusInit, a)
 	require.Equal(t, antennaStatusToString[AntStatusInit], AntStatusInit.String())
+	for k := range antennaStatusToString {
+		require.Equal(t, antennaStatusToString[k], k.String())
+	}
 
 	a = 42
 	require.Equal(t, "UNSUPPORTED VALUE", a.String())
@@ -111,6 +114,9 @@ func TestAntennaPower(t *testing.T) {
 	var a AntennaPower
 	require.Equal(t, AntPowerOff, a)
 	require.Equal(t, antennaPowerToString[AntPowerOff], AntPowerOff.String())
+	for k := range antennaPowerToString {
+		require.Equal(t, antennaPowerToString[k], k.String())
+	}
 
 	a = 42
 	require.Equal(t, "UNSUPPORTED VALUE", a.String())
@@ -120,6 +126,9 @@ func TestGNSSFix(t *testing.T) {
 	var g GNSSFix
 	require.Equal(t, FixUnknown, g)
 	require.Equal(t, gnssFixToString[FixUnknown], FixUnknown.String())
+	for k := range gnssFixToString {
+		require.Equal(t, gnssFixToString[k], k.String())
+	}
 
 	g = 42
 	require.Equal(t, "UNSUPPORTED VALUE", g.String())
@@ -129,6 +138,9 @@ func TestLeapSecondChange(t *testing.T) {
 	var l LeapSecondChange
 	require.Equal(t, LeapNoWarning, l)
 	require.Equal(t, leapSecondChangeToString[LeapNoWarning], LeapNoWarning.String())
+	for k := range leapSecondChangeToString {
+		require.Equal(t, leapSecondChangeToString[k], k.String())
+	}
 
 	l = 42
 	require.Equal(t, "UNSUPPORTED VALUE", l.String())
@@ -139,10 +151,12 @@ func TestClockClass(t *testing.T) {
 	require.Equal(t, ClockClass(ptp.ClockClass7), ClockClassHoldover)
 	require.Equal(t, ClockClass(ptp.ClockClass13), ClockClassCalibrating)
 	require.Equal(t, ClockClass(ptp.ClockClass52), ClockClassUncalibrated)
+
 	require.Equal(t, clockClassToString[ClockClassLock], ClockClassLock.String())
-	require.Equal(t, clockClassToString[ClockClassHoldover], ClockClassHoldover.String())
-	require.Equal(t, clockClassToString[ClockClassCalibrating], ClockClassCalibrating.String())
-	require.Equal(t, clockClassToString[ClockClassUncalibrated], ClockClassUncalibrated.String())
+	for k := range clockClassToString {
+		require.Equal(t, clockClassToString[k], k.String())
+	}
+
 	require.Equal(t, "UNSUPPORTED VALUE", ClockClass(42).String())
 }
 

--- a/ptp/c4u/clock/clock.go
+++ b/ptp/c4u/clock/clock.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	ClockClassLocked       ptp.ClockClass = ptp.ClockClass6
+	ClockClassLock         ptp.ClockClass = ptp.ClockClass6
 	ClockClassHoldover     ptp.ClockClass = ptp.ClockClass7
 	ClockClassCalibrating  ptp.ClockClass = ptp.ClockClass13
 	ClockClassUncalibrated ptp.ClockClass = ptp.ClockClass52

--- a/ptp/c4u/clock/clock_test.go
+++ b/ptp/c4u/clock/clock_test.go
@@ -32,17 +32,17 @@ func TestWorst(t *testing.T) {
 		&DataPoint{
 			PHCOffset:            100 * time.Nanosecond,
 			OscillatorOffset:     100 * time.Nanosecond,
-			OscillatorClockClass: ClockClassLocked,
+			OscillatorClockClass: ClockClassLock,
 		},
 		&DataPoint{
 			PHCOffset:            time.Microsecond,
 			OscillatorOffset:     100 * time.Nanosecond,
-			OscillatorClockClass: ClockClassLocked,
+			OscillatorClockClass: ClockClassLock,
 		},
 		&DataPoint{
 			PHCOffset:            250 * time.Nanosecond,
 			OscillatorOffset:     100 * time.Nanosecond,
-			OscillatorClockClass: ClockClassLocked,
+			OscillatorClockClass: ClockClassLock,
 		},
 	}
 
@@ -60,7 +60,7 @@ func TestWorst(t *testing.T) {
 		&DataPoint{
 			PHCOffset:            10 * time.Nanosecond,
 			OscillatorOffset:     100 * time.Nanosecond,
-			OscillatorClockClass: ClockClassLocked,
+			OscillatorClockClass: ClockClassLock,
 		},
 		nil,
 	}
@@ -104,7 +104,7 @@ func TestBufferRing(t *testing.T) {
 	sample := 2
 	rb := NewRingBuffer(sample)
 	require.Equal(t, sample, rb.size)
-	cc100 := &DataPoint{PHCOffset: 100 * time.Nanosecond, OscillatorOffset: 100 * time.Nanosecond, OscillatorClockClass: ClockClassLocked}
+	cc100 := &DataPoint{PHCOffset: 100 * time.Nanosecond, OscillatorOffset: 100 * time.Nanosecond, OscillatorClockClass: ClockClassLock}
 	cc250 := &DataPoint{PHCOffset: 250 * time.Nanosecond, OscillatorOffset: 250 * time.Nanosecond, OscillatorClockClass: ClockClassCalibrating}
 	cc1u := &DataPoint{PHCOffset: time.Microsecond, OscillatorOffset: time.Microsecond, OscillatorClockClass: ClockClassHoldover}
 	// Write 1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* c4u now reads actual output of oscillatord (class and offset)
* oscillatord offset is a proper time.Duration vs int before
* More unit tests
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### ptpcheck still works
```
$ ptpcheck oscillatord
...
Clock:
	class: Lock (6)
	offset: -7
```
### c4u clearly uses better offset
```
$ ./c4u
INFO[0000] Current: &{ClockAccuracy:34 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0000] Pending: &{ClockAccuracy:32 ClockClass:6 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
```
### c4u in daemon mode estimates accuracy correctly 
```
$ cat /etc/ptp4u.yaml
clockaccuracy: 32
clockclass: 6
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
