### PR TITLE
[oscillatord] pass empty json to oscillatord

### DIFF
--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -264,7 +264,7 @@ func bool2int(b bool) int64 {
 // ReadStatus talks to oscillatord via monitoring port connection and reads reported Status
 func ReadStatus(conn io.ReadWriter) (*Status, error) {
 	// send newline to make oscillatord send us data
-	_, err := conn.Write([]byte{'\n'})
+	_, err := conn.Write([]byte(`{}`))
 	if err != nil {
 		return nil, fmt.Errorf("writing to oscillatord conn: %w", err)
 	}

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -30,8 +30,8 @@ func TestOscillatordRead(t *testing.T) {
 	defer client.Close()
 	defer server.Close()
 	go func() {
-		// read newline
-		b := make([]byte, 1)
+		// read empty json
+		b := make([]byte, 2)
 		_, err := server.Read(b)
 		require.Nil(t, err)
 		// write response
@@ -70,8 +70,8 @@ func TestOscillatordReadFail(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()
 	go func() {
-		// read newline
-		b := make([]byte, 1)
+		// read empty json
+		b := make([]byte, 2)
 		_, err := server.Read(b)
 		require.Nil(t, err)
 		server.Close()
@@ -85,8 +85,8 @@ func TestOscillatordReadGarbage(t *testing.T) {
 	defer client.Close()
 	defer server.Close()
 	go func() {
-		// read newline
-		b := make([]byte, 1)
+		// read empty json
+		b := make([]byte, 2)
 		_, err := server.Read(b)
 		require.Nil(t, err)
 		// write response


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Latest oscillatord only accepts a valid json, no more `\n`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
`ptpcheck` works
```
./ptpcheck oscillatord
Oscillator:
	model: mRO50
	fine_ctrl: 2105
	coarse_ctrl: 4186391
	lock: true
	temperature: 36.29C
GNSS:
	fix: 3D (5)
	fixOk: true
	antenna_power: ON (1)
	antenna_status: OPEN (4)
	leap_second_change: NO WARNING (0)
	leap_seconds: 18
	satellites_count: 27
Clock:
	class: Calibrating (13)
	offset: -25
```
`c4u` works:
```
Current: &{ClockAccuracy:254 ClockClass:52 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
Pending: &{ClockAccuracy:34 ClockClass:13 DrainInterval:30s MaxSubDuration:1h0m0s MetricInterval:1m0s MinSubInterval:1s UTCOffset:37s}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
