### PR TITLE
[ptp4u] signaling messages done by workers

### DIFF
--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Package server implements simple Unicast PTP UDP server.
+*/
 package server
 
 import (

--- a/ptp/ptp4u/server/subscription_test.go
+++ b/ptp/ptp4u/server/subscription_test.go
@@ -50,7 +50,7 @@ func TestSubscriptionStart(t *testing.T) {
 	interval := 1 * time.Minute
 	expire := time.Now().Add(1 * time.Minute)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, nil, ptp.MessageAnnounce, c, interval, expire)
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, nil, ptp.MessageAnnounce, c, interval, expire)
 	sc.SetGclisa(sa)
 
 	go sc.Start(context.Background())
@@ -65,7 +65,7 @@ func TestSubscriptionExpire(t *testing.T) {
 	interval := 10 * time.Millisecond
 	expire := time.Now().Add(200 * time.Millisecond)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
 
 	go sc.Start(context.Background())
 	time.Sleep(100 * time.Millisecond)
@@ -87,7 +87,7 @@ func TestSubscriptionStop(t *testing.T) {
 	interval := 32 * time.Second
 	expire := time.Now().Add(1 * time.Minute)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, interval, expire)
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 
 	go sc.Start(context.Background())
 	time.Sleep(100 * time.Millisecond)
@@ -102,7 +102,7 @@ func TestSubscriptionEnd(t *testing.T) {
 	interval := 10 * time.Millisecond
 	expire := time.Now().Add(300 * time.Millisecond)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go sc.Start(ctx)
@@ -119,7 +119,7 @@ func TestSubscriptionflags(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 
 	sc.UpdateSync()
 	sc.UpdateFollowup(time.Now())
@@ -135,7 +135,7 @@ func TestSyncPacket(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID
 
 	sc.initSync()
@@ -153,7 +153,7 @@ func TestFollowupPacket(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID
 	sc.SetInterval(interval)
 
@@ -179,7 +179,7 @@ func TestAnnouncePacket(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234), DynamicConfig: DynamicConfig{ClockClass: clockClass, ClockAccuracy: clockAccuracy, UTCOffset: UTCOffset}}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sc.sequenceID = sequenceID
 	sc.SetInterval(interval)
 
@@ -210,7 +210,7 @@ func TestDelayRespPacket(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 
 	sp := ptp.PortIdentity{
 		PortNumber:    1,
@@ -238,7 +238,7 @@ func TestGrantPacket(t *testing.T) {
 	w := &sendWorker{}
 	c := &Config{clockIdentity: ptp.ClockIdentity(1234)}
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Second, time.Time{})
 	sg := &ptp.Signaling{}
 
 	mt := ptp.NewUnicastMsgTypeAndFlags(ptp.MessageAnnounce, 0)

--- a/ptp/ptp4u/server/worker_test.go
+++ b/ptp/ptp4u/server/worker_test.go
@@ -54,22 +54,22 @@ func TestWorkerQueue(t *testing.T) {
 	expire := time.Now().Add(time.Millisecond)
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
 
-	scA := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, interval, expire)
+	scA := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, interval, expire)
 	for i := 0; i < 10; i++ {
 		w.queue <- scA
 	}
 
-	scS := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSync, c, interval, expire)
+	scS := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageSync, c, interval, expire)
 	for i := 0; i < 10; i++ {
 		w.queue <- scS
 	}
 
-	scDR := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
+	scDR := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageDelayResp, c, interval, expire)
 	for i := 0; i < 10; i++ {
 		w.queue <- scDR
 	}
 
-	scSig := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSignaling, c, interval, expire)
+	scSig := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageSignaling, c, interval, expire)
 	for i := 0; i < 10; i++ {
 		w.queue <- scSig
 	}
@@ -92,7 +92,7 @@ func TestFindSubscription(t *testing.T) {
 	}
 
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Millisecond, time.Now().Add(time.Second))
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Millisecond, time.Now().Add(time.Second))
 
 	sp := ptp.PortIdentity{
 		PortNumber:    1,
@@ -120,7 +120,7 @@ func TestFindClients(t *testing.T) {
 	}
 
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	sc := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, time.Millisecond, time.Now().Add(time.Second))
+	sc := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, time.Millisecond, time.Now().Add(time.Second))
 
 	sp := ptp.PortIdentity{
 		PortNumber:    1,
@@ -157,7 +157,7 @@ func TestInventoryClients(t *testing.T) {
 	w := newSendWorker(0, c, st)
 
 	sa := timestamp.IPToSockaddr(net.ParseIP("127.0.0.1"), 123)
-	scS1 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSync, c, 10*time.Millisecond, time.Now().Add(time.Minute))
+	scS1 := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageSync, c, 10*time.Millisecond, time.Now().Add(time.Minute))
 	w.RegisterSubscription(clipi1, ptp.MessageSync, scS1)
 	go scS1.Start(context.Background())
 	time.Sleep(10 * time.Millisecond)
@@ -165,7 +165,7 @@ func TestInventoryClients(t *testing.T) {
 	w.inventoryClients()
 	require.Equal(t, 1, len(w.clients))
 
-	scA1 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageAnnounce, c, 10*time.Millisecond, time.Now().Add(time.Minute))
+	scA1 := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageAnnounce, c, 10*time.Millisecond, time.Now().Add(time.Minute))
 	w.RegisterSubscription(clipi1, ptp.MessageAnnounce, scA1)
 	go scA1.Start(context.Background())
 	time.Sleep(10 * time.Millisecond)
@@ -173,7 +173,7 @@ func TestInventoryClients(t *testing.T) {
 	w.inventoryClients()
 	require.Equal(t, 2, len(w.clients))
 
-	scS2 := NewSubscriptionClient(w.queue, sa, sa, ptp.MessageSync, c, 10*time.Millisecond, time.Now().Add(time.Minute))
+	scS2 := NewSubscriptionClient(w.queue, w.grantQueue, sa, sa, ptp.MessageSync, c, 10*time.Millisecond, time.Now().Add(time.Minute))
 	w.RegisterSubscription(clipi2, ptp.MessageSync, scS2)
 	go scS2.Start(context.Background())
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Currently server directly responds to the signaling messages (grants).
However, we already have powerful mechanism of sending messages (sync/fwup/announce/delayResp) via workers.
This change will leverage workers to send grants, completely removing send logic from the server.
This will unblock cancellation messages being generated within the subscription on cancel.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
### Tcpdump/Wireshard
<img width="472" alt="Screen Shot 2022-08-20 at 18 44 50" src="https://user-images.githubusercontent.com/4749052/185760587-65a9ec2c-7f2d-4fcd-a800-1c8b39143dc0.png">

### Works in prod

### Unittests

### Lint issue is unrelated
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
