### PR TITLE
[ptp4u] faster subscription cancellation

### DIFF
--- a/ptp/ptp4u/server/subscription_test.go
+++ b/ptp/ptp4u/server/subscription_test.go
@@ -35,7 +35,7 @@ func TestRunning(t *testing.T) {
 	require.True(t, sc.Expired())
 
 	// Add proper actual expiration time subscription
-	sc.setExpire(time.Now().Add(1 * time.Second))
+	sc.SetExpire(time.Now().Add(1 * time.Second))
 	require.False(t, sc.Expired())
 
 	// Check running status
@@ -50,7 +50,8 @@ func TestSubscriptionStart(t *testing.T) {
 	interval := 1 * time.Minute
 	expire := time.Now().Add(1 * time.Minute)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, interval, expire)
+	sc := NewSubscriptionClient(w.queue, sa, nil, ptp.MessageAnnounce, c, interval, expire)
+	sc.SetGclisa(sa)
 
 	go sc.Start(context.Background())
 	time.Sleep(100 * time.Millisecond)
@@ -83,8 +84,8 @@ func TestSubscriptionStop(t *testing.T) {
 		queue: make(chan *SubscriptionClient, 100),
 	}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
-	interval := 10 * time.Millisecond
-	expire := time.Now().Add(1 * time.Second)
+	interval := 32 * time.Second
+	expire := time.Now().Add(1 * time.Minute)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
@@ -154,7 +155,7 @@ func TestFollowupPacket(t *testing.T) {
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID
-	sc.setInterval(interval)
+	sc.SetInterval(interval)
 
 	i, err := ptp.NewLogInterval(interval)
 	require.NoError(t, err)
@@ -180,7 +181,7 @@ func TestAnnouncePacket(t *testing.T) {
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID
-	sc.setInterval(interval)
+	sc.SetInterval(interval)
 
 	i, err := ptp.NewLogInterval(interval)
 	require.NoError(t, err)

--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -83,7 +83,7 @@ func (s *sendWorker) listen() (eventFD, generalFD int, err error) {
 		return -1, -1, fmt.Errorf("failed to set SO_REUSEPORT on event socket: %w", err)
 	}
 	// bind to any ephemeral port
-	if err := unix.Bind(eventFD, sockAddrAnyPort); err != nil {
+	if err = unix.Bind(eventFD, sockAddrAnyPort); err != nil {
 		return -1, -1, fmt.Errorf("unable to bind event socket connection: %w", err)
 	}
 
@@ -108,11 +108,11 @@ func (s *sendWorker) listen() (eventFD, generalFD int, err error) {
 	// Syncs sent from event port, so need to turn on timestamping here
 	switch s.config.TimestampType {
 	case timestamp.HWTIMESTAMP:
-		if err := timestamp.EnableHWTimestamps(eventFD, s.config.Interface); err != nil {
+		if err = timestamp.EnableHWTimestamps(eventFD, s.config.Interface); err != nil {
 			return -1, -1, fmt.Errorf("failed to enable RX hardware timestamps: %w", err)
 		}
 	case timestamp.SWTIMESTAMP:
-		if err := timestamp.EnableSWTimestamps(eventFD); err != nil {
+		if err = timestamp.EnableSWTimestamps(eventFD); err != nil {
 			return -1, -1, fmt.Errorf("unable to enable RX software timestamps: %w", err)
 		}
 	default:
@@ -130,7 +130,7 @@ func (s *sendWorker) listen() (eventFD, generalFD int, err error) {
 		return -1, -1, fmt.Errorf("failed to set SO_REUSEPORT on general socket: %w", err)
 	}
 	// bind to any ephemeral port
-	if err := unix.Bind(generalFD, sockAddrAnyPort); err != nil {
+	if err = unix.Bind(generalFD, sockAddrAnyPort); err != nil {
 		return -1, -1, fmt.Errorf("binding event socket connection: %w", err)
 	}
 	// enable DSCP

--- a/ptp/ptp4u/server/worker_test.go
+++ b/ptp/ptp4u/server/worker_test.go
@@ -182,12 +182,12 @@ func TestInventoryClients(t *testing.T) {
 	require.Equal(t, 2, len(w.clients[ptp.MessageSync]))
 
 	// Shutting down
-	scS1.setExpire(time.Now())
+	scS1.SetExpire(time.Now())
 	time.Sleep(50 * time.Millisecond)
 	w.inventoryClients()
 	require.Equal(t, 1, len(w.clients[ptp.MessageSync]))
 
-	scA1.setExpire(time.Now())
+	scA1.SetExpire(time.Now())
 	time.Sleep(50 * time.Millisecond)
 	w.inventoryClients()
 	require.Equal(t, 0, len(w.clients[ptp.MessageAnnounce]))

--- a/ptp/ptp4u/stats/json.go
+++ b/ptp/ptp4u/stats/json.go
@@ -60,8 +60,10 @@ func (s *JSONStats) Snapshot() {
 	s.subscriptions.copy(&s.report.subscriptions)
 	s.rx.copy(&s.report.rx)
 	s.tx.copy(&s.report.tx)
-	s.rxSignaling.copy(&s.report.rxSignaling)
-	s.txSignaling.copy(&s.report.txSignaling)
+	s.rxSignalingGrant.copy(&s.report.rxSignalingGrant)
+	s.rxSignalingCancel.copy(&s.report.rxSignalingCancel)
+	s.txSignalingGrant.copy(&s.report.txSignalingGrant)
+	s.txSignalingCancel.copy(&s.report.txSignalingCancel)
 	s.workerQueue.copy(&s.report.workerQueue)
 	s.workerSubs.copy(&s.report.workerSubs)
 	s.txtsattempts.copy(&s.report.txtsattempts)
@@ -105,14 +107,24 @@ func (s *JSONStats) IncTX(t ptp.MessageType) {
 	s.tx.inc(int(t))
 }
 
-// IncRXSignaling atomically add 1 to the counter
-func (s *JSONStats) IncRXSignaling(t ptp.MessageType) {
-	s.rxSignaling.inc(int(t))
+// IncRXSignalingGrant atomically add 1 to the counter
+func (s *JSONStats) IncRXSignalingGrant(t ptp.MessageType) {
+	s.rxSignalingGrant.inc(int(t))
 }
 
-// IncTXSignaling atomically add 1 to the counter
-func (s *JSONStats) IncTXSignaling(t ptp.MessageType) {
-	s.txSignaling.inc(int(t))
+// IncRXSignalingCancel atomically add 1 to the counter
+func (s *JSONStats) IncRXSignalingCancel(t ptp.MessageType) {
+	s.rxSignalingCancel.inc(int(t))
+}
+
+// IncTXSignalingGrant atomically add 1 to the counter
+func (s *JSONStats) IncTXSignalingGrant(t ptp.MessageType) {
+	s.txSignalingGrant.inc(int(t))
+}
+
+// IncTXSignalingCancel atomically add 1 to the counter
+func (s *JSONStats) IncTXSignalingCancel(t ptp.MessageType) {
+	s.txSignalingCancel.inc(int(t))
 }
 
 // IncWorkerSubs atomically add 1 to the counter
@@ -140,14 +152,24 @@ func (s *JSONStats) DecTX(t ptp.MessageType) {
 	s.tx.dec(int(t))
 }
 
-// DecRXSignaling atomically removes 1 from the counter
-func (s *JSONStats) DecRXSignaling(t ptp.MessageType) {
-	s.rxSignaling.dec(int(t))
+// DecRXSignalingGrant atomically removes 1 from the counter
+func (s *JSONStats) DecRXSignalingGrant(t ptp.MessageType) {
+	s.rxSignalingGrant.dec(int(t))
 }
 
-// DecTXSignaling atomically removes 1 from the counter
-func (s *JSONStats) DecTXSignaling(t ptp.MessageType) {
-	s.txSignaling.dec(int(t))
+// DecRXSignalingCancel atomically removes 1 from the counter
+func (s *JSONStats) DecRXSignalingCancel(t ptp.MessageType) {
+	s.rxSignalingCancel.dec(int(t))
+}
+
+// DecTXSignalingGrant atomically removes 1 from the counter
+func (s *JSONStats) DecTXSignalingGrant(t ptp.MessageType) {
+	s.txSignalingGrant.dec(int(t))
+}
+
+// DecTXSignalingCancel atomically removes 1 from the counter
+func (s *JSONStats) DecTXSignalingCancel(t ptp.MessageType) {
+	s.txSignalingCancel.dec(int(t))
 }
 
 // DecWorkerSubs atomically removes 1 from the counter

--- a/ptp/ptp4u/stats/json_test.go
+++ b/ptp/ptp4u/stats/json_test.go
@@ -30,16 +30,19 @@ import (
 func TestJSONStatsReset(t *testing.T) {
 	stats := JSONStats{}
 	stats.subscriptions.init()
-	stats.rxSignaling.init()
+	stats.rxSignalingGrant.init()
+	stats.rxSignalingCancel.init()
 	stats.workerQueue.init()
 
 	stats.IncSubscription(ptp.MessageAnnounce)
-	stats.IncRXSignaling(ptp.MessageSync)
+	stats.IncRXSignalingGrant(ptp.MessageSync)
+	stats.IncRXSignalingCancel(ptp.MessageSync)
 	stats.SetMaxWorkerQueue(10, 42)
 
 	stats.Reset()
 	require.Equal(t, int64(0), stats.subscriptions.load(int(ptp.MessageAnnounce)))
-	require.Equal(t, int64(0), stats.rxSignaling.load(int(ptp.MessageSync)))
+	require.Equal(t, int64(0), stats.rxSignalingGrant.load(int(ptp.MessageSync)))
+	require.Equal(t, int64(0), stats.rxSignalingCancel.load(int(ptp.MessageSync)))
 	require.Equal(t, int64(0), stats.workerQueue.load(10))
 }
 
@@ -86,21 +89,29 @@ func TestJSONStatsTX(t *testing.T) {
 func TestJSONStatsRXSignaling(t *testing.T) {
 	stats := NewJSONStats()
 
-	stats.IncRXSignaling(ptp.MessageSync)
-	require.Equal(t, int64(1), stats.rxSignaling.load(int(ptp.MessageSync)))
+	stats.IncRXSignalingGrant(ptp.MessageSync)
+	stats.IncRXSignalingCancel(ptp.MessageSync)
+	require.Equal(t, int64(1), stats.rxSignalingGrant.load(int(ptp.MessageSync)))
+	require.Equal(t, int64(1), stats.rxSignalingCancel.load(int(ptp.MessageSync)))
 
-	stats.DecRXSignaling(ptp.MessageSync)
-	require.Equal(t, int64(0), stats.rxSignaling.load(int(ptp.MessageSync)))
+	stats.DecRXSignalingGrant(ptp.MessageSync)
+	stats.DecRXSignalingCancel(ptp.MessageSync)
+	require.Equal(t, int64(0), stats.rxSignalingGrant.load(int(ptp.MessageSync)))
+	require.Equal(t, int64(0), stats.rxSignalingCancel.load(int(ptp.MessageSync)))
 }
 
 func TestJSONStatsTXSignaling(t *testing.T) {
 	stats := NewJSONStats()
 
-	stats.IncTXSignaling(ptp.MessageSync)
-	require.Equal(t, int64(1), stats.txSignaling.load(int(ptp.MessageSync)))
+	stats.IncTXSignalingGrant(ptp.MessageSync)
+	stats.IncTXSignalingCancel(ptp.MessageSync)
+	require.Equal(t, int64(1), stats.txSignalingGrant.load(int(ptp.MessageSync)))
+	require.Equal(t, int64(1), stats.txSignalingCancel.load(int(ptp.MessageSync)))
 
-	stats.DecTXSignaling(ptp.MessageSync)
-	require.Equal(t, int64(0), stats.txSignaling.load(int(ptp.MessageSync)))
+	stats.DecTXSignalingGrant(ptp.MessageSync)
+	stats.DecTXSignalingCancel(ptp.MessageSync)
+	require.Equal(t, int64(0), stats.txSignalingGrant.load(int(ptp.MessageSync)))
+	require.Equal(t, int64(0), stats.txSignalingCancel.load(int(ptp.MessageSync)))
 }
 
 func TestJSONStatsSetMaxWorkerQueue(t *testing.T) {
@@ -164,9 +175,9 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	stats.IncSubscription(ptp.MessageAnnounce)
 	stats.IncTX(ptp.MessageSync)
 	stats.IncTX(ptp.MessageSync)
-	stats.IncRXSignaling(ptp.MessageDelayResp)
-	stats.IncRXSignaling(ptp.MessageDelayResp)
-	stats.IncRXSignaling(ptp.MessageDelayResp)
+	stats.IncRXSignalingGrant(ptp.MessageDelayResp)
+	stats.IncRXSignalingGrant(ptp.MessageDelayResp)
+	stats.IncRXSignalingGrant(ptp.MessageDelayResp)
 	stats.SetClockAccuracy(1)
 	stats.SetClockClass(1)
 	stats.SetUTCOffsetSec(1)
@@ -179,7 +190,7 @@ func TestJSONStatsSnapshot(t *testing.T) {
 	expectedStats.init()
 	expectedStats.subscriptions.store(int(ptp.MessageAnnounce), 1)
 	expectedStats.tx.store(int(ptp.MessageSync), 2)
-	expectedStats.rxSignaling.store(int(ptp.MessageDelayResp), 3)
+	expectedStats.rxSignalingGrant.store(int(ptp.MessageDelayResp), 3)
 	expectedStats.utcoffsetSec = 1
 	expectedStats.clockaccuracy = 1
 	expectedStats.clockclass = 1
@@ -188,7 +199,7 @@ func TestJSONStatsSnapshot(t *testing.T) {
 
 	require.Equal(t, expectedStats.subscriptions.m, stats.report.subscriptions.m)
 	require.Equal(t, expectedStats.tx.m, stats.report.tx.m)
-	require.Equal(t, expectedStats.rxSignaling.m, stats.report.rxSignaling.m)
+	require.Equal(t, expectedStats.rxSignalingGrant.m, stats.report.rxSignalingGrant.m)
 	require.Equal(t, expectedStats.utcoffsetSec, stats.report.utcoffsetSec)
 	require.Equal(t, expectedStats.clockaccuracy, stats.report.clockaccuracy)
 	require.Equal(t, expectedStats.clockclass, stats.report.clockclass)
@@ -205,9 +216,11 @@ func TestJSONExport(t *testing.T) {
 	stats.IncSubscription(ptp.MessageAnnounce)
 	stats.IncTX(ptp.MessageSync)
 	stats.IncTX(ptp.MessageSync)
-	stats.IncRXSignaling(ptp.MessageDelayResp)
-	stats.IncRXSignaling(ptp.MessageDelayResp)
-	stats.IncRXSignaling(ptp.MessageDelayResp)
+	stats.IncRXSignalingGrant(ptp.MessageDelayResp)
+	stats.IncRXSignalingGrant(ptp.MessageDelayResp)
+	stats.IncRXSignalingGrant(ptp.MessageDelayResp)
+	stats.IncRXSignalingCancel(ptp.MessageSync)
+	stats.IncRXSignalingCancel(ptp.MessageSync)
 	stats.SetUTCOffsetSec(1)
 	stats.SetClockAccuracy(1)
 	stats.SetClockClass(1)
@@ -230,7 +243,8 @@ func TestJSONExport(t *testing.T) {
 	expectedMap := make(map[string]int64)
 	expectedMap["subscriptions.announce"] = 1
 	expectedMap["tx.sync"] = 2
-	expectedMap["rx.signaling.delay_resp"] = 3
+	expectedMap["rx.signaling.grant.delay_resp"] = 3
+	expectedMap["rx.signaling.cancel.sync"] = 2
 	expectedMap["utcoffset_sec"] = 1
 	expectedMap["clockaccuracy"] = 1
 	expectedMap["clockclass"] = 1

--- a/ptp/ptp4u/stats/stats_test.go
+++ b/ptp/ptp4u/stats/stats_test.go
@@ -67,8 +67,8 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	c.subscriptions.store(1, 1)
 	c.rx.store(1, 1)
 	c.tx.store(1, 1)
-	c.rxSignaling.store(1, 1)
-	c.txSignaling.store(1, 1)
+	c.rxSignalingGrant.store(1, 1)
+	c.txSignalingCancel.store(1, 1)
 	c.workerQueue.store(1, 1)
 	c.workerSubs.store(1, 1)
 	c.txtsattempts.store(1, 1)
@@ -81,8 +81,8 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(1), c.subscriptions.load(1))
 	require.Equal(t, int64(1), c.rx.load(1))
 	require.Equal(t, int64(1), c.tx.load(1))
-	require.Equal(t, int64(1), c.rxSignaling.load(1))
-	require.Equal(t, int64(1), c.txSignaling.load(1))
+	require.Equal(t, int64(1), c.rxSignalingGrant.load(1))
+	require.Equal(t, int64(1), c.txSignalingCancel.load(1))
 	require.Equal(t, int64(1), c.workerQueue.load(1))
 	require.Equal(t, int64(1), c.workerSubs.load(1))
 	require.Equal(t, int64(1), c.txtsattempts.load(1))
@@ -97,8 +97,8 @@ func TestSyncMapInt64Counters(t *testing.T) {
 	require.Equal(t, int64(0), c.subscriptions.load(1))
 	require.Equal(t, int64(0), c.rx.load(1))
 	require.Equal(t, int64(0), c.tx.load(1))
-	require.Equal(t, int64(0), c.rxSignaling.load(1))
-	require.Equal(t, int64(0), c.txSignaling.load(1))
+	require.Equal(t, int64(0), c.rxSignalingGrant.load(1))
+	require.Equal(t, int64(0), c.txSignalingCancel.load(1))
 	require.Equal(t, int64(0), c.workerQueue.load(1))
 	require.Equal(t, int64(0), c.workerSubs.load(1))
 	require.Equal(t, int64(0), c.txtsattempts.load(1))
@@ -115,7 +115,8 @@ func TestCountersToMap(t *testing.T) {
 
 	c.subscriptions.store(int(ptp.MessageAnnounce), 1)
 	c.tx.store(int(ptp.MessageSync), 2)
-	c.rxSignaling.store(int(ptp.MessageDelayResp), 3)
+	c.rxSignalingGrant.store(int(ptp.MessageDelayResp), 3)
+	c.rxSignalingCancel.store(int(ptp.MessageSync), 1)
 	c.utcoffsetSec = 1
 	c.clockaccuracy = 42
 	c.clockclass = 6
@@ -127,7 +128,8 @@ func TestCountersToMap(t *testing.T) {
 	expectedMap := make(map[string]int64)
 	expectedMap["subscriptions.announce"] = 1
 	expectedMap["tx.sync"] = 2
-	expectedMap["rx.signaling.delay_resp"] = 3
+	expectedMap["rx.signaling.grant.delay_resp"] = 3
+	expectedMap["rx.signaling.cancel.sync"] = 1
 	expectedMap["utcoffset_sec"] = 1
 	expectedMap["clockaccuracy"] = 42
 	expectedMap["clockclass"] = 6


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Introduce reload channel which allows to trigger subscription loop faster than normal interval.
* Use the reload during stop. Modify unittests to verify this.
* Split signaling counters into Grant and Cancel to monitor them separately
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/183057146-080ffecb-ca0e-4dae-a730-ce36ab706780.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
