### PR TITLE
[ptp/protocol] support more TLVs

### DIFF
--- a/ptp/protocol/doc.go
+++ b/ptp/protocol/doc.go
@@ -22,8 +22,46 @@ Implementation is focused on unicast communications over IPv6 and is sufficient 
 This package also contains basic management client that can be used to exchange Management Packets
 with ptp server.
 
-Additionally it has helpers to work with NIC hardware and software timestamps.
-
 All references throughout the code relate to the IEEE 1588-2019 Standard.
+
+Implemented protocol parts include:
+
+Marshalling and unmarshalling of defined PTP messages
+
+    Sync
+    Delay_Req
+    Pdelay_Req
+    Pdelay_Resp
+    Follow_Up
+    Delay_Resp
+    Pdelay_Resp_Follow_Up
+    Announce
+    Signaling
+    Management
+
+TLVs
+
+    MANAGEMENT
+    MANAGEMENT_ERROR_STATUS
+    REQUEST_UNICAST_TRANSMISSION
+    GRANT_UNICAST_TRANSMISSION
+    CANCEL_UNICAST_TRANSMISSION
+    ACKNOWLEDGE_CANCEL_UNICAST_TRANSMISSION
+    PATH_TRACE
+    ALTERNATE_TIME_OFFSET_INDICATOR
+
+Management TLVs
+
+    DEFAULT_DATA_SET
+    CURRENT_DATA_SET
+    PARENT_DATA_SET
+
+Non-portable ptp4l-specific Management TLVs
+
+    TIME_STATUS_NP
+    PORT_PROPERTIES_NP
+    PORT_STATS_NP
+    PORT_SERVICE_STATS_NP
+    UNICAST_MASTER_TABLE_NP
 */
 package protocol

--- a/ptp/protocol/tlvs.go
+++ b/ptp/protocol/tlvs.go
@@ -1,0 +1,367 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// TLV abstracts away any TLV
+type TLV interface {
+	Type() TLVType
+}
+
+const tlvHeadSize = 4
+
+// TLVHead is a common part of all TLVs
+type TLVHead struct {
+	TLVType     TLVType
+	LengthField uint16 // The length of all TLVs shall be an even number of octets
+}
+
+// Type implements TLV interface
+func (t TLVHead) Type() TLVType {
+	return t.TLVType
+}
+
+func tlvHeadMarshalBinaryTo(t *TLVHead, b []byte) {
+	binary.BigEndian.PutUint16(b, uint16(t.TLVType))
+	binary.BigEndian.PutUint16(b[2:], t.LengthField)
+}
+
+func unmarshalTLVHeader(p *TLVHead, b []byte) error {
+	if len(b) < tlvHeadSize {
+		return fmt.Errorf("not enough data to decode PTP header")
+	}
+	p.TLVType = TLVType(binary.BigEndian.Uint16(b[0:]))
+	p.LengthField = binary.BigEndian.Uint16(b[2:])
+	return nil
+}
+
+func checkTLVLength(p *TLVHead, l, want int, strict bool) error {
+	if strict && int(p.LengthField) != want {
+		return fmt.Errorf("expected TLV of type %s (%d) to have length of %d, got %d in the header", p.TLVType, p.TLVType, want, p.LengthField)
+	}
+
+	if int(p.LengthField) < want {
+		return fmt.Errorf("expected TLV of type %s (%d) to have length of at least %d, got %d in the header", p.TLVType, p.TLVType, want, p.LengthField)
+	}
+	if tlvHeadSize+int(p.LengthField) > l {
+		return fmt.Errorf("cannot decode TLV of length %d from %d bytes", tlvHeadSize+int(p.LengthField), l)
+	}
+	return nil
+}
+
+func writeTLVs(tlvs []TLV, b []byte) (int, error) {
+	pos := 0
+	for _, tlv := range tlvs {
+		if ttlv, ok := tlv.(BinaryMarshalerTo); ok {
+			nn, err := ttlv.MarshalBinaryTo(b[pos:])
+			if err != nil {
+				return 0, err
+			}
+			pos += nn
+			continue
+		}
+		// very inefficient path for TLVs that don't support MarshalBinaryTo
+		buf := new(bytes.Buffer)
+		if err := binary.Write(buf, binary.BigEndian, tlv); err != nil {
+			return 0, err
+		}
+		bbytes := buf.Bytes()
+		copy(b[pos:], bbytes)
+		pos += len(bbytes)
+	}
+	return pos, nil
+}
+
+func readTLVs(tlvs []TLV, maxLength int, b []byte) ([]TLV, error) {
+	pos := 0
+	var tlvType TLVType
+	for {
+		// packet can have trailing bytes, let's make sure we don't try to read past given length
+		if pos+tlvHeadSize > maxLength {
+			break
+		}
+		tlvType = TLVType(binary.BigEndian.Uint16(b[pos:]))
+
+		switch tlvType {
+		case TLVAcknowledgeCancelUnicastTransmission:
+			tlv := &AcknowledgeCancelUnicastTransmissionTLV{}
+			if err := tlv.UnmarshalBinary(b[pos:]); err != nil {
+				return tlvs, err
+			}
+			tlvs = append(tlvs, tlv)
+			pos += tlvHeadSize + int(tlv.LengthField)
+
+		case TLVGrantUnicastTransmission:
+			tlv := &GrantUnicastTransmissionTLV{}
+			if err := tlv.UnmarshalBinary(b[pos:]); err != nil {
+				return tlvs, err
+			}
+			tlvs = append(tlvs, tlv)
+			pos += tlvHeadSize + int(tlv.LengthField)
+
+		case TLVRequestUnicastTransmission:
+			tlv := &RequestUnicastTransmissionTLV{}
+			if err := tlv.UnmarshalBinary(b[pos:]); err != nil {
+				return tlvs, err
+			}
+			tlvs = append(tlvs, tlv)
+			pos += tlvHeadSize + int(tlv.LengthField)
+		case TLVCancelUnicastTransmission:
+			tlv := &CancelUnicastTransmissionTLV{}
+			if err := tlv.UnmarshalBinary(b[pos:]); err != nil {
+				return tlvs, err
+			}
+			tlvs = append(tlvs, tlv)
+			pos += tlvHeadSize + int(tlv.LengthField)
+		case TLVPathTrace:
+			tlv := &PathTraceTLV{}
+			if err := tlv.UnmarshalBinary(b[pos:]); err != nil {
+				return tlvs, err
+			}
+			tlvs = append(tlvs, tlv)
+			pos += tlvHeadSize + int(tlv.LengthField)
+		case TLVAlternateTimeOffsetIndicator:
+			tlv := &AlternateTimeOffsetIndicatorTLV{}
+			if err := tlv.UnmarshalBinary(b[pos:]); err != nil {
+				return tlvs, err
+			}
+			tlvs = append(tlvs, tlv)
+			pos += tlvHeadSize + int(tlv.LengthField)
+		default:
+			return tlvs, fmt.Errorf("reading TLV %s (%d) is not yet implemented", tlvType, tlvType)
+		}
+	}
+	return tlvs, nil
+}
+
+// Unicast TLVs
+
+// RequestUnicastTransmissionTLV Table 110 REQUEST_UNICAST_TRANSMISSION TLV format
+type RequestUnicastTransmissionTLV struct {
+	TLVHead
+	MsgTypeAndReserved    UnicastMsgTypeAndFlags // first 4 bits only, same enums as with normal message type
+	LogInterMessagePeriod LogInterval
+	DurationField         uint32
+}
+
+// MarshalBinaryTo marshals bytes to RequestUnicastTransmissionTLV
+func (t *RequestUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
+	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
+	b[tlvHeadSize] = byte(t.MsgTypeAndReserved)
+	b[tlvHeadSize+1] = byte(t.LogInterMessagePeriod)
+	binary.BigEndian.PutUint32(b[tlvHeadSize+2:], t.DurationField)
+	return tlvHeadSize + 6, nil
+}
+
+// UnmarshalBinary parses []byte and populates struct fields
+func (t *RequestUnicastTransmissionTLV) UnmarshalBinary(b []byte) error {
+	if err := unmarshalTLVHeader(&t.TLVHead, b); err != nil {
+		return err
+	}
+	if err := checkTLVLength(&t.TLVHead, len(b), 6, true); err != nil {
+		return err
+	}
+	t.MsgTypeAndReserved = UnicastMsgTypeAndFlags(b[4])
+	t.LogInterMessagePeriod = LogInterval(b[5])
+	t.DurationField = binary.BigEndian.Uint32(b[6:])
+	return nil
+}
+
+// GrantUnicastTransmissionTLV Table 111 GRANT_UNICAST_TRANSMISSION TLV format
+type GrantUnicastTransmissionTLV struct {
+	TLVHead
+	MsgTypeAndReserved    UnicastMsgTypeAndFlags // first 4 bits only, same enums as with normal message type
+	LogInterMessagePeriod LogInterval
+	DurationField         uint32
+	Reserved              uint8
+	Renewal               uint8
+}
+
+// MarshalBinaryTo marshals bytes to GrantUnicastTransmissionTLV
+func (t *GrantUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
+	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
+	b[tlvHeadSize] = byte(t.MsgTypeAndReserved)
+	b[tlvHeadSize+1] = byte(t.LogInterMessagePeriod)
+	binary.BigEndian.PutUint32(b[tlvHeadSize+2:], t.DurationField)
+	b[tlvHeadSize+6] = t.Reserved
+	b[tlvHeadSize+7] = t.Renewal
+	return tlvHeadSize + 8, nil
+}
+
+// UnmarshalBinary parses []byte and populates struct fields
+func (t *GrantUnicastTransmissionTLV) UnmarshalBinary(b []byte) error {
+	if err := unmarshalTLVHeader(&t.TLVHead, b); err != nil {
+		return err
+	}
+	if err := checkTLVLength(&t.TLVHead, len(b), 8, true); err != nil {
+		return err
+	}
+	t.MsgTypeAndReserved = UnicastMsgTypeAndFlags(b[4])
+	t.LogInterMessagePeriod = LogInterval(b[5])
+	t.DurationField = binary.BigEndian.Uint32(b[6:])
+	t.Reserved = b[10]
+	t.Renewal = b[11]
+	return nil
+}
+
+// CancelUnicastTransmissionTLV Table 112 CANCEL_UNICAST_TRANSMISSION TLV format
+type CancelUnicastTransmissionTLV struct {
+	TLVHead
+	MsgTypeAndFlags UnicastMsgTypeAndFlags // first 4 bits is msg type, then flags R and/or G
+	Reserved        uint8
+}
+
+// MarshalBinaryTo marshals bytes to CancelUnicastTransmissionTLV
+func (t *CancelUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
+	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
+	b[tlvHeadSize] = byte(t.MsgTypeAndFlags)
+	b[tlvHeadSize+1] = byte(t.Reserved)
+	return tlvHeadSize + 2, nil
+}
+
+// UnmarshalBinary parses []byte and populates struct fields
+func (t *CancelUnicastTransmissionTLV) UnmarshalBinary(b []byte) error {
+	if err := unmarshalTLVHeader(&t.TLVHead, b); err != nil {
+		return err
+	}
+	if err := checkTLVLength(&t.TLVHead, len(b), 2, true); err != nil {
+		return err
+	}
+	t.MsgTypeAndFlags = UnicastMsgTypeAndFlags(b[4])
+	t.Reserved = b[5]
+	return nil
+}
+
+// AcknowledgeCancelUnicastTransmissionTLV Table 113 ACKNOWLEDGE_CANCEL_UNICAST_TRANSMISSION TLV format
+type AcknowledgeCancelUnicastTransmissionTLV struct {
+	TLVHead
+	MsgTypeAndFlags UnicastMsgTypeAndFlags // first 4 bits is msg type, then flags R and/or G
+	Reserved        uint8
+}
+
+// MarshalBinaryTo marshals bytes to AcknowledgeCancelUnicastTransmissionTLV
+func (t *AcknowledgeCancelUnicastTransmissionTLV) MarshalBinaryTo(b []byte) (int, error) {
+	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
+	b[tlvHeadSize] = byte(t.MsgTypeAndFlags)
+	b[tlvHeadSize+1] = byte(t.Reserved)
+	return tlvHeadSize + 2, nil
+}
+
+// UnmarshalBinary parses []byte and populates struct fields
+func (t *AcknowledgeCancelUnicastTransmissionTLV) UnmarshalBinary(b []byte) error {
+	if err := unmarshalTLVHeader(&t.TLVHead, b); err != nil {
+		return err
+	}
+	if err := checkTLVLength(&t.TLVHead, len(b), 2, true); err != nil {
+		return err
+	}
+	t.MsgTypeAndFlags = UnicastMsgTypeAndFlags(b[4])
+	t.Reserved = b[5]
+	return nil
+}
+
+// other TLVs
+
+// PathTraceTLV Table 115 PATH_TRACE TLV format
+type PathTraceTLV struct {
+	TLVHead
+	// The value of the lengthField is 8N.
+	PathSequence []ClockIdentity // N
+}
+
+// MarshalBinaryTo marshals bytes to PathTraceTLV
+func (t *PathTraceTLV) MarshalBinaryTo(b []byte) (int, error) {
+	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
+	pos := tlvHeadSize
+	for _, ps := range t.PathSequence {
+		binary.BigEndian.PutUint64(b[pos:pos+8], uint64(ps))
+		pos += 8
+	}
+	return pos, nil
+}
+
+// UnmarshalBinary parses []byte and populates struct fields
+func (t *PathTraceTLV) UnmarshalBinary(b []byte) error {
+	if err := unmarshalTLVHeader(&t.TLVHead, b); err != nil {
+		return err
+	}
+	if err := checkTLVLength(&t.TLVHead, len(b), 8, false); err != nil {
+		return err
+	}
+	t.PathSequence = []ClockIdentity{}
+	for i := 0; i*8 <= int(t.TLVHead.LengthField); i++ {
+		pos := tlvHeadSize + i*8
+		if pos+8 >= len(b) {
+			break
+		}
+		identity := ClockIdentity(binary.BigEndian.Uint64(b[pos:]))
+		t.PathSequence = append(t.PathSequence, identity)
+	}
+	return nil
+}
+
+// Table 116 ALTERNATE_TIME_OFFSET_INDICATOR TLV format
+type AlternateTimeOffsetIndicatorTLV struct {
+	TLVHead
+	KeyField       uint8
+	CurrentOffset  int32
+	JumpSeconds    int32
+	TimeOfNextJump PTPSeconds // uint48
+	DisplayName    PTPText
+}
+
+// MarshalBinaryTo marshals bytes to AlternateTimeOffsetIndicatorTLV
+func (t *AlternateTimeOffsetIndicatorTLV) MarshalBinaryTo(b []byte) (int, error) {
+	tlvHeadMarshalBinaryTo(&t.TLVHead, b)
+	b[tlvHeadSize] = byte(t.KeyField)
+	binary.BigEndian.PutUint32(b[tlvHeadSize+1:], uint32(t.CurrentOffset))
+	binary.BigEndian.PutUint32(b[tlvHeadSize+5:], uint32(t.JumpSeconds))
+	copy(b[tlvHeadSize+9:], t.TimeOfNextJump[:]) //uint48
+	size := tlvHeadSize + 15
+	if t.DisplayName != "" {
+		dd, err := t.DisplayName.MarshalBinary()
+		if err != nil {
+			return 0, fmt.Errorf("writing AlternateTimeOffsetIndicatorTLV DisplayName: %w", err)
+		}
+		copy(b[tlvHeadSize+15:], dd)
+		size += len(dd)
+	}
+	return size, nil
+}
+
+// UnmarshalBinary parses []byte and populates struct fields
+func (t *AlternateTimeOffsetIndicatorTLV) UnmarshalBinary(b []byte) error {
+	if err := unmarshalTLVHeader(&t.TLVHead, b); err != nil {
+		return err
+	}
+	if err := checkTLVLength(&t.TLVHead, len(b), 20, false); err != nil {
+		return err
+	}
+	t.KeyField = uint8(b[tlvHeadSize])
+	t.CurrentOffset = int32(binary.BigEndian.Uint32(b[tlvHeadSize+1:]))
+	t.JumpSeconds = int32(binary.BigEndian.Uint32(b[tlvHeadSize+5:]))
+	copy(t.TimeOfNextJump[:], b[tlvHeadSize+9:]) // uint48
+	if err := t.DisplayName.UnmarshalBinary(b[tlvHeadSize+15:]); err != nil {
+		return fmt.Errorf("reading AlternateTimeOffsetIndicatorTLV DisplayName: %w", err)
+	}
+	return nil
+}

--- a/ptp/protocol/tlvs_test.go
+++ b/ptp/protocol/tlvs_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLVHeadType(t *testing.T) {
+	head := &TLVHead{
+		TLVType:     TLVRequestUnicastTransmission,
+		LengthField: 10,
+	}
+	require.Equal(t, TLVRequestUnicastTransmission, head.Type())
+}
+
+func TestParseAnnounceWithPathTrace(t *testing.T) {
+	raw := []uint8("\x0b\x12\x00\x4c\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\xc0\xeb\xff\xfe\x63\x7a\x4e\x00\x01\x00\x00\x05\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x25\x00\x80\xf8\xfe\xff\xff\x80\x08\xc0\xeb\xff\xfe\x63\x7a\x4e\x00\x00\xa0\x00\x08\x00\x18\x08\xc0\xeb\xff\xfe\x63\x7a\x4e\x01\xb6\xaf\xc4\xe5\x46\x12\x29\x04\xc0\x87\x32\xf0\x61\xee\xce\x00\x00")
+	packet := new(Announce)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := Announce{
+		Header: Header{
+			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageAnnounce, 0),
+			Version:         Version,
+			MessageLength:   76,
+			DomainNumber:    0,
+			FlagField:       FlagUnicast | FlagPTPTimescale,
+			SequenceID:      0,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 630763432548989518,
+			},
+			LogMessageInterval: 1,
+			ControlField:       5,
+		},
+		AnnounceBody: AnnounceBody{
+			CurrentUTCOffset:     37,
+			Reserved:             0,
+			GrandmasterPriority1: 128,
+			GrandmasterClockQuality: ClockQuality{
+				ClockClass:              248,
+				ClockAccuracy:           254,
+				OffsetScaledLogVariance: 65535,
+			},
+			GrandmasterPriority2: 128,
+			GrandmasterIdentity:  630763432548989518,
+			StepsRemoved:         0,
+			TimeSource:           TimeSourceInternalOscillator,
+		},
+		TLVs: []TLV{
+			&PathTraceTLV{
+				TLVHead: TLVHead{
+					TLVType:     TLVPathTrace,
+					LengthField: 24,
+				},
+				PathSequence: []ClockIdentity{
+					630763432548989518,
+					123479299994292777,
+					342422224531222222,
+				},
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+
+	// test generic DecodePacket as well
+	pp, err := DecodePacket(b)
+	require.Nil(t, err)
+	assert.Equal(t, &want, pp)
+}
+
+func TestParseAnnounceWithAlternateTimeOffsetIndicator(t *testing.T) {
+	raw := []uint8("\x0b\x12\x00\x5a\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\xc0\xeb\xff\xfe\x63\x7a\x4e\x00\x01\x00\x00\x05\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x25\x00\x80\xf8\xfe\xff\xff\x80\x08\xc0\xeb\xff\xfe\x63\x7a\x4e\x00\x00\xa0\x00\x09\x00\x16\x01\x00\x00\x00\x25\x00\x00\x00\x01\x00\x00\x62\xc2\xfd\xb6\x03\x50\x54\x50\x00\x00\x00")
+	packet := new(Announce)
+	err := FromBytes(raw, packet)
+	require.Nil(t, err)
+	want := Announce{
+		Header: Header{
+			SdoIDAndMsgType: NewSdoIDAndMsgType(MessageAnnounce, 0),
+			Version:         Version,
+			MessageLength:   90,
+			DomainNumber:    0,
+			FlagField:       FlagUnicast | FlagPTPTimescale,
+			SequenceID:      0,
+			SourcePortIdentity: PortIdentity{
+				PortNumber:    1,
+				ClockIdentity: 630763432548989518,
+			},
+			LogMessageInterval: 1,
+			ControlField:       5,
+		},
+		AnnounceBody: AnnounceBody{
+			CurrentUTCOffset:     37,
+			Reserved:             0,
+			GrandmasterPriority1: 128,
+			GrandmasterClockQuality: ClockQuality{
+				ClockClass:              248,
+				ClockAccuracy:           254,
+				OffsetScaledLogVariance: 65535,
+			},
+			GrandmasterPriority2: 128,
+			GrandmasterIdentity:  630763432548989518,
+			StepsRemoved:         0,
+			TimeSource:           TimeSourceInternalOscillator,
+		},
+		TLVs: []TLV{
+			&AlternateTimeOffsetIndicatorTLV{
+				TLVHead: TLVHead{
+					TLVType:     TLVAlternateTimeOffsetIndicator,
+					LengthField: 22,
+				},
+				KeyField:       0x01,
+				CurrentOffset:  37,
+				JumpSeconds:    1,
+				TimeOfNextJump: NewPTPSeconds(time.Unix(1656946102, 0)),
+				DisplayName:    PTPText("PTP"),
+			},
+		},
+	}
+	require.Equal(t, want, *packet)
+	b, err := Bytes(packet)
+	require.Nil(t, err)
+	assert.Equal(t, raw, b)
+
+	// test generic DecodePacket as well
+	pp, err := DecodePacket(raw)
+	require.Nil(t, err)
+	assert.Equal(t, &want, pp)
+}

--- a/ptp/protocol/types_test.go
+++ b/ptp/protocol/types_test.go
@@ -68,14 +68,6 @@ func TestProbeMsgType(t *testing.T) {
 	}
 }
 
-func TestTLVHeadType(t *testing.T) {
-	head := &TLVHead{
-		TLVType:     TLVRequestUnicastTransmission,
-		LengthField: 10,
-	}
-	require.Equal(t, TLVRequestUnicastTransmission, head.Type())
-}
-
 func TestMessageTypeString(t *testing.T) {
 	require.Equal(t, "SYNC", MessageSync.String())
 	require.Equal(t, "DELAY_REQ", MessageDelayReq.String())
@@ -167,6 +159,36 @@ func TestTimeIntervalNanoseconds(t *testing.T) {
 			// then convert time.Time we just got back to Timestamp
 			gotTI := NewTimeInterval(got)
 			assert.Equal(t, tt.in, gotTI)
+		})
+	}
+}
+
+func TestPTPSeconds(t *testing.T) {
+	tests := []struct {
+		in      PTPSeconds
+		want    time.Time
+		wantStr string
+	}{
+		{
+			in:      [6]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x02},
+			want:    time.Unix(2, 0),
+			wantStr: fmt.Sprintf("PTPSeconds(%s)", time.Unix(2, 0)),
+		},
+		{
+			in:      [6]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+			want:    time.Time{},
+			wantStr: "PTPSeconds(empty)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("PTPSeconds t=%d", tt.in), func(t *testing.T) {
+			// first, convert from PTPSeconds to time.Time
+			got := tt.in.Time()
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantStr, tt.in.String())
+			// then convert time.Time we just got back to PTPSeconds
+			gotTS := NewPTPSeconds(got)
+			assert.Equal(t, tt.in, gotTS)
 		})
 	}
 }

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -244,7 +244,7 @@ func (sc *SubscriptionClient) initAnnounce() {
 		Header: ptp.Header{
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageAnnounce, 0),
 			Version:         ptp.Version,
-			MessageLength:   uint16(binary.Size(ptp.Announce{})),
+			MessageLength:   uint16(binary.Size(ptp.Announce{}) + binary.Size(ptp.AnnounceBody{})),
 			DomainNumber:    0,
 			FlagField:       ptp.FlagUnicast | ptp.FlagPTPTimescale,
 			SequenceID:      0,

--- a/ptp/simpleclient/client_test.go
+++ b/ptp/simpleclient/client_test.go
@@ -88,7 +88,7 @@ func cancelUnicastPkt(seq int, clockID ptp.ClockIdentity, what ptp.MessageType) 
 }
 
 func announcePkt(seq int) *ptp.Announce {
-	l := binary.Size(ptp.Announce{})
+	l := binary.Size(ptp.Announce{}) + binary.Size(ptp.AnnounceBody{})
 	return &ptp.Announce{
 		Header: ptp.Header{
 			SdoIDAndMsgType:    ptp.NewSdoIDAndMsgType(ptp.MessageAnnounce, 0),


### PR DESCRIPTION
## Summary

In the old repo (now archived) we had this issue https://github.com/facebookarchive/ptp/issues/30 saying we don't support path tracing.

This change:
* adds more TLVs (PATH_TRACE and ALTERNATE_TIME_OFFSET_INDICATOR)
* allows Announce msgs to have TLVs (as per standard any packet can have TLVs in the suffix).
* adds `PTPSeconds` type


Closes https://github.com/facebookarchive/ptp/issues/30

## Test Plan

unittests

**benchmarks** show that there is no regression

was:
```
abulimov@devvm1655 ~/g/time > go test github.com/facebook/time/ptp/protocol/... -bench=. -benchmem
goarch: amd64
pkg: github.com/facebook/time/ptp/protocol
cpu: Intel Core Processor (Broadwell)
BenchmarkReadSyncDelay-24       66118900                17.17 ns/op            0 B/op          0 allocs/op
BenchmarkWriteSync-24           55006518                22.52 ns/op            0 B/op          0 allocs/op
BenchmarkWriteFollowup-24       53691462                22.47 ns/op            0 B/op          0 allocs/op
BenchmarkWriteSignaling-24      30661101                38.18 ns/op            0 B/op          0 allocs/op
BenchmarkReadSignaling-24        6474985               192.9 ns/op            97 B/op          1 allocs/op
PASS
ok      github.com/facebook/time/ptp/protocol   6.361s
```

now:
```
abulimov@devvm1655 ~/g/time > go test github.com/facebook/time/ptp/protocol/... -bench=. -benchmem
goos: linux
goarch: amd64
pkg: github.com/facebook/time/ptp/protocol
cpu: Intel Core Processor (Broadwell)
BenchmarkReadSyncDelay-24               66644743                17.78 ns/op            0 B/op          0 allocs/op
BenchmarkWriteSync-24                   54470494                23.66 ns/op            0 B/op          0 allocs/op
BenchmarkReadAnnounce-24                42575847                26.80 ns/op            0 B/op          0 allocs/op
BenchmarkReadAnnouncePathTrace-24        3963525               297.9 ns/op           125 B/op          2 allocs/op
BenchmarkWriteAnnounce-24               36463590                33.35 ns/op            0 B/op          0 allocs/op
BenchmarkWriteFollowup-24               54767334                22.20 ns/op            0 B/op          0 allocs/op
BenchmarkWriteSignaling-24              28236176                40.78 ns/op            0 B/op          0 allocs/op
BenchmarkReadSignaling-24                5902635               196.0 ns/op           105 B/op          1 allocs/op
PASS
ok      github.com/facebook/time/ptp/protocol   10.291s
```