### PR TITLE
[c4u] implement baseline support

### DIFF
--- a/ptp/c4u/clock/clock.go
+++ b/ptp/c4u/clock/clock.go
@@ -121,15 +121,6 @@ func Worst(points []*DataPoint, accuracyExpr, classExpr string) (*ptp.ClockQuali
 	w.ClockClass = c
 	w.ClockAccuracy = accFromOffset
 
-	// Some override logic to represent the situation better:
-	// * In holdover we don't know the offset. Let's fallback to 1us or worse
-	// * In uncalibrated state we don't know the offset - let's say it
-	if w.ClockClass == ClockClassHoldover && w.ClockAccuracy < ptp.ClockAccuracyMicrosecond1 {
-		w.ClockAccuracy = ptp.ClockAccuracyMicrosecond1
-	} else if w.ClockClass == ClockClassUncalibrated {
-		w.ClockAccuracy = ptp.ClockAccuracyUnknown
-	}
-
 	return w, nil
 }
 

--- a/ptp/c4u/clock/clock_test.go
+++ b/ptp/c4u/clock/clock_test.go
@@ -97,31 +97,8 @@ func TestWorstBig(t *testing.T) {
 
 	// Changing 1 element to sway over the border
 	clocks[592] = &DataPoint{OscillatorClockClass: ptp.ClockClass7, PHCOffset: 250 * time.Nanosecond}
-	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
+	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyNanosecond100}
 	w, err = Worst(clocks, aexpr, cexpr)
-	require.NoError(t, err)
-	require.Equal(t, expected, w)
-}
-
-func TestOverride(t *testing.T) {
-	aexpr := "p99(phcoffset)"
-	cexpr := "p99(oscillatorclass)"
-	expected := &ptp.ClockQuality{ClockClass: ptp.ClockClass52, ClockAccuracy: ptp.ClockAccuracyUnknown}
-
-	dp := &DataPoint{OscillatorClockClass: ClockClassUncalibrated, PHCOffset: 80 * time.Nanosecond}
-	w, err := Worst([]*DataPoint{dp}, aexpr, cexpr)
-	require.NoError(t, err)
-	require.Equal(t, expected, w)
-
-	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond1}
-	dp = &DataPoint{OscillatorClockClass: ClockClassHoldover, PHCOffset: 80 * time.Nanosecond}
-	w, err = Worst([]*DataPoint{dp}, aexpr, cexpr)
-	require.NoError(t, err)
-	require.Equal(t, expected, w)
-
-	expected = &ptp.ClockQuality{ClockClass: ptp.ClockClass7, ClockAccuracy: ptp.ClockAccuracyMicrosecond2point5}
-	dp = &DataPoint{OscillatorClockClass: ClockClassHoldover, PHCOffset: 2 * time.Microsecond}
-	w, err = Worst([]*DataPoint{dp}, aexpr, cexpr)
 	require.NoError(t, err)
 	require.Equal(t, expected, w)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Periodically we get a very good clockAccuracy based on offsets (<100ns or even <25ns). Very often it doesn't really matter but it causes regeneration of the ptp4u config and subsequent client migration/rebalancing.
This option allows us to set baselines which are "best case scenario" and we will never go lower in accuracy.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
Current: &{ClockAccuracy:33 ClockClass:13 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
Pending: &{ClockAccuracy:34 ClockClass:13 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
