### PR TITLE
[ptpcheck] update diag to return exit code depending on result

### DIFF
--- a/cmd/ptpcheck/cmd/diag_test.go
+++ b/cmd/ptpcheck/cmd/diag_test.go
@@ -212,5 +212,23 @@ func TestPortServiceStatsDiagnosers(t *testing.T) {
 	status, msg = diagnosers[3](r)
 	assert.Equal(t, FAIL, status)
 	assert.Equal(t, "FollowUp mismatch count is 2000, we expect it to be within 100. We expect FollowUp packets to arrive in correct order", msg)
+}
 
+func TestRunDiagnosers(t *testing.T) {
+	toRun := []diagnoser{
+		checkGMPresent,
+		checkOffset,
+		checkPathDelay,
+	}
+	r := &checker.PTPCheckResult{
+		MeanPathDelayNS: 100.0,
+	}
+	exitCode := runDiagnosers(r, toRun)
+	require.Equal(t, 2, exitCode)
+	r.GrandmasterPresent = true
+	exitCode = runDiagnosers(r, toRun)
+	require.Equal(t, 1, exitCode)
+	r.OffsetFromMasterNS = 100.0
+	exitCode = runDiagnosers(r, toRun)
+	require.Equal(t, 0, exitCode)
 }


### PR DESCRIPTION
## Summary

Wouldn't it be great if we could rely on exit code to see if all is good?
With this change this dream becomes a reality, and ptpcheck will return the number of failed tests via exit code, and 127 if it failed miserably.

## Test Plan

unittests

manual run:
```
abulimov@dev0003 ~/g/time > sudo ./ptpcheck diag; echo $?
[ OK ] GM is present
[ OK ] Period since last ingress is 762.556412ms, we expect it to be within 1s
[ OK ] GM offset is 34ns, we expect it to be within 250µs
[ OK ] GM mean path delay is 4.96µs, we expect it to be within 100ms
[ OK ] Sync timeout count is 0, we expect it to be within 100
[ OK ] Announce timeout count is 0, we expect it to be within 100
[ OK ] Sync mismatch count is 0, we expect it to be within 100
[ OK ] FollowUp mismatch count is 0, we expect it to be within 100
0
abulimov@dev0003 ~/g/time > sudo systemctl restart ptp4l
abulimov@dev0003 ~/g/time > sudo ./ptpcheck diag; echo $?
[FAIL] GM is not present
[WARN] No ingress time data available
[FAIL] GM offset is 0s, we expect it to be non-zero and within 250µs. Offset is the difference between our clock and remote server (time error).
[FAIL] GM mean path delay is 0s, we expect it to be non-zero and within 100ms. Mean path delay is measured network delay between us and GM
[ OK ] Sync timeout count is 0, we expect it to be within 100
[ OK ] Announce timeout count is 0, we expect it to be within 100
[ OK ] Sync mismatch count is 0, we expect it to be within 100
[ OK ] FollowUp mismatch count is 0, we expect it to be within 100
4
```
