### PR TITLE
[oscillatord] move/extend/test json convertion logic

### DIFF
--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -231,6 +231,36 @@ type Status struct {
 	Clock      Clock      `json:"clock"`
 }
 
+func (s *Status) MonitoringJSON(prefix string) ([]byte, error) {
+	if prefix != "" {
+		prefix = fmt.Sprintf("%s.", prefix)
+	}
+
+	output := map[string]int64{
+		fmt.Sprintf("%soscillator.temperature", prefix):  int64(s.Oscillator.Temperature),
+		fmt.Sprintf("%soscillator.fine_ctrl", prefix):    int64(s.Oscillator.FineCtrl),
+		fmt.Sprintf("%soscillator.coarse_ctrl", prefix):  int64(s.Oscillator.CoarseCtrl),
+		fmt.Sprintf("%soscillator.lock", prefix):         bool2int(s.Oscillator.Lock),
+		fmt.Sprintf("%sgnss.fix_num", prefix):            int64(s.GNSS.Fix),
+		fmt.Sprintf("%sgnss.fix_ok", prefix):             bool2int(s.GNSS.FixOK),
+		fmt.Sprintf("%sgnss.antenna_power", prefix):      int64(s.GNSS.AntennaPower),
+		fmt.Sprintf("%sgnss.antenna_status", prefix):     int64(s.GNSS.AntennaStatus),
+		fmt.Sprintf("%sgnss.leap_second_change", prefix): int64(s.GNSS.LSChange),
+		fmt.Sprintf("%sgnss.leap_seconds", prefix):       int64(s.GNSS.LeapSeconds),
+		fmt.Sprintf("%sgnss.satellites_count", prefix):   int64(s.GNSS.SatellitesCount),
+		fmt.Sprintf("%sclock.class", prefix):             int64(s.Clock.Class),
+		fmt.Sprintf("%sclock.offset", prefix):            int64(s.Clock.Offset),
+	}
+	return json.Marshal(output)
+}
+
+func bool2int(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // ReadStatus talks to oscillatord via monitoring port connection and reads reported Status
 func ReadStatus(conn io.ReadWriter) (*Status, error) {
 	// send newline to make oscillatord send us data

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -181,3 +181,41 @@ func TestClockClassUnmarshalText(t *testing.T) {
 	err = c.UnmarshalText([]byte("blah"))
 	require.Equal(t, errors.New("clock class blah not supported"), err)
 }
+
+func TestJSON(t *testing.T) {
+	expected := `{"ptp.timecard.clock.class":7,"ptp.timecard.clock.offset":-265095,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":10,"ptp.timecard.oscillator.coarse_ctrl":42,"ptp.timecard.oscillator.fine_ctrl":4242,"ptp.timecard.oscillator.lock":0,"ptp.timecard.oscillator.temperature":45}`
+	s := &Status{
+		Oscillator: Oscillator{
+			Model:       "sa5x",
+			FineCtrl:    4242,
+			CoarseCtrl:  42,
+			Lock:        false,
+			Temperature: 45.944,
+		},
+		GNSS: GNSS{
+			Fix:             Fix3D,
+			FixOK:           true,
+			AntennaPower:    AntPowerOn,
+			AntennaStatus:   AntStatusOpen,
+			LSChange:        LeapNoWarning,
+			LeapSeconds:     18,
+			SatellitesCount: 10,
+		},
+		Clock: Clock{
+			Class:  ClockClassHoldover,
+			Offset: -265095,
+		},
+	}
+	j, err := s.MonitoringJSON("ptp.timecard")
+	require.NoError(t, err)
+
+	require.Equal(t, expected, string(j))
+}
+
+func TestBool2int(t *testing.T) {
+	res := bool2int(true)
+	require.Equal(t, int64(1), res)
+
+	res = bool2int(false)
+	require.Equal(t, int64(0), res)
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Move conversion logic to a struct
* Cover with tests
* Export `fine_ctrl` and `coarse_ctrl`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Unittests 
Ptpcheck works
```
./ptpcheck oscillatord --json
{"ptp.timecard.oscillator.temperature":44,"ptp.timecard.oscillator.fine_ctrl":-18924,"ptp.timecard.oscillator.coarse_ctrl":500,"ptp.timecard.oscillator.lock":1,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.antenna_power":0,"ptp.timecard.gnss.antenna_status":3,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":25,"ptp.timecard.clock.class":6,"ptp.timecard.clock.offset":0}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
