### PR TITLE
[ptp4u] reduce heap allocations for signaling grants

### DIFF
--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -254,12 +254,12 @@ func (s *sendWorker) Start() {
 			c.IncSequenceID()
 			s.stats.SetMaxWorkerQueue(s.id, int64(len(s.queue)))
 		case c = <-s.grantQueue:
-			grantb, err := ptp.Bytes(c.Grant())
+			n, err = ptp.BytesTo(c.Grant(), buf)
 			if err != nil {
 				log.Errorf("Failed to prepare the unicast grant: %v", err)
 				continue
 			}
-			err = unix.Sendto(gFd, grantb, 0, c.gclisa)
+			err = unix.Sendto(gFd, buf[:n], 0, c.gclisa)
 			if err != nil {
 				log.Errorf("Failed to send the unicast grant: %v", err)
 				continue


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Greatly reduce number of allocations by using buffers already defined in send workers.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/185803712-dec2f46b-0a3b-4566-8506-2c2f481646f7.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
