### PR TITLE
[ntpcheck] add peer count metric

### DIFF
--- a/cmd/ntpcheck/checker/checkresult.go
+++ b/cmd/ntpcheck/checker/checkresult.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NTPCheckResult represents result of NTPCheck run polulated with information about server and it's peers.
+// NTPCheckResult represents result of NTPCheck run populated with information about the server and its peers.
 type NTPCheckResult struct {
 	// parsed from SystemStatusWord
 	LI          uint8

--- a/cmd/ntpcheck/checker/stats.go
+++ b/cmd/ntpcheck/checker/stats.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// NTPStats is what we want to report as stats for FBAgent to put into ODS
+// NTPStats are metrics for upstream reporting
 type NTPStats struct {
 	PeerDelay   float64 `json:"ntp.peer.delay"`    // sys.peer delay in ms
 	PeerPoll    int     `json:"ntp.peer.poll"`     // sys.peer poll in seconds
@@ -33,6 +33,7 @@ type NTPStats struct {
 	Frequency   float64 `json:"ntp.sys.frequency"` // clock frequency in PPM
 	StatError   bool    `json:"ntp.stat.error"`    // error reported in Leap Status
 	Correction  float64 `json:"ntp.correction"`    // current correction
+	PeerCount   int     `json:"ntp.peer.count"`    // number of upstream peers
 }
 
 // NewNTPStats constructs NTPStats from NTPCheckResult
@@ -97,6 +98,7 @@ func NewNTPStats(r *NTPCheckResult) (*NTPStats, error) {
 		Correction:  r.Correction,
 		// that's how ntpstat defines unsynchronized
 		StatError: r.LI == 3,
+		PeerCount: len(r.Peers),
 	}
 	return &output, nil
 }

--- a/cmd/ntpcheck/checker/stats_test.go
+++ b/cmd/ntpcheck/checker/stats_test.go
@@ -97,6 +97,7 @@ func TestNTPStatsNoSysPeer(t *testing.T) {
 		PeerPoll:    1 << 4,
 		PeerStratum: 3,
 		PeerJitter:  3.55,
+		PeerCount:   2,
 	}
 	require.Equal(t, want, stats)
 }
@@ -134,6 +135,7 @@ func TestNTPStatsWithSysPeer(t *testing.T) {
 		PeerPoll:    1 << 4,
 		PeerStratum: 4,
 		PeerJitter:  4,
+		PeerCount:   2,
 	}
 	require.Equal(t, want, stats)
 }


### PR DESCRIPTION
Summary:
Add a metric to report on number of upstream NTP peers

Test Plan:
```
./ntpcheck stats
{"ntp.peer.delay":0,"ntp.peer.poll":128,"ntp.peer.jitter":0,"ntp.peer.offset":0.02109100023517385,"ntp.peer.stratum":2,"ntp.sys.frequency":-2.807772636413574,"ntp.stat.error":false,"ntp.correction":0.000011605097824940458,"ntp.peer.count":19}
```

