### PR TITLE
[c4u] check clock class > 0

### DIFF
--- a/ptp/c4u/clock/oscillatord.go
+++ b/ptp/c4u/clock/oscillatord.go
@@ -41,8 +41,7 @@ func oscillatorStateFromStatus(status *osc.Status) *oscillatorState {
 	}
 
 	// Safety check in case oscillatord returns an empty struct
-	// + Oscillatord being Unlock means we are Uncalibrated anyway.
-	if status.Oscillator.Lock {
+	if status.Clock.Class > 0 {
 		c.ClockClass = ptp.ClockClass(status.Clock.Class)
 		c.Offset = status.Clock.Offset
 	}

--- a/ptp/c4u/clock/oscillatord_test.go
+++ b/ptp/c4u/clock/oscillatord_test.go
@@ -67,7 +67,7 @@ func TestOscillatorStateFromStatus(t *testing.T) {
 	status.Clock.Class = osc.ClockClass(ptp.ClockClass52)
 	require.Equal(t, expectedUncalibrated, oscillatorStateFromStatus(status))
 
-	status.Oscillator.Lock = false
+	status.Clock.Class = 0
 	require.Equal(t, expectedFailed, oscillatorStateFromStatus(status))
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
We may be losing "lock" in a long holdover. We shouldn't switch to uncalibrated state and keep holdovering.
To check for empty struct its enough to just check the class > 0 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
INFO[0001] Current: &{ClockAccuracy:254 ClockClass:52 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
INFO[0001] Pending: &{ClockAccuracy:35 ClockClass:7 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
