### PR TITLE
[time] migrate off io/ioutil

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -448,7 +447,7 @@ func (a *API) FetchCsv(channel Channel, allData bool) ([][]string, error) {
 		return nil, errors.New(http.StatusText(resp.StatusCode))
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +493,7 @@ func (a *API) FetchChannelProbe(channel Channel) (*Probe, error) {
 		return nil, errors.New(http.StatusText(resp.StatusCode))
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +523,7 @@ func (a *API) FetchChannelTarget(channel Channel, probe Probe) (string, error) {
 		return "", errors.New(http.StatusText(resp.StatusCode))
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/calnex/api/api_test.go
+++ b/calnex/api/api_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -377,7 +376,7 @@ func TestPushVersion(t *testing.T) {
 		Message: "Installing firmware Version: 2.13.1.0.5583D-20210924",
 	}
 	// Firmware file itself
-	fw, err := ioutil.TempFile("/tmp", "calnex")
+	fw, err := os.CreateTemp("/tmp", "calnex")
 	require.NoError(t, err)
 	defer fw.Close()
 	defer os.Remove(fw.Name())
@@ -385,7 +384,7 @@ func TestPushVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Firmware file saved via http
-	fwres, err := ioutil.TempFile("/tmp", "calnex")
+	fwres, err := os.CreateTemp("/tmp", "calnex")
 	require.NoError(t, err)
 	defer os.Remove(fwres.Name())
 
@@ -408,10 +407,10 @@ func TestPushVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, r)
 
-	originalFW, err := ioutil.ReadFile(fw.Name())
+	originalFW, err := os.ReadFile(fw.Name())
 	require.NoError(t, err)
 
-	uploadedFW, err := ioutil.ReadFile(fwres.Name())
+	uploadedFW, err := os.ReadFile(fwres.Name())
 	require.NoError(t, err)
 
 	require.Equal(t, originalFW, uploadedFW)
@@ -503,7 +502,7 @@ func TestFetchProblemReport(t *testing.T) {
 	calnexAPI := NewAPI(parsed.Host, true)
 	calnexAPI.Client = ts.Client()
 
-	dir, err := ioutil.TempDir("/tmp", "calnex")
+	dir, err := os.MkdirTemp("/tmp", "calnex")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -532,7 +531,7 @@ func TestPushCert(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, cert, body)
 		fmt.Fprintln(w, sampleResp)

--- a/calnex/cert/cert.go
+++ b/calnex/cert/cert.go
@@ -164,10 +164,11 @@ func (b *Bundle) Equals(other *Bundle) bool {
 }
 
 // Verify verifies the supplied bundle checking that:
-//  * We have a private key
-//  * We have a cert
-//  * One of the cert CNs matches the supplied hostname
-//  * The cert validity date before and ends after the supplied time.
+//   - We have a private key
+//   - We have a cert
+//   - One of the cert CNs matches the supplied hostname
+//   - The cert validity date before and ends after the supplied time.
+//
 // Returns an error if any of these are not satisfied.
 func (b *Bundle) Verify(hostname string, t time.Time) error {
 	if b == nil {

--- a/calnex/cmd/config.go
+++ b/calnex/cmd/config.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/facebook/time/calnex/config"
@@ -51,7 +51,7 @@ var configCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		defer configFile.Close()
-		b, err := ioutil.ReadAll(configFile)
+		b, err := io.ReadAll(configFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/calnex/firmware/firmware_test.go
+++ b/calnex/firmware/firmware_test.go
@@ -18,7 +18,6 @@ package firmware
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestFirmware(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "calnex")
+	dir, err := os.MkdirTemp("/tmp", "calnex")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/cmd/ntpcheck/cmd/utils.go
+++ b/cmd/ntpcheck/cmd/utils.go
@@ -20,7 +20,6 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -77,7 +76,7 @@ func fakeSeconds(secondsCount int) {
 
 // signFile generates hash for leap Second hashfile and prints is on stdout
 func signFile(fileName string) {
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		fmt.Printf("Error opening %q: %s\n", fileName, err)
 	}

--- a/cmd/ziffy/node/receiver.go
+++ b/cmd/ziffy/node/receiver.go
@@ -120,7 +120,7 @@ func (r *Receiver) handlePacket(rawPacket gopacket.Packet) {
 	}
 }
 
-//sendResponse sends ICMPTypeTimeExceeded to sender
+// sendResponse sends ICMPTypeTimeExceeded to sender
 func (r *Receiver) sendResponse(packet *ptp.SyncDelayReq, sourceIP string, rawPacket gopacket.Packet) error {
 	dst, err := net.ResolveIPAddr("ip6:ipv6-icmp", sourceIP)
 	if err != nil {

--- a/leapsectz/leapsectz.go
+++ b/leapsectz/leapsectz.go
@@ -23,7 +23,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 )
@@ -147,7 +146,7 @@ func parseVx(r io.Reader) ([]LeapSecond, error) {
 			skip += int(hdr.LeapCnt)*8 + int(hdr.IsUtcCnt) + int(hdr.IsStdCnt)
 		}
 
-		if n, _ := io.CopyN(ioutil.Discard, r, int64(skip)); n != int64(skip) {
+		if n, _ := io.CopyN(io.Discard, r, int64(skip)); n != int64(skip) {
 			return nil, errBadData
 		}
 
@@ -177,7 +176,7 @@ func parseVx(r io.Reader) ([]LeapSecond, error) {
 			ret = append(ret, l)
 		}
 		// we need to skip the rest of the data
-		_, _ = io.CopyN(ioutil.Discard, r, int64(skip))
+		_, _ = io.CopyN(io.Discard, r, int64(skip))
 		break
 	}
 	if len(ret) == 0 {

--- a/leapsectz/leapsectz_test.go
+++ b/leapsectz/leapsectz_test.go
@@ -19,7 +19,6 @@ package leapsectz
 import (
 	"bytes"
 	"encoding/binary"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -148,7 +147,7 @@ func TestParse(t *testing.T) {
 		LeapSecond{78796800, 1},
 		LeapSecond{94694401, 2},
 	}
-	f, err := ioutil.TempFile(os.TempDir(), "leaptest-")
+	f, err := os.CreateTemp(os.TempDir(), "leaptest-")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -165,7 +164,7 @@ func TestParse(t *testing.T) {
 
 func TestLatest(t *testing.T) {
 	expected := &LeapSecond{94694401, 2}
-	f, err := ioutil.TempFile(os.TempDir(), "leaptest-")
+	f, err := os.CreateTemp(os.TempDir(), "leaptest-")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -188,7 +187,7 @@ func TestLatestFuture(t *testing.T) {
 		{2649346018, 3},
 	}
 
-	f, err := ioutil.TempFile(os.TempDir(), "leaptest-")
+	f, err := os.CreateTemp(os.TempDir(), "leaptest-")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 

--- a/ntp/chrony/helpers.go
+++ b/ntp/chrony/helpers.go
@@ -87,9 +87,11 @@ func (t *timeSpec) ToTime() time.Time {
 	return time.Unix(int64(highU64<<32|lowU64), int64(t.Nsec))
 }
 
-/* 32-bit floating-point format consisting of 7-bit signed exponent
-   and 25-bit signed coefficient without hidden bit.
-   The result is calculated as: 2^(exp - 25) * coef */
+/*
+32-bit floating-point format consisting of 7-bit signed exponent
+and 25-bit signed coefficient without hidden bit.
+The result is calculated as: 2^(exp - 25) * coef
+*/
 type chronyFloat int32
 
 // ToFloat does magic to decode float from int32.

--- a/ntp/chrony/packet.go
+++ b/ntp/chrony/packet.go
@@ -124,6 +124,7 @@ const (
 )
 
 // response status codes
+//
 //nolint:varcheck,deadcode,unused
 const (
 	sttSuccess            ResponseStatusType = 0

--- a/ptp/c4u/c4u_test.go
+++ b/ptp/c4u/c4u_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package c4u
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -44,7 +43,7 @@ func TestRun(t *testing.T) {
 		UTCOffset:      utcoffset,
 	}
 
-	cfg, err := ioutil.TempFile("", "c4u")
+	cfg, err := os.CreateTemp("", "c4u")
 	require.NoError(t, err)
 	defer os.Remove(cfg.Name())
 

--- a/ptp/c4u/stats/json_test.go
+++ b/ptp/c4u/stats/json_test.go
@@ -18,7 +18,7 @@ package stats
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -94,7 +94,7 @@ func TestJSONExport(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	var data map[string]int64

--- a/ptp/protocol/doc.go
+++ b/ptp/protocol/doc.go
@@ -28,40 +28,40 @@ Implemented protocol parts include:
 
 Marshalling and unmarshalling of defined PTP messages
 
-    Sync
-    Delay_Req
-    Pdelay_Req
-    Pdelay_Resp
-    Follow_Up
-    Delay_Resp
-    Pdelay_Resp_Follow_Up
-    Announce
-    Signaling
-    Management
+	Sync
+	Delay_Req
+	Pdelay_Req
+	Pdelay_Resp
+	Follow_Up
+	Delay_Resp
+	Pdelay_Resp_Follow_Up
+	Announce
+	Signaling
+	Management
 
 TLVs
 
-    MANAGEMENT
-    MANAGEMENT_ERROR_STATUS
-    REQUEST_UNICAST_TRANSMISSION
-    GRANT_UNICAST_TRANSMISSION
-    CANCEL_UNICAST_TRANSMISSION
-    ACKNOWLEDGE_CANCEL_UNICAST_TRANSMISSION
-    PATH_TRACE
-    ALTERNATE_TIME_OFFSET_INDICATOR
+	MANAGEMENT
+	MANAGEMENT_ERROR_STATUS
+	REQUEST_UNICAST_TRANSMISSION
+	GRANT_UNICAST_TRANSMISSION
+	CANCEL_UNICAST_TRANSMISSION
+	ACKNOWLEDGE_CANCEL_UNICAST_TRANSMISSION
+	PATH_TRACE
+	ALTERNATE_TIME_OFFSET_INDICATOR
 
 Management TLVs
 
-    DEFAULT_DATA_SET
-    CURRENT_DATA_SET
-    PARENT_DATA_SET
+	DEFAULT_DATA_SET
+	CURRENT_DATA_SET
+	PARENT_DATA_SET
 
 Non-portable ptp4l-specific Management TLVs
 
-    TIME_STATUS_NP
-    PORT_PROPERTIES_NP
-    PORT_STATS_NP
-    PORT_SERVICE_STATS_NP
-    UNICAST_MASTER_TABLE_NP
+	TIME_STATUS_NP
+	PORT_PROPERTIES_NP
+	PORT_STATS_NP
+	PORT_SERVICE_STATS_NP
+	UNICAST_MASTER_TABLE_NP
 */
 package protocol

--- a/ptp/protocol/management.go
+++ b/ptp/protocol/management.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -114,7 +113,7 @@ func (p *Management) UnmarshalBinary(rawBytes []byte) error {
 	if !found {
 		return fmt.Errorf("unsupported management TLV 0x%x", tlvHead.ManagementID)
 	}
-	tlvData, err := ioutil.ReadAll(r)
+	tlvData, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/ptp/protocol/protocol.go
+++ b/ptp/protocol/protocol.go
@@ -33,7 +33,8 @@ const (
 	MajorVersionMask uint8 = 0x0f
 )
 
-/* UDP port numbers
+/*
+UDP port numbers:
 The UDP destination port of a PTP event message shall be 319.
 The UDP destination port of a multicast PTP general message shall be 320.
 The UDP destination port of a unicast PTP general message that is addressed to a PTP Instance shall be 320.

--- a/ptp/protocol/types.go
+++ b/ptp/protocol/types.go
@@ -524,10 +524,11 @@ PTPText data type is used to represent textual material in PTP messages.
 TextField is encoded as UTF-8.
 The most significant byte of the leading text symbol shall be the element of the array with index 0.
 UTF-8 encoding has variable length, thus LengthField can be larger than number of characters.
-type PTPText struct {
-	LengthField uint8
-	TextField   []byte
-}
+
+	type PTPText struct {
+		LengthField uint8
+		TextField   []byte
+	}
 */
 type PTPText string
 

--- a/ptp/ptp4u/drain/file_test.go
+++ b/ptp/ptp4u/drain/file_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package drain
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 
 	check := &FileDrain{FileName: file.Name()}

--- a/ptp/ptp4u/server/config_test.go
+++ b/ptp/ptp4u/server/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -79,7 +78,7 @@ func TestReadDynamicConfigOk(t *testing.T) {
 	dc, err := ReadDynamicConfig("")
 	require.Error(t, err)
 	require.Nil(t, dc)
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	defer os.Remove(cfg.Name())
 
@@ -108,7 +107,7 @@ metricinterval: "5m"
 minsubinterval: "6s"
 utcoffset: "7s"
 `
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	defer os.Remove(cfg.Name())
 
@@ -122,7 +121,7 @@ utcoffset: "7s"
 
 func TestReadDynamicConfigDamaged(t *testing.T) {
 	config := "Random stuff"
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	defer os.Remove(cfg.Name())
 
@@ -153,7 +152,7 @@ utcoffset: 37s
 		UTCOffset:      37 * time.Second,
 	}
 
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	os.Remove(cfg.Name())
 	require.NoFileExists(t, cfg.Name())
@@ -178,7 +177,7 @@ func TestUTCOffsetSanity(t *testing.T) {
 }
 
 func TestPidFile(t *testing.T) {
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	defer os.Remove(cfg.Name())
 	c := &Config{StaticConfig: StaticConfig{PidFile: cfg.Name()}}

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -209,7 +208,7 @@ func TestHandleSighup(t *testing.T) {
 	require.Equal(t, 2, len(s.sw[0].queue))
 	require.Equal(t, 1, len(s.sw[1].queue))
 
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	defer os.Remove(cfg.Name())
 
@@ -243,7 +242,7 @@ utcoffset: "37s"
 }
 
 func TestHandleSigterm(t *testing.T) {
-	cfg, err := ioutil.TempFile("", "ptp4u")
+	cfg, err := os.CreateTemp("", "ptp4u")
 	require.NoError(t, err)
 	os.Remove(cfg.Name())
 	require.NoFileExists(t, cfg.Name())

--- a/ptp/ptp4u/stats/json_test.go
+++ b/ptp/ptp4u/stats/json_test.go
@@ -18,7 +18,7 @@ package stats
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -233,7 +233,7 @@ func TestJSONExport(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	var data map[string]int64


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
* Since Go 1.16 `io/ioutil` got deprecated. Replacing it with alternatives.
* Since Go 1.19 `fmt` got stricter on the comments. Running go fmt on 1.19.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/187257681-212087b9-18c3-4ec3-b3ea-a9dd925a9f44.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
