### PR TITLE
[ptp4u] send announce to all clients if config changes

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -448,6 +448,15 @@ func (s *Server) handleSighup() {
 		dcMux.Lock()
 		s.Config.DynamicConfig = *dc
 		dcMux.Unlock()
+
+		// Sending announces
+		log.Info("Sending announces")
+		for _, worker := range s.sw {
+			clients := worker.FindClients(ptp.MessageAnnounce)
+			for _, sc := range clients {
+				sc.Once()
+			}
+		}
 		s.Stats.IncReload()
 	}
 }

--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -265,6 +265,17 @@ func (s *sendWorker) FindSubscription(clientID ptp.PortIdentity, st ptp.MessageT
 	return sub
 }
 
+// FindClients retrieves all clients for a particular subscription type
+func (s *sendWorker) FindClients(st ptp.MessageType) map[ptp.PortIdentity]*SubscriptionClient {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	m, ok := s.clients[st]
+	if !ok {
+		return nil
+	}
+	return m
+}
+
 // RegisterSubscription will overwrite an existing subscription.
 // Make sure you call findSubscription before this
 func (s *sendWorker) RegisterSubscription(clientID ptp.PortIdentity, st ptp.MessageType, sc *SubscriptionClient) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Announce messages is a primary mechanism behind the BMCA. We need to send them as soon as possible if something changes.
On the other hand sending them too often can lead to frequent BMCA selection, which sometimes is more damaging than useful.
In any case, sending announce messages on ptp4u SIGHUP will allow us to increase the announce message interval and at the very least greatly reduce traffic.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Manually sending SIGHUP to ptp4u
![image](https://user-images.githubusercontent.com/4749052/178790649-4a7931d4-68c6-4cf8-944b-63c075135bef.png)
+ unit tests of course
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
