### PR TITLE
open-source fbclock

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Implementation of monitoring protocol used by Orolia [oscillatord](https://githu
 ### Calnex
 Command line tool and library for a Calnex Sentinel device.
 
+### fbclock
+Client C library and Go daemon to provide TrueTime API based on PTP time.
+
 # License
 time is licensed under Apache 2.0 as found in the [LICENSE file](LICENSE).
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -57,3 +57,21 @@ Cli Supports several basic commands such as:
 * Device reboot
 * Device clear
 * Device problem report export
+
+# fbclock
+## fbclock-daemon
+Stateful part of fbclock (TrueTime service).
+
+### Quick Installation
+```console
+go install github.com/facebook/time/cmd/fbclock-daemon@latest
+```
+
+## fbclock-bin
+Simple binary written in C that uses client part of fbclock service.
+
+### Quick Installation
+```console
+cd cmd/fbclock-bin
+make
+```

--- a/cmd/fbclock-bin/Makefile
+++ b/cmd/fbclock-bin/Makefile
@@ -1,0 +1,10 @@
+CC=gcc
+CFLAGS=-Wall -g -lrt -msse4.2 -std=gnu11
+
+fbclock-bin:
+	$(CC) $(CFLAGS) -o fbclock-bin fbclock-bin.c ../../fbclock/fbclock.c
+
+.PHONY: clean
+
+clean:
+	rm -f ./fbclock-bin

--- a/cmd/fbclock-bin/fbclock-bin.c
+++ b/cmd/fbclock-bin/fbclock-bin.c
@@ -1,0 +1,74 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "../../fbclock/fbclock.h"
+
+#include <ctype.h>  // for isprint
+#include <fcntl.h>  // For O_* constants
+#include <stdio.h>  // for printf and perror
+#include <stdlib.h> // for EXIT_* constants
+#include <unistd.h> // for sleep, getopt
+
+void show_error(int err_code) { puts(fbclock_strerror(err_code)); }
+
+int main(int argc, char *argv[]) {
+  fbclock_truetime truetime;
+  fbclock_lib lib;
+  int err;
+
+  int fflag = 0;
+  int c;
+
+  while ((c = getopt(argc, argv, "f")) != -1)
+    switch (c) {
+    case 'f':
+      fflag = 1;
+      break;
+    default:
+      fprintf(stderr, "Usage: %s [-f]\n  -f will print TrueTime in a loop\n",
+              argv[0]);
+      exit(EXIT_FAILURE);
+    }
+
+  err = fbclock_init(&lib, FBCLOCK_PATH);
+  if (err != 0) {
+    show_error(err);
+    exit(EXIT_FAILURE);
+  };
+
+  while (1) {
+    err = fbclock_gettime(&lib, &truetime);
+    if (err != 0) {
+      show_error(err);
+      exit(EXIT_FAILURE);
+    }
+    printf("TrueTime:\n");
+    printf("\tEarliest: %lu\n", truetime.earliest_ns);
+    printf("\tLatest: %lu\n", truetime.latest_ns);
+    printf("\tWOU=%lu ns\n", truetime.latest_ns - truetime.earliest_ns);
+    // if not asked to loop - stop
+    if (!fflag) {
+      break;
+    }
+    sleep(1);
+  }
+
+  err = fbclock_destroy(&lib);
+  if (err != 0) {
+    show_error(err);
+    exit(EXIT_FAILURE);
+  };
+}

--- a/cmd/fbclock-daemon/main.go
+++ b/cmd/fbclock-daemon/main.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/facebook/time/fbclock/daemon"
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	var (
+		cfg            = &daemon.Config{}
+		err            error
+		cfgPath        string
+		manageDevice   bool
+		csvLog         bool
+		csvPath        string
+		verbose        bool
+		monitoringPort int
+	)
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "fbclock daemon\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n\nFlags:\n", daemon.MathHelp)
+		flag.PrintDefaults()
+	}
+
+	flag.StringVar(&cfg.Device, "ptpdevice", "/dev/ptp0", "Path to original PTP device we need to copy if -manage is true")
+	flag.StringVar(&cfg.PTP4Lsock, "ptp4lsock", "/var/run/ptp4l", "Path to ptp4l unix socket")
+	flag.IntVar(&monitoringPort, "monitoringport", 21039, "Port to run monitoring server on")
+	flag.IntVar(&cfg.RingSize, "buffer", 100, "Size of ring buffers, must be at least size of largets num of samples used in M and W formulas")
+	flag.StringVar(&cfg.Math.M, "m", "mean(clockaccuracy, 100) + abs(mean(offset, 100)) + 1.0 * stddev(offset, 100)", "Math expression for M")
+	flag.StringVar(&cfg.Math.W, "w", "mean(m, 100) + 4.0 * stddev(m, 100)", "Math expression for W")
+	flag.StringVar(&cfg.Math.Drift, "drift", "mean(freqchangeabs, 99)", "Math expression for Drift PPB")
+	flag.DurationVar(&cfg.Interval, "i", time.Second, "Interval at which we talk to ptp4l and update data in shm")
+	flag.DurationVar(&cfg.LinearizabilityTestInterval, "I", time.Minute, "Interval at which we run linearizability tests. 0 means disabled.")
+
+	flag.StringVar(&cfgPath, "cfg", "", "Path to config")
+	flag.BoolVar(&manageDevice, "manage", true, "Manage devices")
+	flag.BoolVar(&csvLog, "csvlog", true, "Log all the metrics as CSV to log")
+	flag.StringVar(&csvPath, "csvpath", "", "write CSV log into this file")
+	flag.BoolVar(&verbose, "verbose", false, "Verbose logging")
+
+	flag.Parse()
+
+	log.SetReportCaller(true)
+	if verbose {
+		log.SetLevel(log.DebugLevel)
+	}
+	if csvPath != "" && !csvLog {
+		log.Fatalf("'csvpath' flag requires 'csvlog' flag")
+	}
+	if cfgPath != "" {
+		log.Warningf("using config from %s, flag values are ignored", cfgPath)
+		cfg, err = daemon.ReadConfig(cfgPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	if err := cfg.EvalAndValidate(); err != nil {
+		log.Fatal(err)
+	}
+	if manageDevice {
+		if err := daemon.SetupDeviceDir(cfg.Device); err != nil {
+			log.Fatal(err)
+		}
+	}
+	log.Debugf("Config: %+v", *cfg)
+
+	// set up sample logging
+	w := log.StandardLogger().Writer()
+	defer w.Close()
+	var l daemon.Logger = daemon.NewDummyLogger(w)
+	if csvLog {
+		csvW := io.Writer(w)
+		// set up logging of CSV samples to file
+		if csvPath != "" {
+			f, err := os.Create(csvPath)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer f.Close()
+			// write both to stderr and file
+			csvW = io.MultiWriter(w, f)
+		}
+		l = daemon.NewCSVLogger(csvW)
+	}
+	stats := daemon.NewJSONStats()
+	go stats.Start(monitoringPort)
+	s, err := daemon.New(cfg, stats, l)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := s.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/fbclock/Makefile
+++ b/fbclock/Makefile
@@ -1,0 +1,16 @@
+CC=gcc
+CFLAGS=-Wall -g -lrt -msse4.2 -std=gnu11
+CPP=g++
+CPPFLAGS=-fpermissive -lrt -lpthread -msse4.2 -lgtest -g
+
+.PHONY: clean test
+
+fbclock:
+	$(CC) $(CFLAGS) -shared -o fbclock.so -fPIC fbclock.c 
+
+test:
+	$(CPP) $(CPPFLAGS) -o fbclock-test test/test.cpp fbclock.c
+	./fbclock-test
+
+clean:
+	rm -f ./fbclock.so ./fbclock-test ./fbclock.so

--- a/fbclock/daemon/config.go
+++ b/fbclock/daemon/config.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// Config represents configuration we expect to read from file
+type Config struct {
+	PTP4Lsock                   string        // how to talk to ptp4l
+	RingSize                    int           // must be at least the size of N samples we use in expressions
+	Math                        Math          // configuration for calculation we'll be doing
+	Interval                    time.Duration // how often do we poll ptp4l and update data in shm
+	Device                      string        // path to ptp device
+	LinearizabilityTestInterval time.Duration // perform the linearizability test every so often
+}
+
+// EvalAndValidate makes sure config is valid and evaluates expressions for further use.
+func (c *Config) EvalAndValidate() error {
+	if c.PTP4Lsock == "" {
+		return fmt.Errorf("bad config: 'ptp4lsock' must be specified")
+	}
+	if c.RingSize <= 0 {
+		return fmt.Errorf("bad config: 'ringsize' must be >0")
+	}
+	if c.Interval > time.Minute {
+		return fmt.Errorf("bad config: 'interval' is over a minute")
+	}
+	if err := c.Math.Prepare(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadConfig reads config and unmarshals it from yaml into Config
+func ReadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	c := Config{}
+	err = yaml.UnmarshalStrict(data, &c)
+	return &c, err
+}

--- a/fbclock/daemon/daemon.go
+++ b/fbclock/daemon/daemon.go
@@ -1,0 +1,536 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/facebook/time/fbclock"
+
+	"github.com/facebook/time/ptp/linearizability"
+
+	"github.com/facebook/time/phc"
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+var errNotEnoughData = fmt.Errorf("not enough data points")
+
+// connect creates connection to unix socket in unixgram mode
+func connect(address, local string, timeout time.Duration) (*net.UnixConn, error) {
+	deadline := time.Now().Add(timeout)
+
+	addr, err := net.ResolveUnixAddr("unixgram", address)
+	if err != nil {
+		return nil, err
+	}
+	localAddr, _ := net.ResolveUnixAddr("unixgram", local)
+	conn, err := net.DialUnix("unixgram", localAddr, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Chmod(local, 0666); err != nil {
+		return nil, err
+	}
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		return nil, err
+	}
+	log.Debugf("connected to %s", address)
+	return conn, nil
+}
+
+// dataPoint is what we store in datapoint ring buffer
+type dataPoint struct {
+	ingressTimeNS     int64
+	masterOffsetNS    float64
+	pathDelayNS       float64
+	freqAdjustmentPPB float64
+	clockAccuracyNS   float64
+}
+
+func (d *dataPoint) SanityCheck() error {
+	if d.ingressTimeNS == 0 {
+		return fmt.Errorf("ingress time is 0")
+	}
+
+	if d.masterOffsetNS == 0 || d.pathDelayNS == 0 || d.freqAdjustmentPPB == 0 || d.clockAccuracyNS == 0 {
+		return fmt.Errorf("some of the data point values are 0")
+	}
+	if time.Duration(d.clockAccuracyNS) >= ptp.ClockAccuracyUnknown.Duration() {
+		return fmt.Errorf("clock accuracy is unknown")
+	}
+	return nil
+}
+
+// Daemon is a component of fbclock that
+// runs continuously,
+// talks to ptp4l,
+// does the math
+// and populates shared memory for client library to read from.
+type Daemon struct {
+	//*fb303.FacebookBase
+	//server thrift.Server
+
+	cfg   *Config
+	state *daemonState
+	stats StatsServer
+	l     Logger
+
+	// function to get PHC time from configured PHC device
+	getPHCTime func() (time.Time, error)
+	// function to get PHC freq from configured PHC device
+	getPHCFreqPPB func() (float64, error)
+}
+
+// minRingSize calculate how many datapoint we need to have in a ring buffer
+// in order to provide aggregate values over 1 minute
+func minRingSize(configuredRingSize int, interval time.Duration) int {
+	size := configuredRingSize
+	if time.Duration(size)*interval < time.Minute {
+		size = int(math.Ceil(float64(time.Minute) / float64(interval)))
+	}
+	return size
+}
+
+// New creates new fbclock-daemon
+func New(cfg *Config, stats StatsServer, l Logger) (*Daemon, error) {
+	// we need at least 1m of samples for aggregate values
+	effectiveRingSize := minRingSize(cfg.RingSize, cfg.Interval)
+	s := &Daemon{
+		stats: stats,
+		state: newDaemonState(effectiveRingSize),
+		cfg:   cfg,
+		l:     l,
+	}
+	// function to get time from phc
+	s.getPHCTime = func() (time.Time, error) { return phc.TimeFromDevice(s.cfg.Device) }
+	s.getPHCFreqPPB = func() (float64, error) { return phc.FrequencyPPBFromDevice(s.cfg.Device) }
+	// calculated values
+	s.stats.SetCounter("m_ns", 0)
+	s.stats.SetCounter("w_ns", 0)
+	s.stats.SetCounter("time_since_ingress_ns", 0)
+	// error counters
+	s.stats.SetCounter("data_error", 0)
+	s.stats.SetCounter("phc_error", 0)
+	s.stats.SetCounter("processing_error", 0)
+	s.stats.SetCounter("data_sanity_check_error", 0)
+	// values collected from ptp4l
+	s.stats.SetCounter("ingress_time_ns", 0)
+	s.stats.SetCounter("master_offset_ns", 0)
+	s.stats.SetCounter("path_delay_ns", 0)
+	s.stats.SetCounter("freq_adj_ppb", 0)
+	s.stats.SetCounter("clock_accuracy_ns", 0)
+	// aggregated values
+	s.stats.SetCounter("master_offset_ns.60.abs_max", 0)
+	s.stats.SetCounter("path_delay_ns.60.abs_max", 0)
+	s.stats.SetCounter("freq_adj_ppb.60.abs_max", 0)
+	return s, nil
+}
+
+func (s *Daemon) calcW() (float64, error) {
+	lastN := s.state.takeDataPoint(s.cfg.RingSize)
+	if len(lastN) != s.cfg.RingSize {
+		return 0, fmt.Errorf("%w getting M: want %d, got %d", errNotEnoughData, s.cfg.RingSize, len(lastN))
+	}
+	params := prepareMathParameters(lastN)
+	logSample := &LogSample{
+		MasterOffsetNS:          params["offset"][0],
+		MasterOffsetMeanNS:      mean(params["offset"]),
+		MasterOffsetStddevNS:    stddev(params["offset"]),
+		PathDelayNS:             params["delay"][0],
+		PathDelayMeanNS:         mean(params["delay"]),
+		PathDelayStddevNS:       stddev(params["delay"]),
+		FreqAdjustmentPPB:       params["freq"][0],
+		FreqAdjustmentMeanPPB:   mean(params["freq"]),
+		FreqAdjustmentStddevPPB: stddev(params["freq"]),
+		ClockAccuracyMean:       mean(params["clockaccuracie"]),
+	}
+	mRaw, err := s.cfg.Math.mExpr.Evaluate(mapOfInterface(params))
+	if err != nil {
+		return 0, err
+	}
+	m := mRaw.(float64)
+	logSample.MeasurementNS = m
+	s.stats.SetCounter("m_ns", int64(m))
+
+	// push m to ring buffer
+	s.state.pushM(m)
+
+	ms := s.state.takeM(s.cfg.RingSize)
+	if len(ms) != s.cfg.RingSize {
+		return 0, fmt.Errorf("%w getting W: want %d, got %d", errNotEnoughData, s.cfg.RingSize, len(ms))
+	}
+
+	parameters := map[string]interface{}{
+		"m": ms,
+	}
+	logSample.MeasurementMeanNS = mean(ms)
+	logSample.MeasurementStddevNS = stddev(ms)
+
+	wRaw, err := s.cfg.Math.wExpr.Evaluate(parameters)
+	if err != nil {
+		return 0, err
+	}
+	w := wRaw.(float64)
+	logSample.WindowNS = w
+	if err := s.l.Log(logSample); err != nil {
+		log.Errorf("failed to log sample: %v", err)
+	}
+	s.stats.SetCounter("w_ns", int64(w))
+	return w, nil
+}
+
+func (s *Daemon) calcDriftPPB() (float64, error) {
+	lastN := s.state.takeDataPoint(s.cfg.RingSize)
+	if len(lastN) != s.cfg.RingSize {
+		return 0, fmt.Errorf("%w calculating drift: want %d, got %d", errNotEnoughData, s.cfg.RingSize, len(lastN))
+	}
+	params := prepareMathParameters(lastN)
+	driftRaw, err := s.cfg.Math.driftExpr.Evaluate(mapOfInterface(params))
+	if err != nil {
+		return 0, err
+	}
+	drift := driftRaw.(float64)
+	return drift, nil
+}
+
+func (s *Daemon) gmDataFromSocket(local string) (targets []string, iface string, err error) {
+	timeout := s.cfg.Interval / 2
+	conn, err := connect(s.cfg.PTP4Lsock, local, timeout)
+	defer func() {
+		if conn != nil {
+			conn.Close()
+			if f, err := conn.File(); err == nil {
+				f.Close()
+			}
+		}
+		// make sure there is no leftover socket
+		os.RemoveAll(local)
+	}()
+	if err != nil {
+		return targets, iface, fmt.Errorf("failed to connect to ptp4l: %w", err)
+	}
+
+	c := &ptp.MgmtClient{
+		Connection: conn,
+	}
+	ppn, err := c.PortPropertiesNP()
+	if err != nil {
+		return targets, iface, fmt.Errorf("getting PORT_PROPERTIES_NP from ptp4l: %w", err)
+	}
+	log.Debugf("working with interface %s", ppn.Interface)
+	iface = string(ppn.Interface)
+	tlv, err := c.UnicastMasterTableNP()
+	if err != nil {
+		return targets, iface, fmt.Errorf("getting UNICAST_MASTER_TABLE_NP from ptp4l: %w", err)
+	}
+
+	for _, entry := range tlv.UnicastMasterTable.UnicastMasters {
+		// skip the current best master
+		if entry.Selected {
+			continue
+		}
+		// skip GMs we didn't get announce from
+		if entry.PortState == ptp.UnicastMasterStateWait {
+			continue
+		}
+		server := entry.Address.String()
+		targets = append(targets, server)
+	}
+	return
+}
+
+func (s *Daemon) dataFromSocket(local string) (*dataPoint, error) {
+	timeout := s.cfg.Interval / 2
+	conn, err := connect(s.cfg.PTP4Lsock, local, timeout)
+	defer func() {
+		if conn != nil {
+			conn.Close()
+			if f, err := conn.File(); err == nil {
+				f.Close()
+			}
+		}
+		// make sure there is no leftover socket
+		os.RemoveAll(local)
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to ptp4l: %w", err)
+	}
+
+	c := &ptp.MgmtClient{
+		Connection: conn,
+	}
+	status, err := c.TimeStatusNP()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TIME_STATUS_NP: %w", err)
+	}
+	log.Debugf("TIME_STATUS_NP: %+v", status)
+
+	pds, err := c.ParentDataSet()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PARENT_DATA_SET: %w", err)
+	}
+	cds, err := c.CurrentDataSet()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CURRENT_DATA_SET: %w", err)
+	}
+	accuracyNS := pds.GrandmasterClockQuality.ClockAccuracy.Duration().Nanoseconds()
+
+	return &dataPoint{
+		ingressTimeNS:   status.IngressTimeNS,
+		masterOffsetNS:  float64(status.MasterOffsetNS),
+		pathDelayNS:     cds.MeanPathDelay.Nanoseconds(),
+		clockAccuracyNS: float64(int64(status.GMPresent) * accuracyNS),
+	}, nil
+}
+
+func (s *Daemon) calculateSHMData(data *dataPoint) (*fbclock.Data, error) {
+	if err := data.SanityCheck(); err != nil {
+		s.stats.UpdateCounterBy("data_sanity_check_error", 1)
+		return nil, fmt.Errorf("sanity checking data point: %w", err)
+	}
+	s.stats.SetCounter("data_sanity_check_error", 0)
+
+	// store datapoint in ring buffer
+	s.state.pushDataPoint(data)
+
+	// calculate W
+	w, err := s.calcW()
+	if err != nil {
+		return nil, fmt.Errorf("calculating W: %w", err)
+	}
+
+	wUint := uint64(w)
+	if wUint == 0 {
+		return nil, fmt.Errorf("value of W is 0")
+	}
+	// drift is in PPB, parts per billion.
+	// 1ns = 1/billions of second, so we can just say that
+	// hValue is measured in ns per second
+	hValue, err := s.calcDriftPPB()
+	if err != nil {
+		return nil, fmt.Errorf("calculating drift: %w", err)
+	}
+	// increase the hValue by 50% to be conservative
+	hValue *= 1.5
+	return &fbclock.Data{
+		IngressTimeNS:        data.ingressTimeNS,
+		ErrorBoundNS:         wUint,
+		HoldoverMultiplierNS: hValue,
+	}, nil
+}
+
+func (s *Daemon) doWork(shm *fbclock.Shm, data *dataPoint) error {
+	// push stats
+	s.stats.SetCounter("master_offset_ns", int64(data.masterOffsetNS))
+	s.stats.SetCounter("path_delay_ns", int64(data.pathDelayNS))
+	s.stats.SetCounter("ingress_time_ns", data.ingressTimeNS)
+	s.stats.SetCounter("freq_adj_ppb", int64(data.freqAdjustmentPPB))
+	s.stats.SetCounter("clock_accuracy_ns", int64(data.clockAccuracyNS))
+	// try and calculate how long ago was the ingress time
+	// use clock_gettime as the fastest and widely available method
+	if phcTime, err := s.getPHCTime(); err != nil {
+		log.Warningf("Failed to get PHC time from %s: %v", s.cfg.Device, err)
+	} else {
+		if data.ingressTimeNS > 0 {
+			s.state.updateIngressTimeNS(data.ingressTimeNS)
+		}
+		it := s.state.ingressTimeNS()
+		if it > 0 {
+			timeSinceIngress := phcTime.UnixNano() - it
+			s.stats.SetCounter("time_since_ingress_ns", timeSinceIngress)
+			log.Debugf("Time since ingress: %dns", timeSinceIngress)
+		} else {
+			log.Warningf("No data for time since ingress")
+		}
+	}
+	// store everything in shared memory
+	d, err := s.calculateSHMData(data)
+	if err != nil {
+		if errors.Is(err, errNotEnoughData) {
+			log.Warning(err)
+			return nil
+		}
+		return err
+	}
+	if err := fbclock.StoreFBClockData(shm.File.Fd(), *d); err != nil {
+		return err
+	}
+	// aggregated stats over 1 minute
+	maxDp := s.state.aggregateDataPointsMax(minRingSize(s.cfg.RingSize, s.cfg.Interval))
+	s.stats.SetCounter("master_offset_ns.60.abs_max", int64(maxDp.masterOffsetNS))
+	s.stats.SetCounter("path_delay_ns.60.abs_max", int64(maxDp.pathDelayNS))
+	s.stats.SetCounter("freq_adj_ppb.60.abs_max", int64(maxDp.freqAdjustmentPPB))
+	return nil
+}
+
+func targetsDiff(oldTargets []string, targets []string) (added []string, removed []string) {
+	m := map[string]bool{}
+	for _, k := range oldTargets {
+		m[k] = true
+	}
+	for _, k := range targets {
+		if m[k] {
+			delete(m, k)
+		} else {
+			added = append(added, k)
+		}
+	}
+	for k := range m {
+		removed = append(removed, k)
+	}
+	return
+}
+
+func (s *Daemon) runLinearizabilityTests(ctx context.Context) {
+	testers := map[string]*linearizability.Tester{}
+	oldTargets := []string{}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	m := new(sync.Mutex)
+
+	local := filepath.Join("/var/run/", fmt.Sprintf("fbclock.%d.linear.sock", os.Getpid()))
+	ticker := time.NewTicker(s.cfg.LinearizabilityTestInterval)
+	defer ticker.Stop()
+	for ; true; <-ticker.C { // first run without delay, then at interval
+		eg := new(errgroup.Group)
+		currentResults := map[string]*linearizability.TestResult{}
+
+		targets, iface, err := s.gmDataFromSocket(local)
+		if err != nil {
+			log.Errorf("getting linearizability test targets from ptp4l: %v", err)
+			continue
+		}
+		log.Debugf("targets: %v, iface: %q, err: %v", targets, iface, err)
+		// log when set of targets changes
+		added, removed := targetsDiff(oldTargets, targets)
+		if len(added) > 0 || len(removed) > 0 {
+			log.Infof("new set of linearizability test targets. Added: %v, Removed: %v. Resulting set: %v", added, removed, targets)
+			// we never remove testers, as stopping background listener goroutine is not easy
+			oldTargets = targets
+		}
+
+		for _, server := range targets {
+			server := server
+			log.Debugf("talking to %s", server)
+			lt, found := testers[server]
+			if !found { // create tester and start listener only once
+				cfg := &linearizability.TestConfig{
+					Timeout:   time.Second,
+					Server:    server,
+					Interface: iface,
+				}
+				lt, err = linearizability.NewTester(cfg)
+				if err != nil {
+					log.Errorf("creating tester: %v", err)
+					continue
+				}
+				testers[server] = lt
+				go func() {
+					server := server
+					lt := lt
+					if err := lt.RunListener(ctx); err != nil {
+						log.Errorf("running listener for %s: %v", server, err)
+					}
+				}()
+			}
+			eg.Go(func() error {
+				res := lt.RunTest(ctx)
+				m.Lock()
+				currentResults[server] = &res
+				m.Unlock()
+				return nil
+			})
+		}
+		err = eg.Wait()
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Error(err)
+		}
+
+		// get result, log it and push it into ring buffer
+		for _, res := range currentResults {
+			good, err := res.Good()
+			if err != nil {
+				log.Errorf(res.Explain())
+				continue
+			}
+			if !good {
+				log.Warningf(res.Explain())
+			}
+			log.Debugf("got linearizability result: %s", res.Explain())
+			s.state.pushLinearizabilityTestResult(res)
+		}
+		// add stats from linearizability checks
+		stats := linearizability.ProcessMonitoringResults("linearizability.", currentResults)
+		for k, v := range stats {
+			s.stats.SetCounter(k, int64(v))
+		}
+	}
+}
+
+func (s *Daemon) Run(ctx context.Context) error {
+	shm, err := fbclock.OpenFBClockSHM()
+	if err != nil {
+		return fmt.Errorf("opening fbclock shm: %w", err)
+	}
+	defer shm.Close()
+
+	if s.cfg.LinearizabilityTestInterval != 0 {
+		go s.runLinearizabilityTests(ctx)
+	}
+	local := filepath.Join("/var/run/", fmt.Sprintf("fbclock.%d.sock", os.Getpid()))
+
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+	for ; true; <-ticker.C { // first run without delay, then at interval
+		data, err := s.dataFromSocket(local)
+		if err != nil {
+			log.Error(err)
+			s.stats.UpdateCounterBy("data_error", 1)
+			continue
+		}
+		s.stats.SetCounter("data_error", 0)
+		// get PHC freq adjustment
+		freqPPB, err := s.getPHCFreqPPB()
+		if err != nil {
+			log.Error(err)
+			s.stats.UpdateCounterBy("phc_error", 1)
+			continue
+		}
+		s.stats.SetCounter("phc_error", 0)
+		data.freqAdjustmentPPB = freqPPB
+		if err := s.doWork(shm, data); err != nil {
+			log.Error(err)
+			s.stats.UpdateCounterBy("processing_error", 1)
+			continue
+		}
+		s.stats.SetCounter("processing_error", 0)
+	}
+	return nil
+}

--- a/fbclock/daemon/daemon_test.go
+++ b/fbclock/daemon/daemon_test.go
@@ -1,0 +1,613 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/facebook/time/fbclock"
+	"github.com/facebook/time/ptp/linearizability"
+
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+type testLogger struct {
+	samples []*LogSample
+}
+
+func (l *testLogger) Log(s *LogSample) error {
+	l.samples = append(l.samples, s)
+	return nil
+}
+
+func newTestDaemon(cfg *Config, stats StatsServer) *Daemon {
+	s := &Daemon{
+		stats: stats,
+		cfg:   cfg,
+		state: newDaemonState(cfg.RingSize),
+		l:     &testLogger{samples: []*LogSample{}},
+	}
+	return s
+}
+
+func TestDaemonStateLinearizabilityRing(t *testing.T) {
+	s := newDaemonState(3)
+
+	probes := []*linearizability.TestResult{
+		{
+			Server:      "server01",
+			TXTimestamp: time.Unix(0, 1647359186979431100),
+			RXTimestamp: time.Unix(0, 1647359186979431635),
+		},
+		{
+			Server:      "server02",
+			TXTimestamp: time.Unix(0, 1647359186979431200),
+			RXTimestamp: time.Unix(0, 1647359186979431735),
+		},
+		{
+			Server:      "server01",
+			TXTimestamp: time.Unix(0, 1647359186979431300),
+			RXTimestamp: time.Unix(0, 1647359186979431835),
+		},
+	}
+
+	for _, tr := range probes {
+		s.pushLinearizabilityTestResult(tr)
+	}
+	got := s.takeLinearizabilityTestResult(3)
+	require.ElementsMatch(t, probes, got)
+}
+
+func TestDaemonStateAggregateMax(t *testing.T) {
+	s := newDaemonState(3)
+
+	probes := []*dataPoint{
+		{
+			masterOffsetNS:    123.0,
+			pathDelayNS:       3,
+			freqAdjustmentPPB: 4,
+		},
+		{
+			masterOffsetNS:    -2000.0,
+			pathDelayNS:       300,
+			freqAdjustmentPPB: 2,
+		},
+		{
+			masterOffsetNS:    1009.0,
+			pathDelayNS:       200,
+			freqAdjustmentPPB: 5,
+		},
+	}
+
+	for _, tr := range probes {
+		s.pushDataPoint(tr)
+	}
+	got := s.aggregateDataPointsMax(3)
+	want := &dataPoint{
+		masterOffsetNS:    2000.0,
+		pathDelayNS:       300,
+		freqAdjustmentPPB: 5,
+	}
+	require.Equal(t, want, got)
+}
+
+func TestTargetsChange(t *testing.T) {
+	testCases := []struct {
+		name        string
+		oldTargets  []string
+		targets     []string
+		wantAdded   []string
+		wantRemoved []string
+	}{
+		{
+			name: "no new targets",
+			oldTargets: []string{
+				"server1",
+				"server2",
+			},
+			targets:   []string{},
+			wantAdded: []string{},
+			wantRemoved: []string{
+				"server1",
+				"server2",
+			},
+		},
+		{
+			name:       "no old targets",
+			oldTargets: []string{},
+			targets:    []string{"server1", "server2"},
+			wantAdded: []string{
+				"server1",
+				"server2",
+			},
+			wantRemoved: []string{},
+		},
+		{
+			name: "removed old tester",
+			oldTargets: []string{
+				"server1",
+				"server3",
+				"server2",
+			},
+			targets:     []string{"server1", "server2"},
+			wantAdded:   []string{},
+			wantRemoved: []string{"server3"},
+		},
+		{
+			name: "added target",
+			oldTargets: []string{
+				"server1",
+				"server2",
+			},
+			targets:     []string{"server1", "server2", "server3"},
+			wantAdded:   []string{"server3"},
+			wantRemoved: []string{},
+		},
+		{
+			name: "equal",
+			oldTargets: []string{
+				"server2",
+				"server1",
+			},
+			targets:     []string{"server1", "server2"},
+			wantAdded:   []string{},
+			wantRemoved: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAdded, gotRemoved := targetsDiff(tc.oldTargets, tc.targets)
+			assert.ElementsMatch(t, tc.wantAdded, gotAdded, "added")
+			assert.ElementsMatch(t, tc.wantRemoved, gotRemoved, "removed")
+		})
+	}
+}
+
+func TestMathPrepare(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      *Math
+		wantErr bool
+	}{
+		{
+			name: "basic math",
+			in: &Math{
+				M:     "1 + 3",
+				W:     "4 / 1",
+				Drift: "1 - 0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown function",
+			in: &Math{
+				M:     "1 + 3",
+				W:     "missing(m)",
+				Drift: "1 - 0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "known function",
+			in: &Math{
+				M:     "1 + 3",
+				W:     "mean(m)",
+				Drift: "1 - 0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown variable",
+			in: &Math{
+				M:     "1 + 3",
+				W:     "mean(missing)",
+				Drift: "1 - 0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "no data",
+			in: &Math{
+				M:     "",
+				W:     "",
+				Drift: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "all good",
+			in: &Math{
+				M:     "abs(mean(offset, 30)) + 1.0 * stddev(offset, 30) + 1.0 * stddev(delay, 10) + 1.0 * stddev(freq, 5)",
+				W:     "mean(m, 30) + 4.0 * stddev(m, 30)",
+				Drift: "mean(freqchangeabs, 29)",
+			},
+			wantErr: false,
+		},
+		{
+			name: "all good with clock accuracy",
+			in: &Math{
+				M:     "mean(clockaccuracy, 30) + abs(mean(offset, 30)) + 1.0 * stddev(offset, 30)",
+				W:     "mean(m, 30) + 4.0 * stddev(m, 30)",
+				Drift: "mean(freqchangeabs, 29)",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.Prepare()
+			if tc.wantErr {
+				assert.Error(t, got)
+			} else {
+				assert.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestDataPointSanityCheck(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      *dataPoint
+		wantErr bool
+	}{
+		{
+			name: "no ingress time",
+			in: &dataPoint{
+				ingressTimeNS:     0,
+				masterOffsetNS:    23.0,
+				pathDelayNS:       213.0,
+				freqAdjustmentPPB: 212131,
+				clockAccuracyNS:   25.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero offset",
+			in: &dataPoint{
+				ingressTimeNS:     1647359186979431900,
+				masterOffsetNS:    0,
+				pathDelayNS:       213.0,
+				freqAdjustmentPPB: 212131,
+				clockAccuracyNS:   25.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero delay",
+			in: &dataPoint{
+				ingressTimeNS:     1647359186979431900,
+				masterOffsetNS:    123,
+				pathDelayNS:       0,
+				freqAdjustmentPPB: 212131,
+				clockAccuracyNS:   25.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero freq",
+			in: &dataPoint{
+				ingressTimeNS:     1647359186979431900,
+				masterOffsetNS:    123,
+				pathDelayNS:       213.0,
+				freqAdjustmentPPB: 0,
+				clockAccuracyNS:   25.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero clock accuracy",
+			in: &dataPoint{
+				ingressTimeNS:     1647359186979431900,
+				masterOffsetNS:    123,
+				pathDelayNS:       213.0,
+				freqAdjustmentPPB: 212131,
+				clockAccuracyNS:   0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown clock accuracy",
+			in: &dataPoint{
+				ingressTimeNS:     1647359186979431900,
+				masterOffsetNS:    123,
+				pathDelayNS:       213.0,
+				freqAdjustmentPPB: 212131,
+				clockAccuracyNS:   float64(ptp.ClockAccuracyUnknown.Duration()),
+			},
+			wantErr: true,
+		},
+		{
+			name: "all good",
+			in: &dataPoint{
+				ingressTimeNS:     1647359186979431900,
+				masterOffsetNS:    123,
+				pathDelayNS:       213.0,
+				freqAdjustmentPPB: 212131,
+				clockAccuracyNS:   25.0,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.SanityCheck()
+			if tc.wantErr {
+				assert.Error(t, got)
+			} else {
+				assert.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestDaemonCalculateSHMData(t *testing.T) {
+	cfg := &Config{
+		RingSize: 30,
+		Math: Math{
+			M:     "mean(clockaccuracy, 30) + abs(mean(offset, 30)) + 1.0 * stddev(offset, 30)",
+			W:     "mean(m, 30) + 4.0 * stddev(m, 30)",
+			Drift: "mean(freqchangeabs, 29)",
+		},
+	}
+	err := cfg.Math.Prepare()
+	require.NoError(t, err)
+	stats := NewStats()
+	s := newTestDaemon(cfg, stats)
+	startTime := time.Duration(1647359186979431900)
+	var d *dataPoint
+	adj := 212131.0
+	for i := 0; i < 58; i++ {
+		if i%2 == 0 {
+			adj += float64(i)
+		} else {
+			adj -= float64(i)
+		}
+		d = &dataPoint{
+			ingressTimeNS:     int64(startTime + time.Duration(i)*time.Second),
+			masterOffsetNS:    23.0,
+			pathDelayNS:       213.0,
+			freqAdjustmentPPB: adj,
+			clockAccuracyNS:   100.0,
+		}
+		shmData, err := s.calculateSHMData(d)
+		require.Nil(t, shmData)
+		require.Error(t, err, "not enough data should give us error when calculating shm state")
+	}
+	d = &dataPoint{
+		ingressTimeNS:     int64(startTime + 61*time.Second),
+		masterOffsetNS:    23.0,
+		pathDelayNS:       213.0,
+		freqAdjustmentPPB: 212131,
+		clockAccuracyNS:   100.0,
+	}
+
+	want := &fbclock.Data{
+		IngressTimeNS:        d.ingressTimeNS,
+		ErrorBoundNS:         123.0,
+		HoldoverMultiplierNS: 64.5,
+	}
+	shmData, err := s.calculateSHMData(d)
+	require.NoError(t, err)
+	require.Equal(t, want, shmData)
+
+	// ptp4l got restarted, not yet syncing, all values are zeroes
+	d = &dataPoint{
+		ingressTimeNS:     0,
+		masterOffsetNS:    0,
+		pathDelayNS:       0,
+		freqAdjustmentPPB: 0,
+	}
+	shmData, err = s.calculateSHMData(d)
+	require.Error(t, err, "we expect calculateSHMData to produce no new shm state when new input is invalid")
+	require.Nil(t, shmData)
+	// ptp4l started syncing, but haven't started updating the clock
+	d = &dataPoint{
+		ingressTimeNS:     int64(startTime + 65*time.Second),
+		masterOffsetNS:    0,
+		pathDelayNS:       213,
+		freqAdjustmentPPB: 0,
+	}
+	shmData, err = s.calculateSHMData(d)
+	require.Nil(t, shmData)
+	require.Error(t, err, "we expect calculateSHMData to produce no new shm state when new input is incomplete")
+
+	// ptp4l is back to normal operations
+	d = &dataPoint{
+		ingressTimeNS:     int64(startTime + 66*time.Second),
+		masterOffsetNS:    234,
+		pathDelayNS:       213,
+		freqAdjustmentPPB: 32333,
+		clockAccuracyNS:   100,
+	}
+	shmData, err = s.calculateSHMData(d)
+	want = &fbclock.Data{
+		IngressTimeNS:        d.ingressTimeNS,
+		ErrorBoundNS:         157,
+		HoldoverMultiplierNS: 9362.84482758621,
+	}
+	require.NoError(t, err)
+	assert.Equal(t, want, shmData)
+}
+
+func TestDaemonDoWork(t *testing.T) {
+	cfg := &Config{
+		Interval: time.Second,
+		RingSize: 30,
+		Math: Math{
+			M:     "mean(clockaccuracy, 30) + abs(mean(offset, 30)) + 1.0 * stddev(offset, 30)",
+			W:     "mean(m, 30) + 4.0 * stddev(m, 30)",
+			Drift: "mean(freqchangeabs, 29)",
+		},
+	}
+	err := cfg.Math.Prepare()
+	require.NoError(t, err)
+	stats := NewStats()
+	s := newTestDaemon(cfg, stats)
+	startTime := time.Duration(1647359186979431900)
+	phcTime := startTime // we modify this during the test
+	// override function to get PHC time
+	s.getPHCTime = func() (time.Time, error) { return time.Unix(0, int64(phcTime)), nil }
+	// shared mem
+	tmpFile, err := os.CreateTemp("", "daemon_test")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	shm, err := fbclock.OpenFBClockShmCustom(tmpFile.Name())
+	require.NoError(t, err)
+	defer shm.Close()
+
+	// populate the data
+	var d *dataPoint
+
+	// bad data (ptp4l is just starting)
+	for i := 0; i < 10; i++ {
+		d = &dataPoint{
+			ingressTimeNS:     0,
+			masterOffsetNS:    0,
+			pathDelayNS:       0,
+			freqAdjustmentPPB: 0,
+		}
+		err = s.doWork(shm, d)
+		require.Error(t, err, "not enough data should give us error when calculating shm state")
+		// not enough data for those
+		require.Equal(t, int64(0), stats.counters["ingress_time_ns"])
+		require.Equal(t, int64(0), stats.counters["time_since_ingress_ns"])
+		require.Equal(t, int64(0), stats.counters["master_offset_ns"])
+		require.Equal(t, int64(0), stats.counters["path_delay_ns"])
+		require.Equal(t, int64(0), stats.counters["freq_adj_ppb"])
+		require.Equal(t, int64(0), stats.counters["master_offset_ns.60.abs_max"])
+		require.Equal(t, int64(0), stats.counters["path_delay_ns.60.abs_max"])
+		require.Equal(t, int64(0), stats.counters["freq_adj_ppb.60.abs_max"])
+		require.Equal(t, int64(i+1), stats.counters["data_sanity_check_error"])
+	}
+	// good data
+	adj := 212131.0
+	for i := 0; i < 58; i++ {
+		if i%2 == 0 {
+			adj += float64(i)
+		} else {
+			adj -= float64(i)
+		}
+		tme := startTime + time.Duration(i)*time.Second
+		d = &dataPoint{
+			ingressTimeNS:     int64(tme),
+			masterOffsetNS:    23.0,
+			pathDelayNS:       213.0,
+			freqAdjustmentPPB: adj,
+			clockAccuracyNS:   25.0,
+		}
+		phcTime = tme + time.Microsecond
+		err = s.doWork(shm, d)
+		require.NoError(t, err, "not enough data should give us error when calculating shm state, which we log and continue")
+		// check exported stats
+		require.Equal(t, int64(tme), stats.counters["ingress_time_ns"])
+		require.Equal(t, int64(time.Microsecond), stats.counters["time_since_ingress_ns"])
+		require.Equal(t, int64(d.masterOffsetNS), stats.counters["master_offset_ns"])
+		require.Equal(t, int64(d.pathDelayNS), stats.counters["path_delay_ns"])
+		require.Equal(t, int64(d.freqAdjustmentPPB), stats.counters["freq_adj_ppb"])
+		require.Equal(t, int64(0), stats.counters["data_sanity_check_error"])
+		// we can calculate M after 30 seconds
+		if i < 29 {
+			require.Equal(t, int64(0), stats.counters["m_ns"])
+		} else {
+			require.Equal(t, int64(48), stats.counters["m_ns"])
+		}
+		require.Equal(t, int64(0), stats.counters["w_ns"])
+		// not enough data for those
+		require.Equal(t, int64(0), stats.counters["master_offset_ns.60.abs_max"])
+		require.Equal(t, int64(0), stats.counters["path_delay_ns.60.abs_max"])
+		require.Equal(t, int64(0), stats.counters["freq_adj_ppb.60.abs_max"])
+	}
+
+	// another data point, now that we have enough in the ring buffer to write to shm
+	d = &dataPoint{
+		ingressTimeNS:     int64(startTime + 61*time.Second),
+		masterOffsetNS:    23.0,
+		pathDelayNS:       213.0,
+		freqAdjustmentPPB: 212131,
+		clockAccuracyNS:   25.0,
+	}
+	phcTime = startTime + 62*time.Second
+
+	err = s.doWork(shm, d)
+	require.NoError(t, err)
+	// check that we have proper stats reported
+	require.Equal(t, int64(startTime+61*time.Second), stats.counters["ingress_time_ns"], "ingress_time_ns after good data")
+	require.Equal(t, int64(time.Second), stats.counters["time_since_ingress_ns"], "time_since_ingress_ns after good data")
+	require.Equal(t, int64(d.masterOffsetNS), stats.counters["master_offset_ns"], "master_offset_ns after good data")
+	require.Equal(t, int64(d.pathDelayNS), stats.counters["path_delay_ns"], "path_delay_ns after good data")
+	require.Equal(t, int64(d.freqAdjustmentPPB), stats.counters["freq_adj_ppb"], "freq_adj_ppb after good data")
+	require.Equal(t, int64(48), stats.counters["m_ns"], "m_ns after good data")
+	require.Equal(t, int64(48), stats.counters["w_ns"], "w_ns after good data")
+	require.Equal(t, int64(23), stats.counters["master_offset_ns.60.abs_max"], "master_offset_ns.60.abs_max after good data")
+	require.Equal(t, int64(213), stats.counters["path_delay_ns.60.abs_max"], "path_delay_ns.60.abs_max after good data")
+	require.Equal(t, int64(212159), stats.counters["freq_adj_ppb.60.abs_max"], "freq_adj_ppb.60.abs_max after good data")
+	require.Equal(t, int64(0), stats.counters["data_sanity_check_error"])
+
+	// check that we wrote data correctly
+	want := &fbclock.Data{
+		IngressTimeNS:        d.ingressTimeNS,
+		ErrorBoundNS:         48.0,
+		HoldoverMultiplierNS: 64.5,
+	}
+	shmpData, err := fbclock.MmapShmpData(shm.File.Fd())
+	require.NoError(t, err)
+	got, err := fbclock.ReadFBClockData(shmpData)
+	require.NoError(t, err)
+	require.Equal(t, want.IngressTimeNS, got.IngressTimeNS)
+	require.Equal(t, want.ErrorBoundNS, got.ErrorBoundNS)
+	require.InDelta(t, want.HoldoverMultiplierNS, got.HoldoverMultiplierNS, 0.001)
+
+	// ptp4l has a hiccup, but that should be okay
+	d = &dataPoint{
+		ingressTimeNS:     0,
+		masterOffsetNS:    0,
+		pathDelayNS:       0,
+		freqAdjustmentPPB: 0,
+	}
+	phcTime = startTime + 63*time.Second
+
+	err = s.doWork(shm, d)
+	require.Error(t, err, "data point fails sanity check")
+	// check that we have proper stats reported
+	require.Equal(t, int64(0), stats.counters["ingress_time_ns"], "ingress_time_ns after bad data")
+	require.Equal(t, int64(2*time.Second), stats.counters["time_since_ingress_ns"], "time_since_ingress_ns after bad data")
+	require.Equal(t, int64(d.masterOffsetNS), stats.counters["master_offset_ns"], "master_offset_ns after bad data")
+	require.Equal(t, int64(d.pathDelayNS), stats.counters["path_delay_ns"], "path_delay_ns after bad data")
+	require.Equal(t, int64(d.freqAdjustmentPPB), stats.counters["freq_adj_ppb"], "freq_adj_ppb after bad data")
+	require.Equal(t, int64(48), stats.counters["m_ns"], "m_ns after bad data")
+	require.Equal(t, int64(48), stats.counters["w_ns"], "w_ns after bad data")
+	require.Equal(t, int64(23), stats.counters["master_offset_ns.60.abs_max"], "master_offset_ns.60.abs_max after bad data")
+	require.Equal(t, int64(213), stats.counters["path_delay_ns.60.abs_max"], "path_delay_ns.60.abs_max after bad data")
+	require.Equal(t, int64(212159), stats.counters["freq_adj_ppb.60.abs_max"], "freq_adj_ppb.60.abs_max after bad data")
+	require.Equal(t, int64(1), stats.counters["data_sanity_check_error"])
+
+	// check that we wrote data correctly (should be the same as before, as new data point was discarded)
+	got, err = fbclock.ReadFBClockData(shmpData)
+	require.NoError(t, err)
+	require.Equal(t, want.IngressTimeNS, got.IngressTimeNS)
+	require.Equal(t, want.ErrorBoundNS, got.ErrorBoundNS)
+	require.InDelta(t, want.HoldoverMultiplierNS, got.HoldoverMultiplierNS, 0.001)
+}

--- a/fbclock/daemon/device.go
+++ b/fbclock/daemon/device.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/facebook/time/fbclock"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func SetupDeviceDir(device string) error {
+	// explicitly conver to string to prevent GOPLS from panicing here
+	target := string(fbclock.PTPPath)
+	dir := filepath.Dir(target)
+	wantMode := os.ModeCharDevice | os.ModeDevice | 0644
+	devInfo, err := os.Stat(device)
+	if err != nil {
+		return fmt.Errorf("getting PTP device %q info: %w", device, err)
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("preparing dir %s: %w", dir, err)
+	}
+	// check if it's already there
+	if targetInfo, err := os.Stat(target); err == nil {
+		if os.SameFile(devInfo, targetInfo) && targetInfo.Mode() == wantMode {
+			log.Debugf("Device %s already exists, nothing to link", target)
+			return nil
+		}
+		// remove the wrong file
+		if err := os.RemoveAll(target); err != nil {
+			log.Debugf("Removing %s", target)
+			return fmt.Errorf("removing target file %q: %w", target, err)
+		}
+	}
+	log.Debugf("Linking %s to %s", device, target)
+	if err := os.Link(device, target); err != nil {
+		return fmt.Errorf("linking device %s to %s: %w", device, target, err)
+	}
+	return os.Chmod(target, wantMode)
+}

--- a/fbclock/daemon/json_stats.go
+++ b/fbclock/daemon/json_stats.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// JSONStats is what we want to report as stats via http
+type JSONStats struct {
+	Stats
+}
+
+// NewJSONStats returns a new JSONStats
+func NewJSONStats() *JSONStats {
+	return &JSONStats{Stats: *NewStats()}
+}
+
+// Start runs http server and initializes maps
+func (s *JSONStats) Start(monitoringport int) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleRequest)
+	addr := fmt.Sprintf(":%d", monitoringport)
+	log.Infof("Starting http json server on %s", addr)
+	err := http.ListenAndServe(addr, mux)
+	if err != nil {
+		log.Fatalf("Failed to start listener: %v", err)
+	}
+}
+
+// handleRequest is a handler used for all http monitoring requests
+func (s *JSONStats) handleRequest(w http.ResponseWriter, r *http.Request) {
+	js, err := json.Marshal(s.counters)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err = w.Write(js); err != nil {
+		log.Errorf("Failed to reply: %v", err)
+	}
+}

--- a/fbclock/daemon/logging.go
+++ b/fbclock/daemon/logging.go
@@ -1,0 +1,130 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+)
+
+// LogSample has all the measurements we may want to log
+type LogSample struct {
+	MasterOffsetNS          float64
+	MasterOffsetMeanNS      float64
+	MasterOffsetStddevNS    float64
+	PathDelayNS             float64
+	PathDelayMeanNS         float64
+	PathDelayStddevNS       float64
+	FreqAdjustmentPPB       float64
+	FreqAdjustmentMeanPPB   float64
+	FreqAdjustmentStddevPPB float64
+	MeasurementNS           float64
+	MeasurementMeanNS       float64
+	MeasurementStddevNS     float64
+	WindowNS                float64
+	ClockAccuracyMean       float64
+}
+
+var header = []string{
+	"offset",
+	"offset_mean",
+	"offset_stddev",
+	"delay",
+	"delay_mean",
+	"delay_stddev",
+	"freq",
+	"freq_mean",
+	"freq_stddev",
+	"measurement",
+	"measurement_mean",
+	"measurement_stddev",
+	"window",
+	"clock_accuracy_mean",
+}
+
+// CSVRecords returns all data from this sample as CSV. Must by synced with `header` variable.
+func (s *LogSample) CSVRecords() []string {
+	return []string{
+		strconv.FormatFloat(s.MasterOffsetNS, 'f', -1, 64),
+		strconv.FormatFloat(s.MasterOffsetMeanNS, 'f', -1, 64),
+		strconv.FormatFloat(s.MasterOffsetStddevNS, 'f', -1, 64),
+		strconv.FormatFloat(s.PathDelayNS, 'f', -1, 64),
+		strconv.FormatFloat(s.PathDelayMeanNS, 'f', -1, 64),
+		strconv.FormatFloat(s.PathDelayStddevNS, 'f', -1, 64),
+		strconv.FormatFloat(s.FreqAdjustmentPPB, 'f', -1, 64),
+		strconv.FormatFloat(s.FreqAdjustmentMeanPPB, 'f', -1, 64),
+		strconv.FormatFloat(s.FreqAdjustmentStddevPPB, 'f', -1, 64),
+		strconv.FormatFloat(s.MeasurementNS, 'f', -1, 64),
+		strconv.FormatFloat(s.MeasurementMeanNS, 'f', -1, 64),
+		strconv.FormatFloat(s.MeasurementStddevNS, 'f', -1, 64),
+		strconv.FormatFloat(s.WindowNS, 'f', -1, 64),
+		strconv.FormatFloat(s.ClockAccuracyMean, 'f', -1, 64),
+	}
+}
+
+// Logger is something that can store LogSample somewhere
+type Logger interface {
+	Log(*LogSample) error
+}
+
+// CSVLogger logs Sample as CSV into given writer
+type CSVLogger struct {
+	csvwriter     *csv.Writer
+	printedHeader bool
+}
+
+// NewCSVLogger returns new CSVLogger
+func NewCSVLogger(w io.Writer) *CSVLogger {
+	return &CSVLogger{
+		csvwriter: csv.NewWriter(w),
+	}
+}
+
+// Log implements Logger interface
+func (l *CSVLogger) Log(s *LogSample) error {
+	if !l.printedHeader {
+		if err := l.csvwriter.Write(header); err != nil {
+			return err
+		}
+		l.printedHeader = true
+	}
+	csv := s.CSVRecords()
+	if err := l.csvwriter.Write(csv); err != nil {
+		return err
+	}
+	l.csvwriter.Flush()
+	return nil
+}
+
+// DummyLogger logs M and W to given writer
+type DummyLogger struct {
+	w io.Writer
+}
+
+// NewDummyLogger returns new DummyLogger
+func NewDummyLogger(w io.Writer) *DummyLogger {
+	return &DummyLogger{w: w}
+}
+
+// Log implements Logger interface
+func (l *DummyLogger) Log(s *LogSample) error {
+	_, err := fmt.Fprintf(l.w, "m = %v, w = %v\n", time.Duration(s.MeasurementNS), time.Duration(s.WindowNS))
+	return err
+}

--- a/fbclock/daemon/logging_test.go
+++ b/fbclock/daemon/logging_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testSample0 = &LogSample{
+	MasterOffsetNS:          1.1,
+	MasterOffsetMeanNS:      1.2,
+	MasterOffsetStddevNS:    1.3,
+	PathDelayNS:             1.4,
+	PathDelayMeanNS:         1.5,
+	PathDelayStddevNS:       1.6,
+	FreqAdjustmentPPB:       1.7,
+	FreqAdjustmentMeanPPB:   1.8,
+	FreqAdjustmentStddevPPB: 1.9,
+	MeasurementNS:           2.0,
+	MeasurementMeanNS:       2.1,
+	MeasurementStddevNS:     2.2,
+	WindowNS:                2.3,
+	ClockAccuracyMean:       25.1,
+}
+
+var testSample1 = &LogSample{
+	MasterOffsetNS:          0.1,
+	MasterOffsetMeanNS:      0.2,
+	MasterOffsetStddevNS:    0.3,
+	PathDelayNS:             0.4,
+	PathDelayMeanNS:         0.5,
+	PathDelayStddevNS:       0.6,
+	FreqAdjustmentPPB:       0.7,
+	FreqAdjustmentMeanPPB:   0.8,
+	FreqAdjustmentStddevPPB: 0.9,
+	MeasurementNS:           1.0,
+	MeasurementMeanNS:       1.1,
+	MeasurementStddevNS:     1.2,
+	WindowNS:                1.3,
+	ClockAccuracyMean:       100.1,
+}
+
+func TestLogSample_CSVRecords(t *testing.T) {
+	got := testSample0.CSVRecords()
+	want := []string{"1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "2", "2.1", "2.2", "2.3", "25.1"}
+
+	// make sure we are in sync with header
+	require.Equal(t, len(header), len(got))
+
+	assert.Equal(t, want, got)
+}
+
+func TestCSVLogger_Log(t *testing.T) {
+	b := &bytes.Buffer{}
+	l := NewCSVLogger(b)
+
+	err := l.Log(testSample0)
+	require.NoError(t, err)
+	err = l.Log(testSample1)
+	require.NoError(t, err)
+	err = l.Log(testSample0)
+	require.NoError(t, err)
+
+	got := b.String()
+	want := `offset,offset_mean,offset_stddev,delay,delay_mean,delay_stddev,freq,freq_mean,freq_stddev,measurement,measurement_mean,measurement_stddev,window,clock_accuracy_mean
+1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2,2.1,2.2,2.3,25.1
+0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,100.1
+1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2,2.1,2.2,2.3,25.1
+`
+
+	assert.Equal(t, want, got)
+}

--- a/fbclock/daemon/math.go
+++ b/fbclock/daemon/math.go
@@ -1,0 +1,234 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/Knetic/govaluate"
+	"github.com/eclesh/welford"
+)
+
+const MathHelp = `When composing the -m and -w formulas, here is what you can do:
+supported operations:
+  evaluation is done with govaluate, please check https://github.com/Knetic/govaluate/blob/master/MANUAL.md
+supported variables:
+  offset (list of last offsets from GM, in ns)
+  delay (list of last path delays, in ns)
+  freq (list of last frequency adjustments, in PPM)
+  clockaccuracy (list of clock accuracy values received from GM)
+  freqchange (list of last changes in frequency)
+  freqchangeabs (list of last changes in frequency, abs values)
+supported functions:
+  abs(value) - absolute value of single float64, for example abs(-1) = 1
+  mean(values, number) - mean of list of 'number' values, for example mean(offset, 10) will take 10 elements from array 'offset' and return mean for those values
+  variance(values, number) - variance of list of 'number' values, for example variance(offset, 10) will take 10 elements from array 'offset' and return variance for those values
+  stddev(values, number) - standard deviation of list of 'number' values, for example stddev(offset, 10) will take 10 elements from array 'offset' and return standard deviation for those values`
+
+// Math stores our math expressions for M ans W values in two forms: string and parsed
+type Math struct {
+	M         string // Measurement, our value for clock quality
+	mExpr     *govaluate.EvaluableExpression
+	W         string // window of uncertainty, without adjustment for potential holdover
+	wExpr     *govaluate.EvaluableExpression
+	Drift     string // drift in PPB, for holdover multiplier calculations
+	driftExpr *govaluate.EvaluableExpression
+}
+
+// Prepare will prepare all math expressions
+func (m *Math) Prepare() error {
+	var err error
+	m.mExpr, err = prepareExpression(m.M)
+	if err != nil {
+		return fmt.Errorf("evaluating M: %w", err)
+	}
+	m.wExpr, err = prepareExpression(m.W)
+	if err != nil {
+		return fmt.Errorf("evaluating W: %w", err)
+	}
+	m.driftExpr, err = prepareExpression(m.Drift)
+	if err != nil {
+		return fmt.Errorf("evaluating Drift: %w", err)
+	}
+	return nil
+}
+
+func mean(input []float64) float64 {
+	s := welford.New()
+	for _, v := range input {
+		s.Add(v)
+	}
+	return s.Mean()
+}
+
+func variance(input []float64) float64 {
+	s := welford.New()
+	for _, v := range input {
+		s.Add(v)
+	}
+	return s.Variance()
+}
+
+func stddev(input []float64) float64 {
+	s := welford.New()
+	for _, v := range input {
+		s.Add(v)
+	}
+	return s.Stddev()
+}
+
+// convolve mixes two signals together
+func convolve(input, coeffs []float64) ([]float64, error) {
+	if len(input) < len(coeffs) {
+		return nil, fmt.Errorf("not enough values")
+	}
+
+	output := make([]float64, len(input))
+	for i := 0; i < len(coeffs); i++ {
+		var sum float64
+
+		for j := 0; j <= i; j++ {
+			sum += (input[j] * coeffs[len(coeffs)-(1+i-j)])
+		}
+		output[i] = sum
+	}
+
+	for i := len(coeffs); i < len(input); i++ {
+		var sum float64
+		for j := 0; j < len(coeffs); j++ {
+			sum += (input[i-j] * coeffs[j])
+		}
+		output[i] = sum
+	}
+
+	return output, nil
+}
+
+var supportedVariables = []string{
+	"offset",
+	"delay",
+	"freq",
+	"m",
+	"clockaccuracy",
+	"freqchange",
+	"freqchangeabs",
+}
+
+func isSupportedVar(varName string) bool {
+	for _, v := range supportedVariables {
+		if v == varName {
+			return true
+		}
+	}
+	return false
+}
+
+// all the functions we support in expressions
+var functions = map[string]govaluate.ExpressionFunction{
+	"abs": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("abs: wrong number of arguments: want 1, got %d", len(args))
+		}
+		val := args[0].(float64)
+		return math.Abs(val), nil
+	},
+	"mean": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("mean: wrong number of arguments: want 2, got %d", len(args))
+		}
+		vals := args[0].([]float64)
+		nSamples := int(args[1].(float64))
+		if len(vals) < nSamples {
+			return nil, fmt.Errorf("mean: not enough samples: want %d, have %d", nSamples, len(vals))
+		}
+		return mean(vals[:nSamples]), nil
+	},
+	"variance": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("variance: wrong number of arguments: want 2, got %d", len(args))
+		}
+		vals := args[0].([]float64)
+		nSamples := int(args[1].(float64))
+		if len(vals) < nSamples {
+			return nil, fmt.Errorf("variance: not enough samples: want %d, have %d", nSamples, len(vals))
+		}
+		return variance(vals[:nSamples]), nil
+	},
+	"stddev": func(args ...interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("stddev: wrong number of arguments: want 2, got %d", len(args))
+		}
+		vals := args[0].([]float64)
+		nSamples := int(args[1].(float64))
+		if len(vals) < nSamples {
+			return nil, fmt.Errorf("stddev: not enough samples: want %d, have %d", nSamples, len(vals))
+		}
+		return stddev(vals[:nSamples]), nil
+	},
+}
+
+func prepareExpression(exprStr string) (*govaluate.EvaluableExpression, error) {
+	expr, err := govaluate.NewEvaluableExpressionWithFunctions(exprStr, functions)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range expr.Vars() {
+		if !isSupportedVar(v) {
+			return nil, fmt.Errorf("unsupported variable %q", v)
+		}
+	}
+	return expr, nil
+}
+
+func prepareMathParameters(lastN []*dataPoint) map[string][]float64 {
+	size := len(lastN)
+	offsets := make([]float64, size)
+	delays := make([]float64, size)
+	freqs := make([]float64, size)
+	clockAccuracies := make([]float64, size)
+	freqChanges := make([]float64, size-1)
+	freqChangesAbs := make([]float64, size-1)
+	prev := lastN[0]
+	for i := 0; i < size; i++ {
+		offsets[i] = lastN[i].masterOffsetNS
+		delays[i] = lastN[i].pathDelayNS
+		freqs[i] = lastN[i].freqAdjustmentPPB
+		clockAccuracies[i] = lastN[i].clockAccuracyNS
+		if i != 0 {
+			freqChanges[i-1] = lastN[i].freqAdjustmentPPB - prev.freqAdjustmentPPB
+			freqChangesAbs[i-1] = math.Abs(lastN[i].freqAdjustmentPPB - prev.freqAdjustmentPPB)
+		}
+		prev = lastN[i]
+	}
+	return map[string][]float64{
+		"offset":        offsets,
+		"delay":         delays,
+		"freq":          freqs,
+		"clockaccuracy": clockAccuracies,
+		"freqchange":    freqChanges,
+		"freqchangeabs": freqChangesAbs,
+	}
+}
+
+func mapOfInterface(m map[string][]float64) map[string]interface{} {
+	mm := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		mm[k] = v
+	}
+	return mm
+}

--- a/fbclock/daemon/math_test.go
+++ b/fbclock/daemon/math_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvolve(t *testing.T) {
+	input := []float64{
+		-1.70422422e+08,
+		-1.69753965e+08,
+		-1.68707777e+08,
+		-1.67177413e+08,
+		-1.65204696e+08,
+		-1.66994577e+08,
+	}
+	coeffs1 := []float64{0.2, 0.2, 0.2, 0.2, 0.2}
+
+	got1, err := convolve(input, coeffs1)
+	require.Nil(t, err)
+	/*
+		how to get this output (using Python and numpy):
+			import numpy as np
+			x = np.array([-1.70422422e+08, -1.69753965e+08, -1.68707777e+08, -1.67177413e+08, -1.65204696e+08, -1.66994577e+08])
+			coeffs = np.array([0.2, 0.2, 0.2, 0.2, 0.2])
+			c = np.convolve(x, coeffs)
+			print(c)
+	*/
+	want1 := []float64{
+		-3.40844844e+07,
+		-6.80352774e+07,
+		-1.01776833e+08,
+		-1.35212315e+08,
+		-1.68253255e+08,
+		-1.67567686e+08,
+	}
+	require.Equal(t, len(want1), len(got1))
+	assert.InEpsilonSlice(t, want1, got1, 1e+10)
+
+	coeffs2 := []float64{1, 3, -3, 1}
+	got2, err := convolve(input, coeffs2)
+	require.Nil(t, err)
+	want2 := []float64{
+		-1.70422422e+08,
+		-6.81021231e+08,
+		-1.66702406e+08,
+		-3.34461271e+08,
+		-3.30367569e+08,
+		-3.29784203e+08,
+	}
+	require.Equal(t, len(want2), len(got2))
+	assert.InEpsilonSlice(t, want2, got2, 1e+10)
+}
+
+func TestMean(t *testing.T) {
+	input := []float64{3, 5, 8, 8}
+	want := 6.0
+	assert.Equal(t, want, mean(input))
+	input = []float64{1, 4, 0, 3, 8}
+	want = 3.2
+	assert.Equal(t, want, mean(input))
+}
+
+func TestVariance(t *testing.T) {
+	input := []float64{8, 8, 8, 8}
+	want := 0.0
+	assert.Equal(t, want, variance(input))
+	input = []float64{1, 4, 0, 3, 8}
+	want = 9.7
+	assert.Equal(t, want, variance(input))
+}
+
+func TestPrepareExpression(t *testing.T) {
+	input := "mean(clockaccuracy, 5) + abs(mean(offset, 5)) + 1.0 * stddev(offset, 4) + 1.0 * stddev(delay, 4) + 1.0 * stddev(freq, 5)"
+	expr, err := prepareExpression(input)
+	require.Nil(t, err)
+
+	parameters := map[string]interface{}{
+		"offset":        []float64{1, 2, 3, 4, 5},
+		"delay":         []float64{2, 2, 2, 2, 2},
+		"freq":          []float64{123, 424, 444, 222, 424},
+		"clockaccuracy": []float64{100, 150, 50, 100, 100},
+	}
+
+	want := 250.1909601786838
+	got, err := expr.Evaluate(parameters)
+	require.Nil(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPrepareExpressionWrongVari(t *testing.T) {
+	input := "abs(mean(offset, 5)) + 1.0 * stddev(missing, 4)"
+	_, err := prepareExpression(input)
+	require.Error(t, err)
+}
+
+func TestPrepareExpressionNotEnoughValues(t *testing.T) {
+	input := "mean(offset, 50)"
+	expr, err := prepareExpression(input)
+	require.Nil(t, err)
+
+	parameters := map[string]interface{}{
+		"offset": []float64{1, 2, 3, 4, 5},
+	}
+
+	_, err = expr.Evaluate(parameters)
+	require.Error(t, err)
+}

--- a/fbclock/daemon/state.go
+++ b/fbclock/daemon/state.go
@@ -1,0 +1,158 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"container/ring"
+	"math"
+	"sync"
+
+	"github.com/facebook/time/ptp/linearizability"
+)
+
+// state of the daemon, guarded by mutex
+type daemonState struct {
+	sync.Mutex
+
+	dataPoints                 *ring.Ring // dataPoints we collected from ptp4l
+	mmms                       *ring.Ring // M values we calculated
+	linearizabilityTestResults *ring.Ring // linearizability test results
+
+	lastIngressTimeNS int64
+}
+
+func newDaemonState(ringSize int) *daemonState {
+	s := &daemonState{
+		dataPoints:                 ring.New(ringSize),
+		mmms:                       ring.New(ringSize),
+		linearizabilityTestResults: ring.New(ringSize),
+	}
+	// init ring buffers with nils
+	for i := 0; i < ringSize; i++ {
+		s.dataPoints.Value = nil
+		s.dataPoints = s.dataPoints.Next()
+
+		s.mmms.Value = nil
+		s.mmms = s.mmms.Next()
+
+		s.linearizabilityTestResults.Value = nil
+		s.linearizabilityTestResults = s.linearizabilityTestResults.Next()
+	}
+	return s
+}
+
+func (s *daemonState) updateIngressTimeNS(it int64) {
+	s.Lock()
+	defer s.Unlock()
+	s.lastIngressTimeNS = it
+}
+
+func (s *daemonState) ingressTimeNS() int64 {
+	s.Lock()
+	defer s.Unlock()
+	return s.lastIngressTimeNS
+}
+
+func (s *daemonState) pushDataPoint(data *dataPoint) {
+	s.Lock()
+	defer s.Unlock()
+	s.dataPoints.Value = data
+	s.dataPoints = s.dataPoints.Next()
+}
+
+func (s *daemonState) takeDataPoint(n int) []*dataPoint {
+	s.Lock()
+	defer s.Unlock()
+	result := []*dataPoint{}
+	r := s.dataPoints.Prev()
+	for j := 0; j < n; j++ {
+		if r.Value == nil {
+			continue
+		}
+		result = append(result, r.Value.(*dataPoint))
+		r = r.Prev()
+	}
+	return result
+}
+
+func (s *daemonState) aggregateDataPointsMax(n int) *dataPoint {
+	s.Lock()
+	defer s.Unlock()
+	d := &dataPoint{}
+	r := s.dataPoints.Prev()
+	for j := 0; j < n; j++ {
+		if r.Value == nil {
+			continue
+		}
+		dp := r.Value.(*dataPoint)
+		if math.Abs(dp.masterOffsetNS) > d.masterOffsetNS {
+			d.masterOffsetNS = math.Abs(dp.masterOffsetNS)
+		}
+		if math.Abs(dp.pathDelayNS) > d.pathDelayNS {
+			d.pathDelayNS = math.Abs(dp.pathDelayNS)
+		}
+		if math.Abs(dp.freqAdjustmentPPB) > d.freqAdjustmentPPB {
+			d.freqAdjustmentPPB = math.Abs(dp.freqAdjustmentPPB)
+		}
+		r = r.Prev()
+	}
+	return d
+}
+
+func (s *daemonState) pushM(data float64) {
+	s.Lock()
+	defer s.Unlock()
+	s.mmms.Value = data
+	s.mmms = s.mmms.Next()
+}
+
+func (s *daemonState) takeM(n int) []float64 {
+	s.Lock()
+	defer s.Unlock()
+	result := []float64{}
+	r := s.mmms.Prev()
+	for j := 0; j < n; j++ {
+		if r.Value == nil {
+			continue
+		}
+		result = append(result, r.Value.(float64))
+		r = r.Prev()
+	}
+	return result
+}
+
+func (s *daemonState) pushLinearizabilityTestResult(data *linearizability.TestResult) {
+	s.Lock()
+	defer s.Unlock()
+	s.linearizabilityTestResults.Value = data
+	s.linearizabilityTestResults = s.linearizabilityTestResults.Next()
+}
+
+func (s *daemonState) takeLinearizabilityTestResult(n int) []*linearizability.TestResult {
+	s.Lock()
+	defer s.Unlock()
+	result := []*linearizability.TestResult{}
+	r := s.linearizabilityTestResults.Prev()
+	for j := 0; j < n; j++ {
+		if r.Value == nil {
+			continue
+		}
+		result = append(result, r.Value.(*linearizability.TestResult))
+		r = r.Prev()
+	}
+	return result
+}

--- a/fbclock/daemon/stats.go
+++ b/fbclock/daemon/stats.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"sync"
+)
+
+type StatsServer interface {
+	// Reset atomically sets all the counters to 0
+	Reset()
+	SetCounter(key string, val int64)
+	UpdateCounterBy(key string, count int64)
+}
+
+type Stats struct {
+	mux      sync.Mutex
+	counters map[string]int64
+}
+
+func NewStats() *Stats {
+	return &Stats{
+		counters: map[string]int64{},
+	}
+}
+
+// UpdateCounterBy will increment counter
+func (s *Stats) UpdateCounterBy(key string, count int64) {
+	s.mux.Lock()
+	s.counters[key] += count
+	s.mux.Unlock()
+}
+
+// SetCounter will set a counter to the provided value.
+func (s *Stats) SetCounter(key string, val int64) {
+	s.mux.Lock()
+	s.counters[key] = val
+	s.mux.Unlock()
+}
+
+func (s *Stats) Get() map[string]int64 {
+	ret := make(map[string]int64)
+	s.mux.Lock()
+	for key, val := range s.counters {
+		ret[key] = val
+	}
+	s.mux.Unlock()
+	return ret
+}
+
+// copy all key-values between maps
+func (s *Stats) Copy(dst *Stats) {
+	s.mux.Lock()
+	for k, v := range s.counters {
+		dst.SetCounter(k, v)
+	}
+	s.mux.Unlock()
+}
+
+func (s *Stats) Reset() {
+	s.mux.Lock()
+	for k := range s.counters {
+		s.counters[k] = 0
+	}
+	s.mux.Unlock()
+}

--- a/fbclock/fbclock.c
+++ b/fbclock/fbclock.c
@@ -1,0 +1,239 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "fbclock.h"
+#include "missing.h"
+#include <fcntl.h> // For O_* constants
+#include <linux/ptp_clock.h>
+#include <math.h> // pow
+#include <stdint.h>
+#include <stdio.h> // for printf and perror
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h> // close
+
+#ifndef NDEBUG
+#define fbclock_debug_print(fmt, ...)                                          \
+  do {                                                                         \
+    fprintf(stderr, fmt, __VA_ARGS__);                                         \
+  } while (0)
+#else
+#define fbclock_debug_print(fmt, ...)
+#endif
+
+#define FBCLOCK_CLOCKDATA_SIZE sizeof(fbclock_clockdata)
+#define FBCLOCK_MAX_READ_TRIES 1000
+
+#ifdef __x86_64__
+#define fbclock_crc64 __builtin_ia32_crc32di
+#endif
+
+#ifdef __aarch64__
+#ifdef __SSE4_2__
+#define fbclock_crc64 _mm_crc32_u64
+#endif
+#endif
+
+// dumb replacement for platforms we don't fully support
+#ifndef fbclock_crc64
+#define fbclock_crc64(a, b) ({ a ^ b; })
+#endif
+
+static uint64_t fbclock_clockdata_crc(fbclock_clockdata *value) {
+  uint64_t counter = fbclock_crc64(value->ingress_time_ns, 0x04C11DB7);
+  counter = fbclock_crc64(value->error_bound_ns, counter);
+  counter = fbclock_crc64(value->holdover_multiplier_ns, counter);
+  return counter;
+}
+
+// fbclock_clockdata_store_data is used in shmem.go to store timing data
+int fbclock_clockdata_store_data(uint32_t fd, fbclock_clockdata *data) {
+  fbclock_shmdata *shmp = mmap(NULL, FBCLOCK_SHMDATA_SIZE,
+                               PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (shmp == MAP_FAILED) {
+    return FBCLOCK_E_SHMEM_MAP_FAILED;
+  }
+  uint64_t crc = fbclock_clockdata_crc(data);
+  memcpy(&shmp->data, data, FBCLOCK_CLOCKDATA_SIZE);
+  atomic_store(&shmp->crc, crc);
+  munmap(shmp, FBCLOCK_SHMDATA_SIZE);
+  return 0;
+}
+
+int fbclock_clockdata_load_data(fbclock_shmdata *shmp,
+                                fbclock_clockdata *data) {
+  for (int i = 0; i < FBCLOCK_MAX_READ_TRIES; i++) {
+    memcpy(data, &shmp->data, FBCLOCK_CLOCKDATA_SIZE);
+    uint64_t our_crc = fbclock_clockdata_crc(data);
+    uint64_t crc = atomic_load(&shmp->crc);
+    if (our_crc == crc) {
+      fbclock_debug_print("reading clock data took %d tries\n", i + 1);
+      break;
+    }
+  }
+  return 0;
+}
+
+static int64_t fbclock_pct2ns(const struct ptp_clock_time *ptc) {
+  return (int64_t)(ptc->sec * 1000000000) + (int64_t)ptc->nsec;
+}
+
+static int64_t fbclock_read_ptp_offset_extended(int fd) {
+  struct ptp_sys_offset_extended psoe = {.n_samples = 5};
+  int r = ioctl(fd, PTP_SYS_OFFSET_EXTENDED, &psoe);
+  if (r) {
+    perror("PTP_SYS_OFFSET_EXTENDED");
+    return -1;
+  }
+  int64_t total_delay = 0;
+
+  for (unsigned i = 0; i < psoe.n_samples; ++i) {
+    int64_t delay =
+        fbclock_pct2ns(&psoe.ts[i][2]) - fbclock_pct2ns(&psoe.ts[i][0]);
+    total_delay += delay;
+  }
+  int64_t ts = fbclock_pct2ns(&psoe.ts[psoe.n_samples - 1][1]);
+  int64_t mean_delay = total_delay / psoe.n_samples;
+  return ts + mean_delay;
+}
+
+int fbclock_init(fbclock_lib *lib, const char *shm_path) {
+  lib->ptp_path = FBCLOCK_PTPPATH;
+  int sfd = open(shm_path, O_RDONLY, 0);
+  if (sfd == -1) {
+    perror("open shmem device");
+    return FBCLOCK_E_SHMEM_OPEN;
+  }
+  lib->shm_fd = sfd;
+
+  int ffd = open(lib->ptp_path, O_RDONLY);
+  if (ffd == -1) {
+    perror("open PTP device");
+    return FBCLOCK_E_PTP_OPEN;
+  }
+  lib->dev_fd = ffd;
+
+  fbclock_shmdata *shmp =
+      mmap(NULL, FBCLOCK_SHMDATA_SIZE, PROT_READ, MAP_SHARED, lib->shm_fd, 0);
+  if (shmp == MAP_FAILED) {
+    return FBCLOCK_E_SHMEM_MAP_FAILED;
+  }
+  lib->shmp = shmp;
+  return 0;
+}
+
+int fbclock_destroy(fbclock_lib *lib) {
+  munmap(lib->shmp, FBCLOCK_SHMDATA_SIZE);
+  close(lib->dev_fd);
+  close(lib->shm_fd);
+  return 0;
+  // we don't want to unlink it, others might still use it
+}
+
+double fbclock_window_of_uncertainty(int64_t seconds, double error_bound_ns,
+                                     double holdover_multiplier_ns) {
+  double h = holdover_multiplier_ns * seconds;
+  double w = error_bound_ns + h;
+  fbclock_debug_print("error_bound=%f\n", error_bound_ns);
+  fbclock_debug_print("holdover_multiplier=%f\n", holdover_multiplier_ns);
+  fbclock_debug_print("%ld seconds holdover, h=%f\n", seconds, h);
+  fbclock_debug_print("w = %f ns\n", w);
+  fbclock_debug_print("w = %f ms\n", w / 1000000.0);
+  return w;
+}
+
+int fbclock_calculate_time(double error_bound_ns, double h_value_ns,
+                           int64_t ingress_time_ns, int64_t phctime_ns,
+                           fbclock_truetime *truetime) {
+  // first, we check how long it was since last SYNC message from GM, in seconds
+  int64_t seconds = (double)(phctime_ns - ingress_time_ns) / 1000000000.0;
+  if (seconds < 0) {
+    return FBCLOCK_E_PHC_IN_THE_PAST;
+  }
+  // then we calculate WOU
+  double wou_ns =
+      fbclock_window_of_uncertainty(seconds, error_bound_ns, h_value_ns);
+  truetime->earliest_ns = phctime_ns - (uint64_t)wou_ns;
+  truetime->latest_ns = phctime_ns + (uint64_t)wou_ns;
+  return 0;
+}
+
+int fbclock_gettime(fbclock_lib *lib, fbclock_truetime *truetime) {
+  fbclock_clockdata state;
+  int rcode = fbclock_clockdata_load_data(lib->shmp, &state);
+  if (rcode != 0) {
+    return rcode;
+  }
+
+  // if by this point we still haven't managed to get consistent data - go ahead
+  // with potential inconsistency
+  if (state.error_bound_ns == 0 || state.ingress_time_ns == 0) {
+    return FBCLOCK_E_NO_DATA;
+  }
+
+  // if the value is stored as UINT32_MAX then it's too big
+  if (state.error_bound_ns == UINT32_MAX ||
+      state.holdover_multiplier_ns == UINT32_MAX) {
+    return FBCLOCK_E_WOU_TOO_BIG;
+  }
+
+  int64_t phctime_ns = fbclock_read_ptp_offset_extended(lib->dev_fd);
+  if (phctime_ns <= 0) {
+    return FBCLOCK_E_PTP_READ_OFFSET;
+  }
+
+  double error_bound = (double)state.error_bound_ns;
+  double h_value = (double)state.holdover_multiplier_ns / FBCLOCK_POW2_16;
+  return fbclock_calculate_time(error_bound, h_value, state.ingress_time_ns,
+                                phctime_ns, truetime);
+}
+
+const char *fbclock_strerror(int err_code) {
+  const char *err_info = "unknown error";
+  switch (err_code) {
+  case FBCLOCK_E_SHMEM_MAP_FAILED:
+    err_info = "shmem map error";
+    break;
+  case FBCLOCK_E_SHMEM_OPEN:
+    err_info = "shmem open error";
+    break;
+  case FBCLOCK_E_PTP_READ_OFFSET:
+    err_info = "PTP PTP_SYS_OFFSET_EXTENDED ioctl error";
+    break;
+  case FBCLOCK_E_PTP_OPEN:
+    err_info = "PTP device open error";
+    break;
+  case FBCLOCK_E_NO_DATA:
+    err_info = "no data from daemon error";
+    break;
+  case FBCLOCK_E_WOU_TOO_BIG:
+    err_info = "WOU is too big";
+    break;
+  case FBCLOCK_E_PHC_IN_THE_PAST:
+    err_info = "PHC jumped back in time";
+    break;
+  case 0:
+    err_info = "no error";
+    break;
+  default:
+    err_info = "unknown error";
+    break;
+  }
+  return err_info;
+}

--- a/fbclock/fbclock.go
+++ b/fbclock/fbclock.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fbclock
+
+/*
+#cgo LDFLAGS: -lrt
+#cgo amd64 CFLAGS: -msse4.2
+
+#include "fbclock.h"
+
+#include <stdlib.h>   // for free()
+*/
+import "C"
+
+import (
+	"fmt"
+	"time"
+	"unsafe"
+)
+
+func strerror(errCode C.int) string {
+	cStr := C.fbclock_strerror(errCode)
+	return C.GoString(cStr)
+}
+
+// TrueTime is a time interval we are confident the clock is right now
+type TrueTime struct {
+	Earliest time.Time
+	Latest   time.Time
+}
+
+// FBClock wraps around fbclock C lib
+type FBClock struct {
+	cFBClock *C.fbclock_lib
+}
+
+// NewFBClockCustom returns new FBClock wrapper with custom path
+func NewFBClockCustom(path string) (*FBClock, error) {
+	cFBClock := &C.fbclock_lib{}
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	errCode := C.fbclock_init(cFBClock, cPath)
+	if errCode != 0 {
+		return nil, fmt.Errorf("initializing FBClock: %s", strerror(errCode))
+	}
+	return &FBClock{cFBClock: cFBClock}, nil
+}
+
+// NewFBClock returns new FBClock wrapper
+func NewFBClock() (*FBClock, error) {
+	return NewFBClockCustom(C.FBCLOCK_PATH)
+}
+
+// Close destroys fbclock wrapper
+func (f *FBClock) Close() error {
+	errCode := C.fbclock_destroy(f.cFBClock)
+	if errCode != 0 {
+		return fmt.Errorf("destroying FBClock: %s", strerror(errCode))
+	}
+	return nil
+}
+
+// GetTime returns TrueTime
+func (f *FBClock) GetTime() (*TrueTime, error) {
+	tt := &C.fbclock_truetime{}
+	errCode := C.fbclock_gettime(f.cFBClock, tt)
+	if errCode != 0 {
+		return nil, fmt.Errorf("reading FBClock TrueTime: %s", strerror(errCode))
+	}
+
+	earliest := time.Unix(0, int64(tt.earliest_ns))
+	latest := time.Unix(0, int64(tt.latest_ns))
+
+	return &TrueTime{Earliest: earliest, Latest: latest}, nil
+}

--- a/fbclock/fbclock.h
+++ b/fbclock/fbclock.h
@@ -1,0 +1,93 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#if defined(__cplusplus) && !defined(__clang__)
+#include <atomic>
+typedef std::atomic_uint_fast64_t atomic_uint64;
+#else
+#include <stdatomic.h>
+typedef atomic_uint_fast64_t atomic_uint64;
+#endif
+
+#include <stdint.h> /* for proper fixed width types */
+
+// error codes
+#define FBCLOCK_E_SHMEM_MAP_FAILED -1
+#define FBCLOCK_E_SHMEM_OPEN -2
+#define FBCLOCK_E_PTP_READ_OFFSET -3
+#define FBCLOCK_E_PTP_OPEN -4
+#define FBCLOCK_E_NO_DATA -5
+#define FBCLOCK_E_WOU_TOO_BIG -6
+#define FBCLOCK_E_PHC_IN_THE_PAST -7
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct fbclock_clockdata {
+  int64_t ingress_time_ns; // PHC time when ptp client last time received sync
+                           // message
+  uint32_t error_bound_ns; // error bound as calculated based on PTP client GM
+                           // offset, path delay and frequency adjustment
+  uint32_t holdover_multiplier_ns; // multiplier we use to adjust error bound
+                                   // when clock is running in holdover mode
+} fbclock_clockdata;
+
+// Define a structure that will be imposed on the shared memory object.
+typedef struct fbclock_shmdata {
+  atomic_uint64 crc;
+  fbclock_clockdata data;
+} fbclock_shmdata;
+
+#define FBCLOCK_SHMDATA_SIZE sizeof(fbclock_shmdata)
+#define FBCLOCK_PATH "/dev/shm/fbclock_data_v1"
+#define FBCLOCK_POW2_16 ((double)(1ULL << 16))
+#define FBCLOCK_PTPPATH "/dev/fbclock/ptp"
+
+// library
+typedef struct fbclock_lib {
+  char *ptp_path;        // path to PHC clock device
+  int shm_fd;            // file descriptor of opened shared mem
+  int dev_fd;            // file descriptor of opened /dev/ptpN
+  fbclock_shmdata *shmp; // mmap-ed data
+} fbclock_lib;
+
+// what customers get
+typedef struct fbclock_truetime {
+  uint64_t earliest_ns;
+  uint64_t latest_ns;
+} fbclock_truetime;
+
+int fbclock_clockdata_store_data(uint32_t fd, fbclock_clockdata *data);
+int fbclock_clockdata_load_data(fbclock_shmdata *shm, fbclock_clockdata *data);
+double fbclock_window_of_uncertainty(int64_t seconds, double error_bound_ns,
+                                     double holdover_multiplier_ns);
+int fbclock_calculate_time(double error_bound_ns, double h_value_ns,
+                           int64_t ingress_time_ns, int64_t phctime_ns,
+                           fbclock_truetime *truetime);
+
+// methods we provide to end users
+int fbclock_init(fbclock_lib *lib, const char *shm_path);
+int fbclock_destroy(fbclock_lib *lib);
+int fbclock_gettime(fbclock_lib *lib, fbclock_truetime *truetime);
+// turn error code into err msg
+const char *fbclock_strerror(int err_code);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/fbclock/missing.h
+++ b/fbclock/missing.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <linux/ptp_clock.h>
+
+// as in
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/ptp_clock.h
+#ifndef PTP_SYS_OFFSET_EXTENDED
+
+#define PTP_SYS_OFFSET_EXTENDED \
+  _IOWR(PTP_CLK_MAGIC, 9, struct ptp_sys_offset_extended)
+
+struct ptp_sys_offset_extended {
+  unsigned int n_samples; /* Desired number of measurements. */
+  unsigned int rsv[3]; /* Reserved for future use. */
+  /*
+   * Array of [system, phc, system] time stamps. The kernel will provide
+   * 3*n_samples time stamps.
+   */
+  struct ptp_clock_time ts[PTP_MAX_SAMPLES][3];
+};
+
+#endif

--- a/fbclock/shmem.go
+++ b/fbclock/shmem.go
@@ -1,0 +1,170 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fbclock
+
+/*
+#cgo LDFLAGS: -lrt
+
+#include "fbclock.h"
+
+#include <stdlib.h>   // for free()
+#include <sys/stat.h> // For mode constants
+#include <fcntl.h>    // For O_* constants
+#include <unistd.h>   // for ftruncate
+
+*/
+import "C"
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// PTPPath is the path we set for PTP device
+const PTPPath = C.FBCLOCK_PTPPATH
+
+// Shm is POSIX shared memory
+type Shm struct {
+	Path string
+	File *os.File
+}
+
+// OpenShm opens POSIX shared memory
+func OpenShm(path string, flags int, permissions os.FileMode) (*Shm, error) {
+	var err error
+	// store old umask, set it to 0.
+	// otherwise our creating flags might be affected by umask
+	// and shmem won't be readable by all users.
+	oldUmask := C.umask(0)
+	// make sure we return umask back to original value
+	defer C.umask(oldUmask)
+	file, err := os.OpenFile(path, flags, permissions)
+	if err != nil {
+		return nil, err
+	}
+	return &Shm{File: file, Path: path}, nil
+}
+
+// Close cleans up open POSIX shm resources
+func (s *Shm) Close() error {
+	if err := s.File.Close(); err != nil {
+		return err
+	}
+
+	cPath := C.CString(s.Path)
+	defer C.free(unsafe.Pointer(cPath))
+	return nil
+}
+
+// Data is a Go equivalent of what we want to store in shared memory for fbclock to use
+type Data struct {
+	IngressTimeNS        int64
+	ErrorBoundNS         uint64
+	HoldoverMultiplierNS float64 // float stored as multiplier of  2**16
+}
+
+// OpenFBClockShmCustom returns opened POSIX shared mem used by fbclock,
+// with custom path
+func OpenFBClockShmCustom(path string) (*Shm, error) {
+	shm, err := OpenShm(
+		path,
+		C.O_CREAT|C.O_RDWR,
+		C.S_IRUSR|C.S_IWUSR|C.S_IRGRP|C.S_IROTH,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := shm.File.Truncate(C.FBCLOCK_SHMDATA_SIZE); err != nil {
+		shm.Close()
+		return nil, err
+	}
+	return shm, nil
+}
+
+// OpenFBClockSHM returns opened POSIX shared mem used by fbclock
+func OpenFBClockSHM() (*Shm, error) {
+	return OpenFBClockShmCustom(C.FBCLOCK_PATH)
+}
+
+// FloatAsUint32 stores float as multiplier of 2**16.
+// Effectively this means we can store max 65k like this.
+func FloatAsUint32(val float64) uint32 {
+	valAsUint := C.FBCLOCK_POW2_16 * val
+	if valAsUint > math.MaxUint32 {
+		valAsUint = math.MaxUint32
+	}
+	return uint32(valAsUint)
+}
+
+// Uint32AsFloat restores float that was stored as a multiplier of 2**16.
+func Uint32AsFloat(val uint32) float64 {
+	return float64(val) / C.FBCLOCK_POW2_16
+}
+
+// Uint64ToUint32 converts uint64 to uint32, handling the overflow.
+// If the uint64 value is more than MaxUint32, result is set to MaxUint32.
+func Uint64ToUint32(val uint64) uint32 {
+	if val > math.MaxUint32 {
+		val = math.MaxUint32
+	}
+	return uint32(val)
+}
+
+// StoreFBClockData will store fbclock data in shared mem,
+// fd param should be open file descriptor of that shared mem.
+func StoreFBClockData(fd uintptr, d Data) error {
+	cData := &C.fbclock_clockdata{
+		ingress_time_ns:        C.int64_t(d.IngressTimeNS),
+		error_bound_ns:         C.uint32_t(Uint64ToUint32(d.ErrorBoundNS)),
+		holdover_multiplier_ns: C.uint32_t(FloatAsUint32(d.HoldoverMultiplierNS)),
+	}
+	// fbclock_clockdata_store_data comes from fbclock.c
+	res := C.fbclock_clockdata_store_data(C.uint(fd), cData)
+	if res != 0 {
+		return fmt.Errorf("failed to store data: %s", strerror(res))
+	}
+	return nil
+}
+
+// MmapShmpData mmaps open file as fbclock shared memory. Used in tests only.
+func MmapShmpData(fd uintptr) (unsafe.Pointer, error) {
+	data, err := unix.Mmap(int(fd), 0, C.FBCLOCK_SHMDATA_SIZE, unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, err
+	}
+	return unsafe.Pointer(&data[0]), nil
+}
+
+// ReadFBClockData will read Data from mmaped fbclock shared memory. Used in tests only
+func ReadFBClockData(shmp unsafe.Pointer) (*Data, error) {
+	cData := &C.fbclock_clockdata{}
+	shmpData := (*C.fbclock_shmdata)(shmp)
+	// fbclock_clockdata_load_data comes from fbclock.c
+	res := C.fbclock_clockdata_load_data(shmpData, cData)
+	if res != 0 {
+		return nil, fmt.Errorf("failed to store data: %s", strerror(res))
+	}
+	return &Data{
+		IngressTimeNS:        int64(cData.ingress_time_ns),
+		ErrorBoundNS:         uint64(cData.error_bound_ns),
+		HoldoverMultiplierNS: Uint32AsFloat(uint32(cData.holdover_multiplier_ns)),
+	}, nil
+}

--- a/fbclock/shmem_test.go
+++ b/fbclock/shmem_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fbclock
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFloatAsUint32(t *testing.T) {
+	v := 0.312
+	g := FloatAsUint32(v)
+	require.Equal(t, uint32(0x4fdf), g)
+	require.InDelta(t, v, Uint32AsFloat(g), 0.001)
+
+	v = 32333233
+	g = FloatAsUint32(v)
+	require.Equal(t, uint32(math.MaxUint32), g)
+}
+
+func TestUint64ToUint32(t *testing.T) {
+	var v uint64 = 100
+	g := Uint64ToUint32(v)
+	require.Equal(t, uint32(v), g)
+
+	v = 32333233333
+	g = Uint64ToUint32(v)
+	require.Equal(t, uint32(math.MaxUint32), g)
+}
+
+func TestShmem(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "shmemtest")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	shm, err := OpenFBClockShmCustom(tmpfile.Name())
+	require.NoError(t, err)
+	defer shm.Close()
+	d := Data{
+		IngressTimeNS:        1648137249050666302,
+		ErrorBoundNS:         314000000, // over 65k, our old limit
+		HoldoverMultiplierNS: 1.001,
+	}
+	err = StoreFBClockData(shm.File.Fd(), d)
+	require.NoError(t, err)
+
+	shmdata, err := MmapShmpData(shm.File.Fd())
+	require.NoError(t, err)
+
+	readD, err := ReadFBClockData(shmdata)
+	require.NoError(t, err)
+	require.Equal(t, d.IngressTimeNS, readD.IngressTimeNS)
+	require.Equal(t, d.ErrorBoundNS, readD.ErrorBoundNS)
+	require.InDelta(t, d.HoldoverMultiplierNS, readD.HoldoverMultiplierNS, 0.001)
+}

--- a/fbclock/stats.go
+++ b/fbclock/stats.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fbclock
+
+import "C"
+
+import (
+	"time"
+)
+
+// Stats aggregate stats for fbclock GetTime results
+type Stats struct {
+	Requests    int64
+	Errors      int64
+	WOUAvg      int64
+	WOUMax      int64
+	WOUlt10us   int64
+	WOUlt100us  int64
+	WOUlt1000us int64
+	WOUge1000us int64
+}
+
+// StatsCollector collects stats based on GetTime results
+type StatsCollector struct {
+	stats Stats
+	// internal stuff
+	wouSum int64
+}
+
+// Update processes result of GetTime call and updates Stats
+func (s *StatsCollector) Update(tt *TrueTime, err error) {
+	s.stats.Requests++
+	if err != nil {
+		s.stats.Errors++
+		return
+	}
+	wou := tt.Latest.Sub(tt.Earliest)
+	s.wouSum += int64(wou)
+	s.stats.WOUAvg = s.wouSum / (s.stats.Requests - s.stats.Errors)
+	if wou < 10*time.Microsecond {
+		s.stats.WOUlt10us++
+	} else if wou < 100*time.Microsecond {
+		s.stats.WOUlt100us++
+	} else if wou < 1000*time.Microsecond {
+		s.stats.WOUlt1000us++
+	} else {
+		s.stats.WOUge1000us++
+	}
+	if int64(wou) > s.stats.WOUMax {
+		s.stats.WOUMax = int64(wou)
+	}
+}
+
+// Stats returns collected stats
+func (s *StatsCollector) Stats() Stats {
+	return s.stats
+}

--- a/fbclock/stats_test.go
+++ b/fbclock/stats_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fbclock
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsUpdate(t *testing.T) {
+	type in struct {
+		tt  *TrueTime
+		err error
+	}
+	testCases := []struct {
+		name   string
+		inputs []in
+		want   Stats
+	}{
+		{
+			name: "empty",
+			want: Stats{},
+		},
+		{
+			name: "single error",
+			inputs: []in{
+				{
+					tt:  nil,
+					err: fmt.Errorf("oh no"),
+				},
+			},
+			want: Stats{
+				Requests: 1,
+				Errors:   1,
+			},
+		},
+		{
+			name: "single value",
+			inputs: []in{
+				{
+					tt:  &TrueTime{Earliest: time.Unix(0, 1648137249050666302), Latest: time.Unix(0, 1648137249050666313)},
+					err: nil,
+				},
+			},
+			want: Stats{
+				Requests:  1,
+				Errors:    0,
+				WOUAvg:    11,
+				WOUMax:    11,
+				WOUlt10us: 1,
+			},
+		},
+		{
+			name: "mixed",
+			inputs: []in{
+				{
+					tt:  &TrueTime{Earliest: time.Unix(0, 1648137249050666302), Latest: time.Unix(0, 1648137249050666313)},
+					err: nil,
+				},
+				{
+					tt:  &TrueTime{Earliest: time.Unix(0, 1648137249050666902), Latest: time.Unix(0, 1648137249050667333)},
+					err: nil,
+				},
+				{
+					tt:  nil,
+					err: fmt.Errorf("oh no"),
+				},
+				{
+					tt:  &TrueTime{Earliest: time.Unix(0, 1648137249050667499), Latest: time.Unix(0, 1648137249050668300)},
+					err: nil,
+				},
+				{
+					tt:  nil,
+					err: fmt.Errorf("whoops"),
+				},
+				{
+					tt:  &TrueTime{Earliest: time.Unix(0, 1648137249050668999), Latest: time.Unix(0, 1648137249050699300)},
+					err: nil,
+				},
+			},
+			want: Stats{
+				Requests:   6,
+				Errors:     2,
+				WOUAvg:     7886,
+				WOUMax:     30301,
+				WOUlt10us:  3,
+				WOUlt100us: 1,
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StatsCollector{}
+			for _, v := range tt.inputs {
+				s.Update(v.tt, v.err)
+			}
+			require.Equal(t, tt.want, s.Stats())
+		})
+	}
+}

--- a/fbclock/test/test.cpp
+++ b/fbclock/test/test.cpp
@@ -1,0 +1,199 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <future>
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <thread>
+
+#include "../fbclock.h"
+
+TEST(fbclock_test, test_write_read) {
+  int err;
+  char *test_shm = std::tmpnam(nullptr);
+
+  // open file, write data into it
+  FILE *f = fopen(test_shm, "wb+");
+  int sfd_rw = fileno(f);
+  ASSERT_NE(sfd_rw, -1);
+
+  err = ftruncate(sfd_rw, FBCLOCK_SHMDATA_SIZE);
+  ASSERT_EQ(err, 0);
+
+  fbclock_clockdata data = {
+      .ingress_time_ns = 1, .error_bound_ns = 2, .holdover_multiplier_ns = 3};
+  err = fbclock_clockdata_store_data(sfd_rw, &data);
+  ASSERT_EQ(err, 0);
+
+  fclose(f);
+
+  // read data from the file
+  f = fopen(test_shm, "r");
+  int sfd_ro = fileno(f);
+  ASSERT_NE(sfd_ro, -1);
+
+  fbclock_shmdata *shmp = (fbclock_shmdata *)mmap(
+      nullptr, FBCLOCK_SHMDATA_SIZE, PROT_READ, MAP_SHARED, sfd_ro, 0);
+  ASSERT_NE(shmp, MAP_FAILED);
+
+  fbclock_clockdata read_data;
+
+  err = fbclock_clockdata_load_data(shmp, &read_data);
+  ASSERT_EQ(err, 0);
+
+  munmap(shmp, FBCLOCK_SHMDATA_SIZE);
+  fclose(f);
+
+  EXPECT_EQ(data.ingress_time_ns, read_data.ingress_time_ns);
+  EXPECT_EQ(data.error_bound_ns, read_data.error_bound_ns);
+  EXPECT_EQ(data.holdover_multiplier_ns, read_data.holdover_multiplier_ns);
+
+  remove(test_shm);
+}
+
+int writer_thread(int sfd_rw, int tries) {
+  int err;
+  fbclock_clockdata data = {
+      .ingress_time_ns = 1, .error_bound_ns = 2, .holdover_multiplier_ns = 3};
+  for (int i = 0; i < tries; i++) {
+    err = fbclock_clockdata_store_data(sfd_rw, &data);
+    if (err != 0) {
+      return err;
+    }
+    data.ingress_time_ns = data.ingress_time_ns + 1;
+    if (data.ingress_time_ns > 10000) {
+      data.ingress_time_ns = 1;
+    }
+    data.error_bound_ns = data.ingress_time_ns * 2;
+    data.holdover_multiplier_ns = data.ingress_time_ns * 3;
+  }
+  return 0;
+}
+
+int reader_thread(fbclock_shmdata *shmp, int tries) {
+  int err;
+  fbclock_clockdata data;
+  for (int i = 0; i < tries; i++) {
+    err = fbclock_clockdata_load_data(shmp, &data);
+    if (err != 0) {
+      return err;
+    }
+    if (data.ingress_time_ns * 2 != data.error_bound_ns) {
+      printf("ingress_time_ns: %lu\n", data.ingress_time_ns);
+      printf("error_bound_ns: %d\n", data.error_bound_ns);
+      printf("holdover_multiplier_ns: %d\n", data.holdover_multiplier_ns);
+      return -1;
+    }
+    if (data.ingress_time_ns * 3 != data.holdover_multiplier_ns) {
+      printf("ingress_time_ns: %lu\n", data.ingress_time_ns);
+      printf("error_bound_ns: %d\n", data.error_bound_ns);
+      printf("holdover_multiplier_ns: %d\n", data.holdover_multiplier_ns);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+TEST(fbclock_test, test_concurrent) {
+  int err;
+  char *test_shm = std::tmpnam(nullptr);
+
+  // open file, write data into it
+  FILE *f_rw = fopen(test_shm, "wb+");
+  int sfd_rw = fileno(f_rw);
+  ASSERT_NE(sfd_rw, -1);
+
+  err = ftruncate(sfd_rw, FBCLOCK_SHMDATA_SIZE);
+  ASSERT_EQ(err, 0);
+
+  // read data from the file
+  FILE *f_ro = fopen(test_shm, "r");
+  int sfd_ro = fileno(f_ro);
+  ASSERT_NE(sfd_ro, -1);
+
+  fbclock_shmdata *shmp = (fbclock_shmdata *)mmap(
+      nullptr, FBCLOCK_SHMDATA_SIZE, PROT_READ, MAP_SHARED, sfd_ro, 0);
+  ASSERT_NE(shmp, MAP_FAILED);
+
+  int tries = 10000;
+
+  // spawn two functions asynchronously, make sure there is no incosistent data
+  auto future_writer =
+      std::async(std::launch::async, writer_thread, sfd_rw, tries);
+  auto future_reader =
+      std::async(std::launch::async, reader_thread, shmp, tries);
+  err = future_writer.get();
+  ASSERT_EQ(err, 0);
+  err = future_reader.get();
+  ASSERT_EQ(err, 0);
+  munmap(shmp, FBCLOCK_SHMDATA_SIZE);
+  remove(test_shm);
+}
+
+TEST(fbclock_test, test_window_of_uncertainty) {
+  int64_t seconds = 0; // how long ago was the last SYNC
+  double error_bound_ns = 172.0;
+  double holdover_multiplier_ns = 50.5;
+
+  double wou = fbclock_window_of_uncertainty(seconds, error_bound_ns,
+                                             holdover_multiplier_ns);
+  EXPECT_DOUBLE_EQ(wou, 172.0);
+
+  seconds = 10;
+  wou = fbclock_window_of_uncertainty(seconds, error_bound_ns,
+                                      holdover_multiplier_ns);
+
+  EXPECT_DOUBLE_EQ(wou, 677.0);
+}
+
+TEST(fbclock_test, test_fbclock_calculate_time) {
+  int err;
+  fbclock_truetime truetime;
+  double error_bound_ns = 172.0;
+  double h_value_ns = 50.5;
+  // phc time is before ingress time, error
+  int64_t ingress_time_ns = 1647269091803102957;
+  int64_t phctime_ns = 1647269082943150996;
+
+  err = fbclock_calculate_time(error_bound_ns, h_value_ns, ingress_time_ns,
+                               phctime_ns, &truetime);
+  ASSERT_EQ(err, FBCLOCK_E_PHC_IN_THE_PAST);
+
+  // phc time is after ingress time, all good
+  ingress_time_ns = 1647269082943150996;
+  phctime_ns = 1647269091803102957;
+  err = fbclock_calculate_time(error_bound_ns, h_value_ns, ingress_time_ns,
+                               phctime_ns, &truetime);
+  ASSERT_EQ(err, 0);
+
+  EXPECT_EQ(truetime.earliest_ns, 1647269091803102381);
+  EXPECT_EQ(truetime.latest_ns, 1647269091803103533);
+
+  // WOU is very big
+  error_bound_ns = 1000.0;
+  phctime_ns += 6 * 3600 * 1000000000.0; // + 6 hours
+  err = fbclock_calculate_time(error_bound_ns, h_value_ns, ingress_time_ns,
+                               phctime_ns, &truetime);
+  ASSERT_EQ(err, 0);
+  EXPECT_EQ(truetime.earliest_ns, 1647290691802010772);
+  EXPECT_EQ(truetime.latest_ns, 1647290691804195180);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Open-source our implementation of TrueTime service.
New stuff:
* `fbclock` - C lib and CGO wrapper for it
* `fbclock/daemon` - stateful part of fbclock
* `cmd/fbclock-daemon` - daemon for stateful part
* `cmd/fbclock-bin` - C tool to use fbclock API

Proper docs for fbclock will follow in a separate PR, this is big enough already.

## Test Plan

tests pass, build works:
```
go build github.com/facebook/time/cmd/fbclock-daemon
```

```
> cd cmd/fbclock-bin
> make
```

```
> cd fbclock
> make test
[       OK ] fbclock_test.test_fbclock_calculate_time (0 ms)
[----------] 4 tests from fbclock_test (46 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (46 ms total)
[  PASSED  ] 4 tests.
```
