### PR TITLE
feat(chrony): add activity command

### DIFF
--- a/ntp/chrony/packet_test.go
+++ b/ntp/chrony/packet_test.go
@@ -327,6 +327,38 @@ func TestDecodeNTPData(t *testing.T) {
 	require.Equal(t, want, packet)
 }
 
+func TestDecodeActivity(t *testing.T) {
+	raw := []uint8{
+		0x06, 0x02, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x0c, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa7, 0xa8, 0x73, 0x83,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	packet, err := decodePacket(raw)
+	require.Nil(t, err)
+	want := &ReplyActivity{
+		ReplyHead: ReplyHead{
+			Version:  protoVersionNumber,
+			PKTType:  pktTypeCmdReply,
+			Res1:     0,
+			Res2:     0,
+			Command:  reqActivity,
+			Reply:    rpyActivity,
+			Status:   sttSuccess,
+			Sequence: 2812834691,
+		},
+		Activity: Activity{
+			Online:       4,
+			Offline:      0,
+			BurstOnline:  0,
+			BurstOffline: 0,
+			Unresolved:   0,
+		},
+	}
+	require.Equal(t, want, packet)
+}
+
 func TestSourceStateTypeToString(t *testing.T) {
 	v := SourceStateUnreach
 	got := v.String()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR adds support for the `activity` command to the chrony package.

[chrony docs](https://chrony.tuxfamily.org/doc/4.2/chronyc.html):

> **activity**
This command reports the number of servers and peers that are online and offline. If the auto_offline option is used in specifying some of the servers or peers, the activity command can be useful for detecting when all of them have entered the offline state after the network link has been disconnected.

We use `tracking` and `activity` commands for [chrony monitoring](https://github.com/netdata/netdata#netdata-is-high-fidelity-infrastructure-monitoring-and-troubleshootingopen-source-free-preconfigured-opinionated-and-always-real-time). I'd like to get this PR merged so we can use this library.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->

- The changes are pretty straightforward:
  - RPY_ACTIVITY code is [12](https://github.com/mlichvar/chrony/blob/7daf34675a5a2487895c74d1578241ca91a4eb70/candm.h#L508).
  - REQ_ACTIVITY code is [44](https://github.com/mlichvar/chrony/blob/7daf34675a5a2487895c74d1578241ca91a4eb70/candm.h#L84). 
  - [RPY_Activity structure](https://github.com/mlichvar/chrony/blob/7daf34675a5a2487895c74d1578241ca91a4eb70/candm.h#L685-L692).

- test binary that queries activity

```cmd
$ ./main
&{ReplyHead:{Version:6 PKTType:reply Res1:0 Res2:0 Command:44 Reply:12 Status:SUCCESS Pad1:0 Pad2:0 Pad3:0 Sequence:1 Pad4:0 Pad5:0} Activity:{Online:4 Offline:0 BurstOnline:0 BurstOffline:0 Unresolved:0}}
```

