### PR TITLE
[oscillatord] report temperature as float in monitoring JSON

### DIFF
--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -236,8 +236,8 @@ func (s *Status) MonitoringJSON(prefix string) ([]byte, error) {
 		prefix = fmt.Sprintf("%s.", prefix)
 	}
 
-	output := map[string]int64{
-		fmt.Sprintf("%soscillator.temperature", prefix):  int64(s.Oscillator.Temperature),
+	output := map[string]any{
+		fmt.Sprintf("%soscillator.temperature", prefix):  s.Oscillator.Temperature,
 		fmt.Sprintf("%soscillator.fine_ctrl", prefix):    int64(s.Oscillator.FineCtrl),
 		fmt.Sprintf("%soscillator.coarse_ctrl", prefix):  int64(s.Oscillator.CoarseCtrl),
 		fmt.Sprintf("%soscillator.lock", prefix):         bool2int(s.Oscillator.Lock),

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -183,7 +183,7 @@ func TestClockClassUnmarshalText(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	expected := `{"ptp.timecard.clock.class":7,"ptp.timecard.clock.offset":-265095,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":10,"ptp.timecard.oscillator.coarse_ctrl":42,"ptp.timecard.oscillator.fine_ctrl":4242,"ptp.timecard.oscillator.lock":0,"ptp.timecard.oscillator.temperature":45}`
+	expected := `{"ptp.timecard.clock.class":7,"ptp.timecard.clock.offset":-265095,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":10,"ptp.timecard.oscillator.coarse_ctrl":42,"ptp.timecard.oscillator.fine_ctrl":4242,"ptp.timecard.oscillator.lock":0,"ptp.timecard.oscillator.temperature":45.944}`
 	s := &Status{
 		Oscillator: Oscillator{
 			Model:       "sa5x",


### PR DESCRIPTION
## Summary

More granular data for oscillator temperature.

## Test Plan

unittests

```
> ./ptpcheck oscillatord --json | jq .
{
  "ptp.timecard.clock.class": 6,
  "ptp.timecard.clock.offset": 11,
  "ptp.timecard.gnss.antenna_power": 1,
  "ptp.timecard.gnss.antenna_status": 4,
  "ptp.timecard.gnss.fix_num": 5,
  "ptp.timecard.gnss.fix_ok": 1,
  "ptp.timecard.gnss.leap_second_change": 0,
  "ptp.timecard.gnss.leap_seconds": 18,
  "ptp.timecard.gnss.satellites_count": 28,
  "ptp.timecard.oscillator.coarse_ctrl": 10000,
  "ptp.timecard.oscillator.fine_ctrl": -750,
  "ptp.timecard.oscillator.lock": 1,
  "ptp.timecard.oscillator.temperature": 42.655
}
```