### PR TITLE
[phc] ClockAdjtime and helper to get PHC frequency

### DIFF
--- a/phc/offset.go
+++ b/phc/offset.go
@@ -100,7 +100,7 @@ func TimeAndOffsetFromDevice(device string, method TimeMethod) (SysoffResult, er
 		defer f.Close()
 		var ts unix.Timespec
 		ts1 := time.Now()
-		err = unix.ClockGettime(fdToClockID(f.Fd()), &ts)
+		err = unix.ClockGettime(FDToClockID(f.Fd()), &ts)
 		ts2 := time.Now()
 		if err != nil {
 			return SysoffResult{}, fmt.Errorf("failed clock_gettime: %w", err)


### PR DESCRIPTION
## Summary

* ClockAdjtime function, similar to what `unix` package provides
* `IfaceToPHCDevice` function to help with mapping from iface to phc device
* Export `FBToClockID` so people using `ClockAdjtime` have this helper
* `FrequencyPPB` and `FrequencyPPBFromDevice` to simply get frequency from nic/phc

## Test Plan

manual runs of tools using this new functions