### PR TITLE
[ptp] update stat names to include units

### DIFF
--- a/ptp/c4u/c4u.go
+++ b/ptp/c4u/c4u.go
@@ -58,11 +58,11 @@ func Run(config *Config, rb *clock.RingBuffer, st stats.Stats) error {
 	rb.Write(c)
 	// stats
 	if c != nil {
-		st.SetPHCOffset(int64(c.PHCOffset))
-		st.SetOscillatorOffset(int64(c.OscillatorOffset))
+		st.SetPHCOffsetNS(int64(c.PHCOffset))
+		st.SetOscillatorOffsetNS(int64(c.OscillatorOffset))
 	} else {
-		st.SetPHCOffset(0)
-		st.SetOscillatorOffset(0)
+		st.SetPHCOffsetNS(0)
+		st.SetOscillatorOffsetNS(0)
 	}
 
 	w, err := clock.Worst(rb.Data(), config.AccuracyExpr, config.ClassExpr)
@@ -107,7 +107,7 @@ func Run(config *Config, rb *clock.RingBuffer, st stats.Stats) error {
 
 	st.SetClockClass(int64(pending.ClockClass))
 	st.SetClockAccuracy(int64(pending.ClockAccuracy))
-	st.SetUTCOffset(int64(pending.UTCOffset.Seconds()))
+	st.SetUTCOffsetSec(int64(pending.UTCOffset.Seconds()))
 
 	if *current != *pending {
 		log.Infof("Current: %+v", current)

--- a/ptp/c4u/stats/json.go
+++ b/ptp/c4u/stats/json.go
@@ -53,9 +53,9 @@ func (s *JSONStats) Start(monitoringport int) {
 
 // Snapshot the values so they can be reported atomically
 func (s *JSONStats) Snapshot() {
-	s.report.utcOffset = s.utcOffset
-	s.report.phcOffset = s.phcOffset
-	s.report.oscillatorOffset = s.oscillatorOffset
+	s.report.utcOffsetSec = s.utcOffsetSec
+	s.report.phcOffsetNS = s.phcOffsetNS
+	s.report.oscillatorOffsetNS = s.oscillatorOffsetNS
 	s.report.clockAccuracy = s.clockAccuracy
 	s.report.clockClass = s.clockClass
 	s.report.reload = s.reload
@@ -95,19 +95,19 @@ func (s *JSONStats) ResetDataError() {
 	atomic.StoreInt64(&s.dataError, 0)
 }
 
-// SetUTCOffset atomically sets the utcoffset
-func (s *JSONStats) SetUTCOffset(utcOffset int64) {
-	atomic.StoreInt64(&s.utcOffset, utcOffset)
+// SetUTCOffsetSec atomically sets the utcoffset
+func (s *JSONStats) SetUTCOffsetSec(utcOffsetSec int64) {
+	atomic.StoreInt64(&s.utcOffsetSec, utcOffsetSec)
 }
 
-// SetPHCOffset atomically sets the phcoffset
-func (s *JSONStats) SetPHCOffset(phcOffset int64) {
-	atomic.StoreInt64(&s.phcOffset, phcOffset)
+// SetPHCOffsetNS atomically sets the phcoffset
+func (s *JSONStats) SetPHCOffsetNS(phcOffsetNS int64) {
+	atomic.StoreInt64(&s.phcOffsetNS, phcOffsetNS)
 }
 
-// SetOscillatorOffset atomically sets the oscillatoroffset
-func (s *JSONStats) SetOscillatorOffset(oscillatorOffset int64) {
-	atomic.StoreInt64(&s.oscillatorOffset, oscillatorOffset)
+// SetOscillatorOffsetNS atomically sets the oscillatoroffset
+func (s *JSONStats) SetOscillatorOffsetNS(oscillatorOffsetNS int64) {
+	atomic.StoreInt64(&s.oscillatorOffsetNS, oscillatorOffsetNS)
 }
 
 // SetClockAccuracy atomically sets the clock accuracy

--- a/ptp/c4u/stats/json_test.go
+++ b/ptp/c4u/stats/json_test.go
@@ -60,18 +60,18 @@ func TestJSONStatsSnapshot(t *testing.T) {
 
 	stats.SetClockAccuracy(1)
 	stats.SetClockClass(1)
-	stats.SetUTCOffset(1)
+	stats.SetUTCOffsetSec(1)
 	stats.IncReload()
 
 	stats.Snapshot()
 
 	expectedStats := counters{}
-	expectedStats.utcOffset = 1
+	expectedStats.utcOffsetSec = 1
 	expectedStats.clockAccuracy = 1
 	expectedStats.clockClass = 1
 	expectedStats.reload = 1
 
-	require.Equal(t, expectedStats.utcOffset, stats.report.utcOffset)
+	require.Equal(t, expectedStats.utcOffsetSec, stats.report.utcOffsetSec)
 	require.Equal(t, expectedStats.clockAccuracy, stats.report.clockAccuracy)
 	require.Equal(t, expectedStats.clockClass, stats.report.clockClass)
 	require.Equal(t, expectedStats.reload, stats.report.reload)
@@ -83,7 +83,7 @@ func TestJSONExport(t *testing.T) {
 	go stats.Start(8889)
 	time.Sleep(time.Second)
 
-	stats.SetUTCOffset(1)
+	stats.SetUTCOffsetSec(1)
 	stats.SetClockAccuracy(1)
 	stats.SetClockClass(1)
 	stats.IncReload()
@@ -102,13 +102,13 @@ func TestJSONExport(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedMap := map[string]int64{
-		"phcoffset":        0,
-		"oscillatoroffset": 0,
-		"utcoffset":        1,
-		"clockaccuracy":    1,
-		"clockclass":       1,
-		"dataerror":        0,
-		"reload":           1,
+		"phcoffset_ns":        0,
+		"oscillatoroffset_ns": 0,
+		"utcoffset_sec":       1,
+		"clockaccuracy":       1,
+		"clockclass":          1,
+		"dataerror":           0,
+		"reload":              1,
 	}
 
 	require.Equal(t, expectedMap, data)

--- a/ptp/c4u/stats/stats.go
+++ b/ptp/c4u/stats/stats.go
@@ -44,14 +44,14 @@ type Stats interface {
 	// ResetDataError atomically sets counter to 0
 	ResetDataError()
 
-	// SetUTCOffset atomically sets the utcOffset
-	SetUTCOffset(utcOffset int64)
+	// SetUTCOffsetSec atomically sets the utcOffsetSec
+	SetUTCOffsetSec(utcOffsetSec int64)
 
-	// SetUTCOffset atomically sets the phcOffset
-	SetPHCOffset(phcOffset int64)
+	// SetUTCOffsetNS atomically sets the phcOffsetNS
+	SetPHCOffsetNS(phcOffsetNS int64)
 
-	// SetOscillatorOffset atomically sets the oscillatorOffset
-	SetOscillatorOffset(oscillatorOffset int64)
+	// SetOscillatorOffsetNS atomically sets the oscillatorOffsetNS
+	SetOscillatorOffsetNS(oscillatorOffsetNS int64)
 
 	// SetClockAccuracy atomically sets the clock accuracy
 	SetClockAccuracy(clockAccuracy int64)
@@ -61,21 +61,21 @@ type Stats interface {
 }
 
 type counters struct {
-	utcOffset        int64
-	phcOffset        int64
-	oscillatorOffset int64
-	clockAccuracy    int64
-	clockClass       int64
-	reload           int64
-	dataError        int64
+	utcOffsetSec       int64
+	phcOffsetNS        int64
+	oscillatorOffsetNS int64
+	clockAccuracy      int64
+	clockClass         int64
+	reload             int64
+	dataError          int64
 }
 
 // toMap converts counters to a map
 func (c *counters) toMap() (export map[string]int64) {
 	res := make(map[string]int64)
-	res["utcoffset"] = c.utcOffset
-	res["phcoffset"] = c.phcOffset
-	res["oscillatoroffset"] = c.oscillatorOffset
+	res["utcoffset_sec"] = c.utcOffsetSec
+	res["phcoffset_ns"] = c.phcOffsetNS
+	res["oscillatoroffset_ns"] = c.oscillatorOffsetNS
 	res["clockaccuracy"] = c.clockAccuracy
 	res["clockclass"] = c.clockClass
 	res["reload"] = c.reload

--- a/ptp/c4u/stats/stats_test.go
+++ b/ptp/c4u/stats/stats_test.go
@@ -24,20 +24,20 @@ import (
 
 func TestCountersToMap(t *testing.T) {
 	c := counters{
-		utcOffset:        1,
-		phcOffset:        2,
-		oscillatorOffset: 3,
-		clockAccuracy:    42,
-		clockClass:       6,
-		reload:           7,
-		dataError:        8,
+		utcOffsetSec:       1,
+		phcOffsetNS:        2,
+		oscillatorOffsetNS: 3,
+		clockAccuracy:      42,
+		clockClass:         6,
+		reload:             7,
+		dataError:          8,
 	}
 	result := c.toMap()
 
 	expectedMap := make(map[string]int64)
-	expectedMap["utcoffset"] = 1
-	expectedMap["phcoffset"] = 2
-	expectedMap["oscillatoroffset"] = 3
+	expectedMap["utcoffset_sec"] = 1
+	expectedMap["phcoffset_ns"] = 2
+	expectedMap["oscillatoroffset_ns"] = 3
 	expectedMap["clockaccuracy"] = 42
 	expectedMap["clockclass"] = 6
 	expectedMap["reload"] = 7

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -141,7 +141,7 @@ func (s *Server) Start() error {
 			for _, w := range s.sw {
 				w.inventoryClients()
 			}
-			s.Stats.SetUTCOffset(int64(s.Config.UTCOffset.Seconds()))
+			s.Stats.SetUTCOffsetSec(int64(s.Config.UTCOffset.Seconds()))
 			s.Stats.SetClockAccuracy(int64(s.Config.ClockAccuracy))
 			s.Stats.SetClockClass(int64(s.Config.ClockClass))
 

--- a/ptp/ptp4u/stats/json.go
+++ b/ptp/ptp4u/stats/json.go
@@ -65,7 +65,7 @@ func (s *JSONStats) Snapshot() {
 	s.workerQueue.copy(&s.report.workerQueue)
 	s.workerSubs.copy(&s.report.workerSubs)
 	s.txtsattempts.copy(&s.report.txtsattempts)
-	s.report.utcoffset = s.utcoffset
+	s.report.utcoffsetSec = s.utcoffsetSec
 	s.report.clockaccuracy = s.clockaccuracy
 	s.report.clockclass = s.clockclass
 	s.report.drain = s.drain
@@ -169,9 +169,9 @@ func (s *JSONStats) SetMaxTXTSAttempts(workerid int, attempts int64) {
 	}
 }
 
-// SetUTCOffset atomically sets the utcoffset
-func (s *JSONStats) SetUTCOffset(utcoffset int64) {
-	atomic.StoreInt64(&s.utcoffset, utcoffset)
+// SetUTCOffsetSec atomically sets the utcoffset
+func (s *JSONStats) SetUTCOffsetSec(utcoffsetSec int64) {
+	atomic.StoreInt64(&s.utcoffsetSec, utcoffsetSec)
 }
 
 // SetClockAccuracy atomically sets the clock accuracy

--- a/ptp/ptp4u/stats/json_test.go
+++ b/ptp/ptp4u/stats/json_test.go
@@ -130,8 +130,8 @@ func TestJSONStatsSetMaxTXTSAttempts(t *testing.T) {
 func TestJSONStatsSetUTCOffset(t *testing.T) {
 	stats := NewJSONStats()
 
-	stats.SetUTCOffset(42)
-	require.Equal(t, int64(42), stats.utcoffset)
+	stats.SetUTCOffsetSec(42)
+	require.Equal(t, int64(42), stats.utcoffsetSec)
 }
 
 func TestJSONStatsSetClockAccuracy(t *testing.T) {
@@ -169,7 +169,7 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.SetClockAccuracy(1)
 	stats.SetClockClass(1)
-	stats.SetUTCOffset(1)
+	stats.SetUTCOffsetSec(1)
 	stats.SetDrain(1)
 	stats.IncReload()
 
@@ -180,7 +180,7 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	expectedStats.subscriptions.store(int(ptp.MessageAnnounce), 1)
 	expectedStats.tx.store(int(ptp.MessageSync), 2)
 	expectedStats.rxSignaling.store(int(ptp.MessageDelayResp), 3)
-	expectedStats.utcoffset = 1
+	expectedStats.utcoffsetSec = 1
 	expectedStats.clockaccuracy = 1
 	expectedStats.clockclass = 1
 	expectedStats.drain = 1
@@ -189,7 +189,7 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	require.Equal(t, expectedStats.subscriptions.m, stats.report.subscriptions.m)
 	require.Equal(t, expectedStats.tx.m, stats.report.tx.m)
 	require.Equal(t, expectedStats.rxSignaling.m, stats.report.rxSignaling.m)
-	require.Equal(t, expectedStats.utcoffset, stats.report.utcoffset)
+	require.Equal(t, expectedStats.utcoffsetSec, stats.report.utcoffsetSec)
 	require.Equal(t, expectedStats.clockaccuracy, stats.report.clockaccuracy)
 	require.Equal(t, expectedStats.clockclass, stats.report.clockclass)
 	require.Equal(t, expectedStats.drain, stats.report.drain)
@@ -208,7 +208,7 @@ func TestJSONExport(t *testing.T) {
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.IncRXSignaling(ptp.MessageDelayResp)
 	stats.IncRXSignaling(ptp.MessageDelayResp)
-	stats.SetUTCOffset(1)
+	stats.SetUTCOffsetSec(1)
 	stats.SetClockAccuracy(1)
 	stats.SetClockClass(1)
 	stats.SetDrain(1)
@@ -231,7 +231,7 @@ func TestJSONExport(t *testing.T) {
 	expectedMap["subscriptions.announce"] = 1
 	expectedMap["tx.sync"] = 2
 	expectedMap["rx.signaling.delay_resp"] = 3
-	expectedMap["utcoffset"] = 1
+	expectedMap["utcoffset_sec"] = 1
 	expectedMap["clockaccuracy"] = 1
 	expectedMap["clockclass"] = 1
 	expectedMap["drain"] = 1

--- a/ptp/ptp4u/stats/stats.go
+++ b/ptp/ptp4u/stats/stats.go
@@ -86,8 +86,8 @@ type Stats interface {
 	// SetMaxTXTSAttempts atomically sets number of retries for get latest TX timestamp
 	SetMaxTXTSAttempts(workerid int, retries int64)
 
-	// SetUTCOffset atomically sets the utcoffset
-	SetUTCOffset(utcoffset int64)
+	// SetUTCOffsetSec atomically sets the utcoffset
+	SetUTCOffsetSec(utcoffsetSec int64)
 
 	// SetClockAccuracy atomically sets the clock accuracy
 	SetClockAccuracy(clockaccuracy int64)
@@ -175,7 +175,7 @@ type counters struct {
 	txtsattempts  syncMapInt64
 	workerQueue   syncMapInt64
 	workerSubs    syncMapInt64
-	utcoffset     int64
+	utcoffsetSec  int64
 	clockaccuracy int64
 	clockclass    int64
 	drain         int64
@@ -202,7 +202,7 @@ func (c *counters) reset() {
 	c.workerQueue.reset()
 	c.workerSubs.reset()
 	c.txtsattempts.reset()
-	c.utcoffset = 0
+	c.utcoffsetSec = 0
 	c.clockaccuracy = 0
 	c.clockclass = 0
 	c.drain = 0
@@ -258,7 +258,7 @@ func (c *counters) toMap() (export map[string]int64) {
 		res[fmt.Sprintf("worker.%d.txtsattempts", t)] = c
 	}
 
-	res["utcoffset"] = c.utcoffset
+	res["utcoffset_sec"] = c.utcoffsetSec
 	res["clockaccuracy"] = c.clockaccuracy
 	res["clockclass"] = c.clockclass
 	res["drain"] = c.drain

--- a/ptp/ptp4u/stats/stats_test.go
+++ b/ptp/ptp4u/stats/stats_test.go
@@ -72,7 +72,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	c.workerQueue.store(1, 1)
 	c.workerSubs.store(1, 1)
 	c.txtsattempts.store(1, 1)
-	c.utcoffset = 1
+	c.utcoffsetSec = 1
 	c.clockaccuracy = 1
 	c.clockclass = 1
 	c.drain = 1
@@ -86,7 +86,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(1), c.workerQueue.load(1))
 	require.Equal(t, int64(1), c.workerSubs.load(1))
 	require.Equal(t, int64(1), c.txtsattempts.load(1))
-	require.Equal(t, int64(1), c.utcoffset)
+	require.Equal(t, int64(1), c.utcoffsetSec)
 	require.Equal(t, int64(1), c.clockaccuracy)
 	require.Equal(t, int64(1), c.clockclass)
 	require.Equal(t, int64(1), c.drain)
@@ -102,7 +102,7 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(0), c.workerQueue.load(1))
 	require.Equal(t, int64(0), c.workerSubs.load(1))
 	require.Equal(t, int64(0), c.txtsattempts.load(1))
-	require.Equal(t, int64(0), c.utcoffset)
+	require.Equal(t, int64(0), c.utcoffsetSec)
 	require.Equal(t, int64(0), c.clockaccuracy)
 	require.Equal(t, int64(0), c.clockclass)
 	require.Equal(t, int64(0), c.drain)
@@ -116,7 +116,7 @@ func TestCountersToMap(t *testing.T) {
 	c.subscriptions.store(int(ptp.MessageAnnounce), 1)
 	c.tx.store(int(ptp.MessageSync), 2)
 	c.rxSignaling.store(int(ptp.MessageDelayResp), 3)
-	c.utcoffset = 1
+	c.utcoffsetSec = 1
 	c.clockaccuracy = 42
 	c.clockclass = 6
 	c.drain = 1
@@ -128,7 +128,7 @@ func TestCountersToMap(t *testing.T) {
 	expectedMap["subscriptions.announce"] = 1
 	expectedMap["tx.sync"] = 2
 	expectedMap["rx.signaling.delay_resp"] = 3
-	expectedMap["utcoffset"] = 1
+	expectedMap["utcoffset_sec"] = 1
 	expectedMap["clockaccuracy"] = 42
 	expectedMap["clockclass"] = 6
 	expectedMap["drain"] = 1


### PR DESCRIPTION
## Summary

Best practice is including published stat unit in the name.

## Test Plan

tests passs

run c4u
```
 > curl 127.0.0.1:8889; echo;
{"clockaccuracy":254,"clockclass":52,"dataerror":13,"oscillatoroffset_ns":0,"phcoffset_ns":0,"reload":0,"utcoffset_sec":37}
```