### PR TITLE
[ptp4u] don't send announce on reload

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -449,14 +449,6 @@ func (s *Server) handleSighup() {
 		s.Config.DynamicConfig = *dc
 		dcMux.Unlock()
 
-		// Sending announces
-		log.Info("Sending announces")
-		for _, worker := range s.sw {
-			clients := worker.FindClients(ptp.MessageAnnounce)
-			for _, sc := range clients {
-				sc.Reload()
-			}
-		}
 		s.Stats.IncReload()
 	}
 }

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -213,8 +213,7 @@ utcoffset: "37s"
 	require.Equal(t, expected.DynamicConfig, c.DynamicConfig)
 	dcMux.Unlock()
 
-	// Make sure after we send SIGHUP we get the event in the Announce queue only
-	require.Equal(t, 2, len(s.sw[0].queue))
+	require.Equal(t, 1, len(s.sw[0].queue))
 	require.Equal(t, 1, len(s.sw[1].queue))
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Reverting an extra announce on ptp4u reload.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
![image](https://user-images.githubusercontent.com/4749052/189929285-7f0ec219-12cd-4248-b51c-01f962890012.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
