### PR TITLE
[calnex] set tie_mode to TIE + 1 PPS Alignment

### DIFF
--- a/calnex/config/config.go
+++ b/calnex/config/config.go
@@ -138,8 +138,8 @@ func (c *config) baseConfig(s *ini.Section) {
 	// 25h measurement
 	c.set(s, "meas_time", "1 days 1 hours")
 
-	// tie_mode=TIE + 1 PPS TE
-	c.set(s, "tie_mode", "TIE + 1 PPS TE")
+	// tie_mode=TIE + 1 PPS Alignment
+	c.set(s, "tie_mode", "TIE + 1 PPS Alignment")
 
 	// ch8 is a ref channel. Always ON
 	c.set(s, "ch8\\used", api.YES)

--- a/calnex/config/config_test.go
+++ b/calnex/config/config_test.go
@@ -74,7 +74,7 @@ ch8\used=No
 	expectedConfig := `[measure]
 continuous=On
 meas_time=1 days 1 hours
-tie_mode=TIE + 1 PPS TE
+tie_mode=TIE + 1 PPS Alignment
 ch8\used=Yes
 ch6\synce_enabled=Off
 ch7\synce_enabled=Off
@@ -406,7 +406,7 @@ func TestConfig(t *testing.T) {
 	expectedConfig := `[measure]
 continuous=On
 meas_time=1 days 1 hours
-tie_mode=TIE + 1 PPS TE
+tie_mode=TIE + 1 PPS Alignment
 ch0\used=Yes
 ch1\used=No
 ch2\used=No


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Enable a special PPS mode to avoid 1s jumps
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

```
$ config --target calnex.example.com --apply
INFO[0004] setting tie_mode to TIE + 1 PPS Alignment
INFO[0004] pushing the config
INFO[0026] starting measurement
```
UI accepted the change
<img width="372" alt="image" src="https://user-images.githubusercontent.com/4749052/174782440-a1746a52-45e8-4307-8add-4cc114eb5cbc.png">
Measurements are collected fine
<img width="620" alt="image" src="https://user-images.githubusercontent.com/4749052/174782562-3198604b-3942-46bc-b269-a2c5f0920ec1.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
