### PR TITLE
Update cmd/README with "go install"

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -8,12 +8,6 @@ CLI and library to perform various NTP-related tasks, including:
 
 ### Quick Installation
 ```console
-go get github.com/facebook/time/cmd/ntpcheck
-```
-
-If you are using Go 1.18, please run:
-
-```console
 go install github.com/facebook/time/cmd/ntpcheck@latest
 ```
 
@@ -40,7 +34,7 @@ CLI and library to perform various PTP-related tasks, including:
 
 ### Quick Installation
 ```console
-go get github.com/facebook/time/cmd/ptpcheck
+go install github.com/facebook/time/cmd/ptpcheck@latest
 ```
 
 ## ptp4u
@@ -51,7 +45,7 @@ Config generator for ptp4u.
 
 ### Quick Installation
 ```console
-go get github.com/facebook/time/cmd/ptp4u
+go install github.com/facebook/time/cmd/ptp4u@latest
 ```
 
 # Calnex

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -11,6 +11,12 @@ CLI and library to perform various NTP-related tasks, including:
 go get github.com/facebook/time/cmd/ntpcheck
 ```
 
+If you are using Go 1.18, please run:
+
+```console
+go install github.com/facebook/time/cmd/ntpcheck@latest
+```
+
 ## NTPResponder
 Simple NTP server implementation with kernel timestamps support
 


### PR DESCRIPTION
## Summary

As of Go 1.18, `go get` is deprecated for installing executables.

This commit adds `go install github.com/facebook/time/cmd/ntpcheck@latest` to section quick install as install command with Go 1.18.

https://go.dev/doc/go-get-install-deprecation

## Test Plan

This pull request changes cmd/README.md only, there are no code changes.