### PR TITLE
Enable fuzzing in ptp/protocol tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,6 @@ jobs:
       - run: sudo apt-get install libpcap-dev
       - run: go build -v ./...
       - run: go test -v -race -coverprofile=coverage.txt ./...
+      # fuzzing for ptp/protocol, can't use it with multiple packages
+      - run: go test -v -fuzz='.*' -fuzztime=1m ./ptp/protocol/
       - uses: codecov/codecov-action@v2


### PR DESCRIPTION
## Summary

We now have fuzzing tests in `ptp/protocol`, let's run them on PRs.

## Test Plan

Look at CI for this change.
