### PR TITLE
[ptp4l] only send 2 extra announce messages

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -376,12 +376,12 @@ func (s *Server) handleGeneralMessages(generalConn *net.UDPConn) {
 						if !sc.Running() {
 							go sc.Start(s.ctx)
 						}
-						// Send 3 announce messages to allow quick restart of ptp4l
+						// Send 2 announce messages to allow quick restart of ptp4l
 						// https://sourceforge.net/p/linuxptp/mailman/message/37685839/
 						// https://github.com/richardcochran/linuxptp/blob/ef9ba9489c2f664ea34e5e4dbddbb76cddef5254/foreign.h#L28
 						// https://github.com/richardcochran/linuxptp/blob/33ac7d25cd9212e79be6f7023ba18cfa5020e35b/port.c#L2546
 						if signaling.Header.SequenceID == 0 && grantType == ptp.MessageAnnounce {
-							for i := 0; i < 3; i++ {
+							for i := 0; i < 2; i++ {
 								sc.Once()
 							}
 						}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
FOREIGN_MASTER_THRESHOLD  is in fact 2 https://github.com/richardcochran/linuxptp/blob/ef9ba9489c2f664ea34e5e4dbddbb76cddef5254/foreign.h#L28
So let's send 2 and not 3 which may actually mess with ptp4l state machine.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/182817609-8c069ac0-5bfa-43ad-ae17-5a30a749ca8a.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
