### PR TITLE
[calnex] make reset configurable

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -386,7 +386,7 @@ func (p Probe) CalnexName() string {
 const (
 	// measureURL is a base URL for to the measurement API
 	measureURL = "https://%s/api/get/measure/%s"
-	dataURL    = "https://%s/api/getdata?channel=%s&datatype=%s&reset=false"
+	dataURL    = "https://%s/api/getdata?channel=%s&datatype=%s&reset=%t"
 
 	startMeasure = "https://%s/api/startmeasurement"
 	stopMeasure  = "https://%s/api/stopmeasurement"
@@ -436,8 +436,8 @@ func NewAPI(source string, insecureTLS bool) *API {
 
 // FetchCsv takes channel name (like 1, 2, c, d)
 // it returns list of CSV lines which is []string
-func (a *API) FetchCsv(channel Channel) ([][]string, error) {
-	url := fmt.Sprintf(dataURL, a.source, channel, MeasureChannelDatatypeMap[channel])
+func (a *API) FetchCsv(channel Channel, allData bool) ([][]string, error) {
+	url := fmt.Sprintf(dataURL, a.source, channel, MeasureChannelDatatypeMap[channel], allData)
 	resp, err := a.Client.Get(url)
 	if err != nil {
 		return nil, err

--- a/calnex/api/api_test.go
+++ b/calnex/api/api_test.go
@@ -147,7 +147,7 @@ func TestFetchCsv(t *testing.T) {
 	calnexAPI := NewAPI(parsed.Host, true)
 	calnexAPI.Client = ts.Client()
 	for _, channel := range legitChannelNames {
-		lines, err := calnexAPI.FetchCsv(channel)
+		lines, err := calnexAPI.FetchCsv(channel, true)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(lines))
 		require.Equal(t, sampleResp, strings.Join(lines[0], ","))
@@ -164,7 +164,7 @@ func TestFetchCsvNoData(t *testing.T) {
 	parsed, _ := url.Parse(ts.URL)
 	calnexAPI := NewAPI(parsed.Host, true)
 	calnexAPI.Client = ts.Client()
-	lines, err := calnexAPI.FetchCsv(ChannelVP22)
+	lines, err := calnexAPI.FetchCsv(ChannelVP22, true)
 	require.Error(t, err)
 	require.Nil(t, lines)
 }

--- a/calnex/cmd/cmd.go
+++ b/calnex/cmd/cmd.go
@@ -28,10 +28,11 @@ var RootCmd = &cobra.Command{
 }
 
 var (
+	allData     bool
 	apply       bool
-	insecureTLS bool
 	channels    []string
 	dir         string
+	insecureTLS bool
 	source      string
 	target      string
 )

--- a/calnex/cmd/export.go
+++ b/calnex/cmd/export.go
@@ -27,8 +27,9 @@ import (
 
 func init() {
 	RootCmd.AddCommand(exportCmd)
-	exportCmd.Flags().StringArrayVar(&channels, "channel", []string{}, "Channel name. Ex: 1, 2, c ,d, VP1. Repeat for multiple. Skip for auto-detection")
+	exportCmd.Flags().BoolVar(&allData, "allData", true, "Export entire data from device every run. Set false for unread only")
 	exportCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
+	exportCmd.Flags().StringArrayVar(&channels, "channel", []string{}, "Channel name. Ex: 1, 2, c ,d, VP1. Repeat for multiple. Skip for auto-detection")
 	exportCmd.Flags().StringVar(&source, "source", "localhost", "Source of the data. Ex: calnex01.example.com")
 	if err := exportCmd.MarkFlagRequired("source"); err != nil {
 		log.Fatal(err)
@@ -48,7 +49,7 @@ var exportCmd = &cobra.Command{
 			chs = append(chs, *c)
 		}
 		l := export.JSONLogger{Out: os.Stdout}
-		if err := export.Export(source, insecureTLS, chs, l); err != nil {
+		if err := export.Export(source, insecureTLS, allData, chs, l); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/calnex/export/export.go
+++ b/calnex/export/export.go
@@ -27,7 +27,7 @@ var errNoUsedChannels = errors.New("no used channels")
 var errNoTarget = errors.New("no target succeeds")
 
 // Export data from the device about specified channels to the specified output
-func Export(source string, insecureTLS bool, channels []api.Channel, l Logger) (err error) {
+func Export(source string, insecureTLS bool, allData bool, channels []api.Channel, l Logger) (err error) {
 	var success bool
 	calnexAPI := api.NewAPI(source, insecureTLS)
 
@@ -53,7 +53,7 @@ func Export(source string, insecureTLS bool, channels []api.Channel, l Logger) (
 			success = success || false
 			continue
 		}
-		csvLines, err := calnexAPI.FetchCsv(channel)
+		csvLines, err := calnexAPI.FetchCsv(channel, allData)
 		if err != nil {
 			log.Errorf("Failed to fetch data from channel %s: %v", channel, err)
 			success = success || false

--- a/calnex/export/export_test.go
+++ b/calnex/export/export_test.go
@@ -80,15 +80,15 @@ func TestExport(t *testing.T) {
 		fmt.Sprintf("{\"float\":{\"value\":-2.50504e-7},\"int\":{\"time\":1607961194},\"normal\":{\"channel\":\"VP1\",\"target\":\"127.0.0.1\",\"protocol\":\"ntp\",\"source\":\"%s\"}}\n", parsed.Host),
 		fmt.Sprintf("{\"float\":{\"value\":-2.50501e-7},\"int\":{\"time\":1607961193},\"normal\":{\"channel\":\"a\",\"target\":\"127.0.0.1\",\"protocol\":\"pps\",\"source\":\"%s\"}}\n", parsed.Host),
 	}
-	err := Export(parsed.Host, true, []api.Channel{}, l)
+	err := Export(parsed.Host, true, true, []api.Channel{}, l)
 	require.NoError(t, err)
 	require.ElementsMatch(t, expected, w.data)
 }
 
 func TestExportFail(t *testing.T) {
-	err := Export("localhost", true, []api.Channel{}, nil)
+	err := Export("localhost", true, true, []api.Channel{}, nil)
 	require.ErrorIs(t, errNoUsedChannels, err)
 
-	err = Export("localhost", true, []api.Channel{api.ChannelONE}, nil)
+	err = Export("localhost", true, true, []api.Channel{api.ChannelONE}, nil)
 	require.ErrorIs(t, errNoTarget, err)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
If we simply keep reset=false by default we will no be able to run 2 exports in parallel (for debug purposes for example) because we will lose the data in between.
Make reset=true by default (every time export all data) and make reset=false configurable with a bit saner name (`allData`). We will make sure export scripts run with `reset=false` and by default human will run with `reset=true` not to lose data.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
```
$ calnex -- export --source calnex01.example.com --channel d
```
Dumps all the data

```
$ calnex -- export --source calnex01.example.com --channel d --allData=false
```
Only dumps unread data

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
