### PR TITLE
[c4u] combine oscillatord and ts2phc offsets

### DIFF
--- a/cmd/c4u/main.go
+++ b/cmd/c4u/main.go
@@ -40,7 +40,7 @@ func main() {
 	flag.BoolVar(&once, "once", false, "Run once and exit")
 	flag.StringVar(&c.Path, "path", "/etc/ptp4u.yaml", "Path to a config file")
 	flag.StringVar(&c.Pid, "ptp4u", "/var/run/ptp4u.pid", "Path to a ptp4u pid file")
-	flag.StringVar(&c.AccuracyExpr, "accuracyExpr", "max(abs(mean(phcoffset)) + 3 * stddev(phcoffset), abs(mean(oscillatoroffset)))", "Math to calculate clock accuracy")
+	flag.StringVar(&c.AccuracyExpr, "accuracyExpr", "abs(mean(phcoffset)) + 3 * stddev(phcoffset) + abs(mean(oscillatoroffset)) + 3 * stddev(oscillatoroffset)", "Math to calculate clock accuracy")
 	flag.StringVar(&c.ClassExpr, "classExpr", "p99(oscillatorclass)", "Math to calculate clock class")
 	flag.IntVar(&sample, "sample", 600, "Sliding window size (samples) for clock data calculations")
 	flag.DurationVar(&interval, "interval", time.Second, "Data cata collection interval")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Use both offsets equally (`ts2phc` and `oscillatord`) 
* Summary both instead of picking max and ignoring the second
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/167455265-d741b27f-e510-4b44-9247-6a514ee382ab.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
