### PR TITLE
[c4u] export stats

### DIFF
--- a/ptp/c4u/c4u_test.go
+++ b/ptp/c4u/c4u_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/facebook/time/ptp/c4u/clock"
+	"github.com/facebook/time/ptp/c4u/stats"
 	"github.com/facebook/time/ptp/c4u/utcoffset"
 	ptp "github.com/facebook/time/ptp/protocol"
 	"github.com/facebook/time/ptp/ptp4u/server"
@@ -55,7 +56,9 @@ func TestRun(t *testing.T) {
 		ClassExpr:    "1",
 	}
 
-	err = Run(c, clock.NewRingBuffer(1))
+	st := stats.NewJSONStats()
+
+	err = Run(c, clock.NewRingBuffer(1), st)
 	require.NoError(t, err)
 
 	dc, err := server.ReadDynamicConfig(c.Path)

--- a/ptp/c4u/stats/json.go
+++ b/ptp/c4u/stats/json.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// JSONStats is what we want to report as stats via http
+type JSONStats struct {
+	report counters
+
+	counters
+}
+
+// NewJSONStats returns a new JSONStats
+func NewJSONStats() *JSONStats {
+	s := &JSONStats{}
+
+	return s
+}
+
+// Start runs http server and initializes maps
+func (s *JSONStats) Start(monitoringport int) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleRequest)
+	addr := fmt.Sprintf(":%d", monitoringport)
+	log.Infof("Starting http json server on %s", addr)
+	err := http.ListenAndServe(addr, mux)
+	if err != nil {
+		log.Fatalf("Failed to start listener: %v", err)
+	}
+}
+
+// Snapshot the values so they can be reported atomically
+func (s *JSONStats) Snapshot() {
+	s.report.utcOffset = s.utcOffset
+	s.report.phcOffset = s.phcOffset
+	s.report.oscillatorOffset = s.oscillatorOffset
+	s.report.clockAccuracy = s.clockAccuracy
+	s.report.clockClass = s.clockClass
+	s.report.reload = s.reload
+	s.report.dataError = s.dataError
+}
+
+// handleRequest is a handler used for all http monitoring requests
+func (s *JSONStats) handleRequest(w http.ResponseWriter, r *http.Request) {
+	js, err := json.Marshal(s.report.toMap())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err = w.Write(js); err != nil {
+		log.Errorf("Failed to reply: %v", err)
+	}
+}
+
+// IncReload atomically add 1 to the counter
+func (s *JSONStats) IncReload() {
+	atomic.AddInt64(&s.reload, 1)
+}
+
+// ResetReload atomically sets the counter to 0
+func (s *JSONStats) ResetReload() {
+	atomic.StoreInt64(&s.reload, 0)
+}
+
+// IncDataError atomically add 1 to the counter
+func (s *JSONStats) IncDataError() {
+	atomic.AddInt64(&s.dataError, 1)
+}
+
+// ResetDataError atomically sets the counter to 0
+func (s *JSONStats) ResetDataError() {
+	atomic.StoreInt64(&s.dataError, 0)
+}
+
+// SetUTCOffset atomically sets the utcoffset
+func (s *JSONStats) SetUTCOffset(utcOffset int64) {
+	atomic.StoreInt64(&s.utcOffset, utcOffset)
+}
+
+// SetPHCOffset atomically sets the phcoffset
+func (s *JSONStats) SetPHCOffset(phcOffset int64) {
+	atomic.StoreInt64(&s.phcOffset, phcOffset)
+}
+
+// SetOscillatorOffset atomically sets the oscillatoroffset
+func (s *JSONStats) SetOscillatorOffset(oscillatorOffset int64) {
+	atomic.StoreInt64(&s.oscillatorOffset, oscillatorOffset)
+}
+
+// SetClockAccuracy atomically sets the clock accuracy
+func (s *JSONStats) SetClockAccuracy(clockAccuracy int64) {
+	atomic.StoreInt64(&s.clockAccuracy, clockAccuracy)
+}
+
+// SetClockClass atomically sets the clock class
+func (s *JSONStats) SetClockClass(clockClass int64) {
+	atomic.StoreInt64(&s.clockClass, clockClass)
+}

--- a/ptp/c4u/stats/json_test.go
+++ b/ptp/c4u/stats/json_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONStatsReset(t *testing.T) {
+	stats := JSONStats{}
+
+	stats.IncDataError()
+	stats.IncReload()
+
+	stats.ResetDataError()
+	stats.ResetReload()
+	require.Equal(t, int64(0), stats.reload)
+	require.Equal(t, int64(0), stats.dataError)
+}
+
+func TestJSONStatsSetClockAccuracy(t *testing.T) {
+	stats := NewJSONStats()
+
+	stats.SetClockAccuracy(42)
+	require.Equal(t, int64(42), stats.clockAccuracy)
+}
+
+func TestJSONStatsSetClockCLass(t *testing.T) {
+	stats := NewJSONStats()
+
+	stats.SetClockClass(42)
+	require.Equal(t, int64(42), stats.clockClass)
+}
+
+func TestJSONStatsSnapshot(t *testing.T) {
+	stats := NewJSONStats()
+
+	go stats.Start(0)
+	time.Sleep(time.Millisecond)
+
+	stats.SetClockAccuracy(1)
+	stats.SetClockClass(1)
+	stats.SetUTCOffset(1)
+	stats.IncReload()
+
+	stats.Snapshot()
+
+	expectedStats := counters{}
+	expectedStats.utcOffset = 1
+	expectedStats.clockAccuracy = 1
+	expectedStats.clockClass = 1
+	expectedStats.reload = 1
+
+	require.Equal(t, expectedStats.utcOffset, stats.report.utcOffset)
+	require.Equal(t, expectedStats.clockAccuracy, stats.report.clockAccuracy)
+	require.Equal(t, expectedStats.clockClass, stats.report.clockClass)
+	require.Equal(t, expectedStats.reload, stats.report.reload)
+}
+
+func TestJSONExport(t *testing.T) {
+	stats := NewJSONStats()
+
+	go stats.Start(8889)
+	time.Sleep(time.Second)
+
+	stats.SetUTCOffset(1)
+	stats.SetClockAccuracy(1)
+	stats.SetClockClass(1)
+	stats.IncReload()
+
+	stats.Snapshot()
+
+	resp, err := http.Get("http://localhost:8889")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var data map[string]int64
+	err = json.Unmarshal([]byte(body), &data)
+	require.NoError(t, err)
+
+	expectedMap := map[string]int64{
+		"phcoffset":        0,
+		"oscillatoroffset": 0,
+		"utcoffset":        1,
+		"clockaccuracy":    1,
+		"clockclass":       1,
+		"dataerror":        0,
+		"reload":           1,
+	}
+
+	require.Equal(t, expectedMap, data)
+}

--- a/ptp/c4u/stats/stats.go
+++ b/ptp/c4u/stats/stats.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package stats implements statistics collection and reporting.
+It is used by server to report internal statistics, such as number of
+requests and responses.
+*/
+package stats
+
+import ()
+
+// Stats is a metric collection interface
+type Stats interface {
+	// Start starts a stat reporter
+	// Use this for passive reporters
+	Start(monitoringport int)
+
+	// Snapshot the values so they can be reported atomically
+	Snapshot()
+
+	// IncReload atomically add 1 to the counter
+	IncReload()
+
+	// ResetReload atomically sets counter to 0
+	ResetReload()
+
+	// IncDataError atomically add 1 to the counter
+	IncDataError()
+
+	// ResetDataError atomically sets counter to 0
+	ResetDataError()
+
+	// SetUTCOffset atomically sets the utcOffset
+	SetUTCOffset(utcOffset int64)
+
+	// SetUTCOffset atomically sets the phcOffset
+	SetPHCOffset(phcOffset int64)
+
+	// SetOscillatorOffset atomically sets the oscillatorOffset
+	SetOscillatorOffset(oscillatorOffset int64)
+
+	// SetClockAccuracy atomically sets the clock accuracy
+	SetClockAccuracy(clockAccuracy int64)
+
+	// SetClockClass atomically sets the clock class
+	SetClockClass(clockClass int64)
+}
+
+type counters struct {
+	utcOffset        int64
+	phcOffset        int64
+	oscillatorOffset int64
+	clockAccuracy    int64
+	clockClass       int64
+	reload           int64
+	dataError        int64
+}
+
+// toMap converts counters to a map
+func (c *counters) toMap() (export map[string]int64) {
+	res := make(map[string]int64)
+	res["utcoffset"] = c.utcOffset
+	res["phcoffset"] = c.phcOffset
+	res["oscillatoroffset"] = c.oscillatorOffset
+	res["clockaccuracy"] = c.clockAccuracy
+	res["clockclass"] = c.clockClass
+	res["reload"] = c.reload
+	res["dataerror"] = c.dataError
+
+	return res
+}

--- a/ptp/c4u/stats/stats_test.go
+++ b/ptp/c4u/stats/stats_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountersToMap(t *testing.T) {
+	c := counters{
+		utcOffset:        1,
+		phcOffset:        2,
+		oscillatorOffset: 3,
+		clockAccuracy:    42,
+		clockClass:       6,
+		reload:           7,
+		dataError:        8,
+	}
+	result := c.toMap()
+
+	expectedMap := make(map[string]int64)
+	expectedMap["utcoffset"] = 1
+	expectedMap["phcoffset"] = 2
+	expectedMap["oscillatoroffset"] = 3
+	expectedMap["clockaccuracy"] = 42
+	expectedMap["clockclass"] = 6
+	expectedMap["reload"] = 7
+	expectedMap["dataerror"] = 8
+
+	require.Equal(t, expectedMap, result)
+}


### PR DESCRIPTION
## Summary

Export runtime stats, similar to other services.

## Test Plan
unittests

local run
```
> curl 127.0.0.1:8889; echo;
{"clockaccuracy":254,"clockclass":52,"dataerror":5,"oscillatoroffset":0,"phcoffset":0,"reload":0,"utcoffset":37}
```
