### PR TITLE
[timestamp] check if hw timestamps are enabled before enabling them

### DIFF
--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -62,7 +62,7 @@ type ifreq struct {
 }
 
 // from include/uapi/linux/net_tstamp.h
-type hwtstampСonfig struct {
+type hwtstampConfig struct {
 	flags    int32
 	txType   int32
 	rxFilter int32


### PR DESCRIPTION
## Summary

Enabling timestamps requires `CAP_NET_ADMIN` capabilities, and we may already have them enabled when configuring socket.

## Test Plan

ran ptpcheck trace on MLNX and BCM machines, all works as expected.

if hw ts is not enabled we get correct msg:
```
failed to run ioctl SIOCSHWTSTAMP to set timestamps enabled: EPERM (operation not permitted)
```

if it's not supported, we get correct msg as well:
```
failed to run ioctl SIOCGHWTSTAMP to see what is enabled: ENOTSUP (operation not supported)
```
