### PR TITLE
Gnss survey

### DIFF
--- a/cmd/ptpcheck/cmd/oscillatord.go
+++ b/cmd/ptpcheck/cmd/oscillatord.go
@@ -58,6 +58,7 @@ func printOscillatord(status *oscillatord.Status) {
 	fmt.Printf("\tleap_second_change: %s (%d)\n", status.GNSS.LSChange, status.GNSS.LSChange)
 	fmt.Printf("\tleap_seconds: %d\n", status.GNSS.LeapSeconds)
 	fmt.Printf("\tsatellites_count: %d\n", status.GNSS.SatellitesCount)
+	fmt.Printf("\tsurvey_in_position_error: %d\n", status.GNSS.SurveyInPositionError)
 
 	fmt.Println("Clock:")
 	fmt.Printf("\tclass: %s (%d)\n", status.Clock.Class, status.Clock.Class)

--- a/oscillatord/monitoring.go
+++ b/oscillatord/monitoring.go
@@ -209,13 +209,14 @@ type Oscillator struct {
 
 // GNSS describes structure that oscillatord returns for gnss
 type GNSS struct {
-	Fix             GNSSFix          `json:"fix"`
-	FixOK           bool             `json:"fixOk"`
-	AntennaPower    AntennaPower     `json:"antenna_power"`
-	AntennaStatus   AntennaStatus    `json:"antenna_status"`
-	LSChange        LeapSecondChange `json:"lsChange"`
-	LeapSeconds     int              `json:"leap_seconds"`
-	SatellitesCount int              `json:"satellites_count"`
+	Fix                   GNSSFix          `json:"fix"`
+	FixOK                 bool             `json:"fixOk"`
+	AntennaPower          AntennaPower     `json:"antenna_power"`
+	AntennaStatus         AntennaStatus    `json:"antenna_status"`
+	LSChange              LeapSecondChange `json:"lsChange"`
+	LeapSeconds           int              `json:"leap_seconds"`
+	SatellitesCount       int              `json:"satellites_count"`
+	SurveyInPositionError int              `json:"survey_in_position_error"`
 }
 
 // Clock describes structure that oscillatord returns for clock
@@ -237,19 +238,20 @@ func (s *Status) MonitoringJSON(prefix string) ([]byte, error) {
 	}
 
 	output := map[string]any{
-		fmt.Sprintf("%soscillator.temperature", prefix):  s.Oscillator.Temperature,
-		fmt.Sprintf("%soscillator.fine_ctrl", prefix):    int64(s.Oscillator.FineCtrl),
-		fmt.Sprintf("%soscillator.coarse_ctrl", prefix):  int64(s.Oscillator.CoarseCtrl),
-		fmt.Sprintf("%soscillator.lock", prefix):         bool2int(s.Oscillator.Lock),
-		fmt.Sprintf("%sgnss.fix_num", prefix):            int64(s.GNSS.Fix),
-		fmt.Sprintf("%sgnss.fix_ok", prefix):             bool2int(s.GNSS.FixOK),
-		fmt.Sprintf("%sgnss.antenna_power", prefix):      int64(s.GNSS.AntennaPower),
-		fmt.Sprintf("%sgnss.antenna_status", prefix):     int64(s.GNSS.AntennaStatus),
-		fmt.Sprintf("%sgnss.leap_second_change", prefix): int64(s.GNSS.LSChange),
-		fmt.Sprintf("%sgnss.leap_seconds", prefix):       int64(s.GNSS.LeapSeconds),
-		fmt.Sprintf("%sgnss.satellites_count", prefix):   int64(s.GNSS.SatellitesCount),
-		fmt.Sprintf("%sclock.class", prefix):             int64(s.Clock.Class),
-		fmt.Sprintf("%sclock.offset", prefix):            int64(s.Clock.Offset),
+		fmt.Sprintf("%soscillator.temperature", prefix):        s.Oscillator.Temperature,
+		fmt.Sprintf("%soscillator.fine_ctrl", prefix):          int64(s.Oscillator.FineCtrl),
+		fmt.Sprintf("%soscillator.coarse_ctrl", prefix):        int64(s.Oscillator.CoarseCtrl),
+		fmt.Sprintf("%soscillator.lock", prefix):               bool2int(s.Oscillator.Lock),
+		fmt.Sprintf("%sgnss.fix_num", prefix):                  int64(s.GNSS.Fix),
+		fmt.Sprintf("%sgnss.fix_ok", prefix):                   bool2int(s.GNSS.FixOK),
+		fmt.Sprintf("%sgnss.antenna_power", prefix):            int64(s.GNSS.AntennaPower),
+		fmt.Sprintf("%sgnss.antenna_status", prefix):           int64(s.GNSS.AntennaStatus),
+		fmt.Sprintf("%sgnss.leap_second_change", prefix):       int64(s.GNSS.LSChange),
+		fmt.Sprintf("%sgnss.leap_seconds", prefix):             int64(s.GNSS.LeapSeconds),
+		fmt.Sprintf("%sgnss.satellites_count", prefix):         int64(s.GNSS.SatellitesCount),
+		fmt.Sprintf("%sgnss.survey_in_position_error", prefix): int64(s.GNSS.SurveyInPositionError),
+		fmt.Sprintf("%sclock.class", prefix):                   int64(s.Clock.Class),
+		fmt.Sprintf("%sclock.offset", prefix):                  int64(s.Clock.Offset),
 	}
 	return json.Marshal(output)
 }

--- a/oscillatord/monitoring_test.go
+++ b/oscillatord/monitoring_test.go
@@ -35,7 +35,7 @@ func TestOscillatordRead(t *testing.T) {
 		_, err := server.Read(b)
 		require.Nil(t, err)
 		// write response
-		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18, "satellites_count": 10 }, "clock": { "class": "Holdover", "offset": -265095 } }`
+		data := `{ "oscillator": { "model": "sa3x", "fine_ctrl": 0, "coarse_ctrl": 0, "lock": false, "temperature": 45.944000000000003 }, "gnss": { "fix": 5, "fixOk": true, "antenna_power": 1, "antenna_status": 4, "lsChange": 0, "leap_seconds": 18, "satellites_count": 10, "survey_in_position_error": 12 }, "clock": { "class": "Holdover", "offset": -265095 } }`
 		_, err = server.Write([]byte(data))
 		require.Nil(t, err)
 	}()
@@ -50,13 +50,14 @@ func TestOscillatordRead(t *testing.T) {
 			Temperature: 45.944,
 		},
 		GNSS: GNSS{
-			Fix:             Fix3D,
-			FixOK:           true,
-			AntennaPower:    AntPowerOn,
-			AntennaStatus:   AntStatusOpen,
-			LSChange:        LeapNoWarning,
-			LeapSeconds:     18,
-			SatellitesCount: 10,
+			Fix:                   Fix3D,
+			FixOK:                 true,
+			AntennaPower:          AntPowerOn,
+			AntennaStatus:         AntStatusOpen,
+			LSChange:              LeapNoWarning,
+			LeapSeconds:           18,
+			SatellitesCount:       10,
+			SurveyInPositionError: 12,
 		},
 		Clock: Clock{
 			Class:  ClockClassHoldover,
@@ -183,7 +184,7 @@ func TestClockClassUnmarshalText(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	expected := `{"ptp.timecard.clock.class":7,"ptp.timecard.clock.offset":-265095,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":10,"ptp.timecard.oscillator.coarse_ctrl":42,"ptp.timecard.oscillator.fine_ctrl":4242,"ptp.timecard.oscillator.lock":0,"ptp.timecard.oscillator.temperature":45.944}`
+	expected := `{"ptp.timecard.clock.class":7,"ptp.timecard.clock.offset":-265095,"ptp.timecard.gnss.antenna_power":1,"ptp.timecard.gnss.antenna_status":4,"ptp.timecard.gnss.fix_num":5,"ptp.timecard.gnss.fix_ok":1,"ptp.timecard.gnss.leap_second_change":0,"ptp.timecard.gnss.leap_seconds":18,"ptp.timecard.gnss.satellites_count":10,"ptp.timecard.gnss.survey_in_position_error":12,"ptp.timecard.oscillator.coarse_ctrl":42,"ptp.timecard.oscillator.fine_ctrl":4242,"ptp.timecard.oscillator.lock":0,"ptp.timecard.oscillator.temperature":45.944}`
 	s := &Status{
 		Oscillator: Oscillator{
 			Model:       "sa5x",
@@ -193,13 +194,14 @@ func TestJSON(t *testing.T) {
 			Temperature: 45.944,
 		},
 		GNSS: GNSS{
-			Fix:             Fix3D,
-			FixOK:           true,
-			AntennaPower:    AntPowerOn,
-			AntennaStatus:   AntStatusOpen,
-			LSChange:        LeapNoWarning,
-			LeapSeconds:     18,
-			SatellitesCount: 10,
+			Fix:                   Fix3D,
+			FixOK:                 true,
+			AntennaPower:          AntPowerOn,
+			AntennaStatus:         AntStatusOpen,
+			LSChange:              LeapNoWarning,
+			LeapSeconds:           18,
+			SatellitesCount:       10,
+			SurveyInPositionError: 12,
 		},
 		Clock: Clock{
 			Class:  ClockClassHoldover,


### PR DESCRIPTION
### Description:
Cover new monitoring values
### Test plan:
1. Socket sends this json:
```
{ "Action requested": "None", "disciplining": { "status": "LOCK_HIGH_RESOLUTION", "current_phase_convergence_count": -1, "valid_phase_convergence_threshold": -1, "convergence_progress": 0.0, "tracking_only": "false", "ready_for_holdover": "false" }, "clock": { "class": "Lock", "offset": 2 }, "oscillator": { "model": "sa5x", "fine_ctrl": -625, "coarse_ctrl": 10000, "lock": true, "temperature": 46.935000000000002 }, "gnss": { "fix": 3, "fixOk": true, "antenna_power": 1, "antenna_status": 2, "lsChange": 0, "leap_seconds": 18, "satellites_count": 27, "survey_in_position_error": 8 } }
```
2. ptpcheck shows:
```
Oscillator:
	model: sa5x
	fine_ctrl: -625
	coarse_ctrl: 10000
	lock: true
	temperature: 46.94C
GNSS:
	fix: Time (3)
	fixOk: true
	antenna_power: ON (1)
	antenna_status: OK (2)
	leap_second_change: NO WARNING (0)
	leap_seconds: 18
	satellites_count: 27
	survey_in_position_error: 8
Clock:
	class: Lock (6)
	offset: 2
```