### PR TITLE
[ptp4l] only send 1 extra announce messages

### DIFF
--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -202,7 +202,7 @@ func TestHandleSighup(t *testing.T) {
 	go scS.Start(context.Background())
 	time.Sleep(100 * time.Millisecond)
 
-	require.Equal(t, 3, len(s.sw[0].queue))
+	require.Equal(t, 2, len(s.sw[0].queue))
 	require.Equal(t, 1, len(s.sw[1].queue))
 
 	cfg, err := ioutil.TempFile("", "ptp4u")
@@ -234,7 +234,7 @@ utcoffset: "37s"
 	dcMux.Unlock()
 
 	// Make sure after we send SIGHUP we get the event in the Announce queue only
-	require.Equal(t, 4, len(s.sw[0].queue))
+	require.Equal(t, 3, len(s.sw[0].queue))
 	require.Equal(t, 1, len(s.sw[1].queue))
 }
 

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -92,14 +92,12 @@ func (sc *SubscriptionClient) Start(ctx context.Context) {
 	// Send first message right away
 	sc.reload <- true
 
-	// Send 2 announce additional messages to allow quick restart of ptp4l
+	// Send 1 announce additional messages to allow quicker restart of ptp4l
 	// https://sourceforge.net/p/linuxptp/mailman/message/37685839/
 	// https://github.com/richardcochran/linuxptp/blob/ef9ba9489c2f664ea34e5e4dbddbb76cddef5254/foreign.h#L28
 	// https://github.com/richardcochran/linuxptp/blob/33ac7d25cd9212e79be6f7023ba18cfa5020e35b/port.c#L2546
 	if sc.subscriptionType == ptp.MessageAnnounce {
-		for i := 0; i < 2; i++ {
-			sc.reload <- true
-		}
+		sc.reload <- true
 	}
 
 	sc.runningInterval = sc.interval


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Only send 1 extra announce because rushing actually locks ptp4l
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
ptp4l clients no longer hang
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
