### PR TITLE
[c4u] override clockAccuracy while in holdover and uncalibrated classes

### DIFF
--- a/ptp/c4u/clock/clock_test.go
+++ b/ptp/c4u/clock/clock_test.go
@@ -97,8 +97,31 @@ func TestWorstBig(t *testing.T) {
 
 	// Changing 1 element to sway over the border
 	clocks[592] = &DataPoint{OscillatorClockClass: ptp.ClockClass7, PHCOffset: 250 * time.Nanosecond}
-	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond250}
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
 	w, err = Worst(clocks, aexpr, cexpr)
+	require.NoError(t, err)
+	require.Equal(t, expected, w)
+}
+
+func TestOverride(t *testing.T) {
+	aexpr := "p99(phcoffset)"
+	cexpr := "p99(oscillatorclass)"
+	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass52, ClockAccuracy: ptp.ClockAccuracyUnknown}
+
+	dp := &DataPoint{OscillatorClockClass: ClockClassUncalibrated, PHCOffset: 80 * time.Nanosecond}
+	w, err := Worst([]*DataPoint{dp}, aexpr, cexpr)
+	require.NoError(t, err)
+	require.Equal(t, expected, w)
+
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
+	dp = &DataPoint{OscillatorClockClass: ClockClassHoldover, PHCOffset: 80 * time.Nanosecond}
+	w, err = Worst([]*DataPoint{dp}, aexpr, cexpr)
+	require.NoError(t, err)
+	require.Equal(t, expected, w)
+
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond2point5}
+	dp = &DataPoint{OscillatorClockClass: ClockClassHoldover, PHCOffset: 2 * time.Microsecond}
+	w, err = Worst([]*DataPoint{dp}, aexpr, cexpr)
 	require.NoError(t, err)
 	require.Equal(t, expected, w)
 }

--- a/ptp/protocol/types.go
+++ b/ptp/protocol/types.go
@@ -331,39 +331,39 @@ func ClockAccuracyFromOffset(offset time.Duration) ClockAccuracy {
 	}
 
 	// https://datatracker.ietf.org/doc/html/rfc8173#section-7.6.2.4
-	if offset < 25*time.Nanosecond {
+	if offset <= 25*time.Nanosecond {
 		return ClockAccuracyNanosecond25
-	} else if offset < 100*time.Nanosecond {
+	} else if offset <= 100*time.Nanosecond {
 		return ClockAccuracyNanosecond100
-	} else if offset < 250*time.Nanosecond {
+	} else if offset <= 250*time.Nanosecond {
 		return ClockAccuracyNanosecond250
-	} else if offset < time.Microsecond {
+	} else if offset <= time.Microsecond {
 		return ClockAccuracyMicrosecond1
-	} else if offset < 2500*time.Nanosecond {
+	} else if offset <= 2500*time.Nanosecond {
 		return ClockAccuracyMicrosecond2point5
-	} else if offset < 10*time.Microsecond {
+	} else if offset <= 10*time.Microsecond {
 		return ClockAccuracyMicrosecond10
-	} else if offset < 25*time.Microsecond {
+	} else if offset <= 25*time.Microsecond {
 		return ClockAccuracyMicrosecond25
-	} else if offset < 100*time.Microsecond {
+	} else if offset <= 100*time.Microsecond {
 		return ClockAccuracyMicrosecond100
-	} else if offset < 250*time.Microsecond {
+	} else if offset <= 250*time.Microsecond {
 		return ClockAccuracyMicrosecond250
-	} else if offset < time.Millisecond {
+	} else if offset <= time.Millisecond {
 		return ClockAccuracyMillisecond1
-	} else if offset < 2500*time.Microsecond {
+	} else if offset <= 2500*time.Microsecond {
 		return ClockAccuracyMillisecond2point5
-	} else if offset < 10*time.Millisecond {
+	} else if offset <= 10*time.Millisecond {
 		return ClockAccuracyMillisecond10
-	} else if offset < 25*time.Millisecond {
+	} else if offset <= 25*time.Millisecond {
 		return ClockAccuracyMillisecond25
-	} else if offset < 100*time.Millisecond {
+	} else if offset <= 100*time.Millisecond {
 		return ClockAccuracyMillisecond100
-	} else if offset < 250*time.Millisecond {
+	} else if offset <= 250*time.Millisecond {
 		return ClockAccuracyMillisecond250
-	} else if offset < time.Second {
+	} else if offset <= time.Second {
 		return ClockAccuracySecond1
-	} else if offset < 10*time.Second {
+	} else if offset <= 10*time.Second {
 		return ClockAccuracySecond10
 	}
 

--- a/ptp/protocol/types_test.go
+++ b/ptp/protocol/types_test.go
@@ -266,7 +266,7 @@ func TestClockAccuracyFromOffset(t *testing.T) {
 	require.Equal(t, ClockAccuracyMicrosecond1, ClockAccuracyFromOffset(567*time.Nanosecond))
 	require.Equal(t, ClockAccuracyMicrosecond2point5, ClockAccuracyFromOffset(2*time.Microsecond))
 	require.Equal(t, ClockAccuracyMicrosecond10, ClockAccuracyFromOffset(8*time.Microsecond))
-	require.Equal(t, ClockAccuracyMicrosecond25, ClockAccuracyFromOffset(10*time.Microsecond))
+	require.Equal(t, ClockAccuracyMicrosecond25, ClockAccuracyFromOffset(11*time.Microsecond))
 	require.Equal(t, ClockAccuracyMicrosecond100, ClockAccuracyFromOffset(-42*time.Microsecond))
 	require.Equal(t, ClockAccuracyMicrosecond250, ClockAccuracyFromOffset(123*time.Microsecond))
 	require.Equal(t, ClockAccuracyMillisecond1, ClockAccuracyFromOffset(678*time.Microsecond))
@@ -276,6 +276,6 @@ func TestClockAccuracyFromOffset(t *testing.T) {
 	require.Equal(t, ClockAccuracyMillisecond100, ClockAccuracyFromOffset(69*time.Millisecond))
 	require.Equal(t, ClockAccuracyMillisecond250, ClockAccuracyFromOffset(222*time.Millisecond))
 	require.Equal(t, ClockAccuracySecond1, ClockAccuracyFromOffset(-999*time.Millisecond))
-	require.Equal(t, ClockAccuracySecond10, ClockAccuracyFromOffset(8*time.Second))
+	require.Equal(t, ClockAccuracySecond10, ClockAccuracyFromOffset(10*time.Second))
 	require.Equal(t, ClockAccuracySecondGreater10, ClockAccuracyFromOffset(9*time.Minute))
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* In holdover we don't know the offset. Let's fallback to 1us or worse
* In uncalibrated state we don't know the offset - let's say it
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ cat /etc/ptp4u.yaml
clockaccuracy: 35
clockclass: 7
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
