### PR TITLE
[ptp4u] graceful shutdown

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -51,6 +51,9 @@ type Server struct {
 	// drain logic
 	cancel context.CancelFunc
 	ctx    context.Context
+
+	// graceful shutdown
+	stop bool
 }
 
 // Start the workers send bind to event and general UDP ports
@@ -151,6 +154,12 @@ func (s *Server) Start() error {
 
 	// Wait for ANY gorouine to finish
 	wg.Wait()
+
+	// graceful shutdown
+	if s.stop {
+		return nil
+	}
+
 	return fmt.Errorf("one of server routines finished")
 }
 
@@ -468,4 +477,7 @@ func (s *Server) handleSigterm() {
 	if err := s.Config.DeletePidFile(); err != nil {
 		log.Fatalf("Failed to remove pid file: %v", err)
 	}
+
+	// graceful shutdown
+	s.stop = true
 }


### PR DESCRIPTION
Avoid returning an error on graceful shutdown.

Before:

```
ptp4u -workers 200 -timestamptype hardware -loglevel warning -dscp 35 -config /etc/ptp4u.yaml
WARN[0023]third-party-source/go/github.com/facebook/time/ptp/ptp4u/server/server.go:462 third-party-source/go/github.com/facebook/time/ptp/ptp4u/server.(*Server).handleSigterm() Shutting down ptp4u                          
WARN[0023]third-party-source/go/github.com/facebook/time/ptp/ptp4u/server/server.go:420 third-party-source/go/github.com/facebook/time/ptp/ptp4u/server.(*Server).Drain() Still waiting for 1 subscriptions on worker 118 to finish... 
FATA[0024]ptp/ptp4u/main.go:142 main.main() Server run failed: one of server routines finished 
```


After:

```
ptp4u -workers 200 -timestamptype hardware -loglevel warning -dscp 35 -config /etc/ptp4u.yaml
WARN[0024]third-party-source/go/github.com/facebook/time/ptp/ptp4u/server/server.go:471 third-party-source/go/github.com/facebook/time/ptp/ptp4u/server.(*Server).handleSigterm() Shutting down ptp4u                          
```