### PR TITLE
[calnex] set reset=false in getdata call

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -386,7 +386,7 @@ func (p Probe) CalnexName() string {
 const (
 	// measureURL is a base URL for to the measurement API
 	measureURL = "https://%s/api/get/measure/%s"
-	dataURL    = "https://%s/api/getdata?channel=%s&datatype=%s&reset=true"
+	dataURL    = "https://%s/api/getdata?channel=%s&datatype=%s&reset=false"
 
 	startMeasure = "https://%s/api/startmeasurement"
 	stopMeasure  = "https://%s/api/stopmeasurement"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Reset = false means don't reset the last read position data.
While having Reset = true is useful to ensure we always export all the data, it's getting slower and slower especially with PPS (86400) measurements X several channels.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ calnex export --source calnex01.example.com --channel d
{"float":{"value":-3.2908e-8},"int":{"time":1652464950},"normal":{"channel":"d","target":"1.2.3.4","protocol":"pps","source":"calnex01.example.com"}}
{"float":{"value":-3.5782e-8},"int":{"time":1652464951},"normal":{"channel":"d","target":"1.2.3.4","protocol":"pps","source":"calnex01.example.com"}}
```
```
$ calnex export --source calnex01.example.com --channel d
{"float":{"value":-3.4283e-8},"int":{"time":1652464952},"normal":{"channel":"d","target":"1.2.3.4","protocol":"pps","source":"calnex01.example.com"}}
{"float":{"value":-3.0296e-8},"int":{"time":1652464953},"normal":{"channel":"d","target":"1.2.3.4","protocol":"pps","source":"calnex01.example.com"}}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
