### PR TITLE
[fbclock] use network interface instead of phc device path

### DIFF
--- a/cmd/fbclock-daemon/main.go
+++ b/cmd/fbclock-daemon/main.go
@@ -46,7 +46,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	flag.StringVar(&cfg.Device, "ptpdevice", "/dev/ptp0", "Path to original PTP device we need to copy if -manage is true")
+	flag.StringVar(&cfg.Iface, "iface", "eth0", "Network interface to use PHC device from. Used for linearizability tests as well. Must match what ptp4l is configured to use")
 	flag.StringVar(&cfg.PTP4Lsock, "ptp4lsock", "/var/run/ptp4l", "Path to ptp4l unix socket")
 	flag.IntVar(&monitoringPort, "monitoringport", 21039, "Port to run monitoring server on")
 	flag.IntVar(&cfg.RingSize, "buffer", daemon.MathDefaultHistory, "Size of ring buffers, must be at least size of largest num of samples used in M and W formulas")
@@ -57,7 +57,7 @@ func main() {
 	flag.DurationVar(&cfg.LinearizabilityTestInterval, "I", time.Minute, "Interval at which we run linearizability tests. 0 means disabled.")
 
 	flag.StringVar(&cfgPath, "cfg", "", "Path to config")
-	flag.BoolVar(&manageDevice, "manage", true, "Manage devices")
+	flag.BoolVar(&manageDevice, "manage", true, fmt.Sprintf("Manage device. This will setup %q as a copy of PHC device associated with given network interface", daemon.ManagedPTPDevicePath))
 	flag.BoolVar(&csvLog, "csvlog", true, "Log all the metrics as CSV to log")
 	flag.StringVar(&csvPath, "csvpath", "", "write CSV log into this file")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose logging")
@@ -82,7 +82,7 @@ func main() {
 		log.Fatal(err)
 	}
 	if manageDevice {
-		if err := daemon.SetupDeviceDir(cfg.Device); err != nil {
+		if err := daemon.SetupDeviceDir(cfg.Iface); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/fbclock/daemon/config.go
+++ b/fbclock/daemon/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	RingSize                    int           // must be at least the size of N samples we use in expressions
 	Math                        Math          // configuration for calculation we'll be doing
 	Interval                    time.Duration // how often do we poll ptp4l and update data in shm
-	Device                      string        // path to ptp device
+	Iface                       string        // network interface to use
 	LinearizabilityTestInterval time.Duration // perform the linearizability test every so often
 }
 

--- a/phc/offset.go
+++ b/phc/offset.go
@@ -78,14 +78,10 @@ func sysoffEstimateExtended(extended *PTPSysOffsetExtended) SysoffResult {
 
 // TimeAndOffset returns time we got from network card + offset
 func TimeAndOffset(iface string, method TimeMethod) (SysoffResult, error) {
-	info, err := IfaceInfo(iface)
+	device, err := IfaceToPHCDevice(iface)
 	if err != nil {
-		return SysoffResult{}, fmt.Errorf("getting interface info: %w", err)
+		return SysoffResult{}, err
 	}
-	if info.PHCIndex < 0 {
-		return SysoffResult{}, fmt.Errorf("%s doesn't support PHC", iface)
-	}
-	device := fmt.Sprintf("/dev/ptp%d", info.PHCIndex)
 	return TimeAndOffsetFromDevice(device, method)
 }
 

--- a/phc/offset_test.go
+++ b/phc/offset_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSysoffEstimateBasic(t *testing.T) {
+	ts1 := time.Unix(0, 1667818190552297411)
+	rt := time.Unix(0, 1667818153552297462)
+	ts2 := time.Unix(0, 1667818190552297522)
+	got := sysoffEstimateBasic(ts1, rt, ts2)
+	want := SysoffResult{
+		SysTime: time.Unix(0, 1667818190552297466),
+		PHCTime: rt,
+		Delay:   ts2.Sub(ts1),
+		Offset:  time.Duration(37000000005),
+	}
+	require.Equal(t, want, got)
+}
+
+func TestSysoffEstimateExtended(t *testing.T) {
+	extended := &PTPSysOffsetExtended{
+		NSamples: 3,
+		TS: [ptpMaxSamples][3]PTPClockTime{
+			{{Sec: 1667818190, NSec: 552297411}, {Sec: 1667818153, NSec: 552297462}, {Sec: 1667818190, NSec: 552297522}},
+			{{Sec: 1667818190, NSec: 552297533}, {Sec: 1667818153, NSec: 552297582}, {Sec: 1667818190, NSec: 552297622}},
+			{{Sec: 1667818190, NSec: 552297644}, {Sec: 1667818153, NSec: 552297661}, {Sec: 1667818190, NSec: 552297722}},
+		},
+	}
+	got := sysoffEstimateExtended(extended)
+	want := SysoffResult{
+		SysTime: time.Unix(0, 1667818190552297683),
+		PHCTime: time.Unix(0, 1667818153552297661),
+		Delay:   time.Duration(78),
+		Offset:  time.Duration(37000000022),
+	}
+	require.Equal(t, want, got)
+}

--- a/phc/phc.go
+++ b/phc/phc.go
@@ -55,16 +55,20 @@ const (
 // SupportedMethods is a list of supported TimeMethods
 var SupportedMethods = []TimeMethod{MethodSyscallClockGettime, MethodIoctlSysOffsetExtended}
 
+func ifaceInfoToPHCDevice(info *EthtoolTSinfo) (string, error) {
+	if info.PHCIndex < 0 {
+		return "", fmt.Errorf("interface doesn't support PHC")
+	}
+	return fmt.Sprintf("/dev/ptp%d", info.PHCIndex), nil
+}
+
 // IfaceToPHCDevice returns path to PHC device associated with given network card iface
 func IfaceToPHCDevice(iface string) (string, error) {
 	info, err := IfaceInfo(iface)
 	if err != nil {
-		return "", fmt.Errorf("getting interface info: %w", err)
+		return "", fmt.Errorf("getting interface %s info: %w", iface, err)
 	}
-	if info.PHCIndex < 0 {
-		return "", fmt.Errorf("%s doesn't support PHC", iface)
-	}
-	return fmt.Sprintf("/dev/ptp%d", info.PHCIndex), nil
+	return ifaceInfoToPHCDevice(info)
 }
 
 // Time returns time we got from network card

--- a/phc/phc_test.go
+++ b/phc/phc_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIfaceInfoToPHCDevice(t *testing.T) {
+	info := &EthtoolTSinfo{
+		PHCIndex: 0,
+	}
+	got, err := ifaceInfoToPHCDevice(info)
+	require.NoError(t, err)
+	require.Equal(t, "/dev/ptp0", got)
+
+	info.PHCIndex = 23
+	got, err = ifaceInfoToPHCDevice(info)
+	require.NoError(t, err)
+	require.Equal(t, "/dev/ptp23", got)
+
+	info.PHCIndex = -1
+	_, err = ifaceInfoToPHCDevice(info)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

On multi-NIC devices we can't just assume that `/dev/ptp0` corresponds to `eth0`. Stop making assumptions and accept iface to use, as we still need to know it for linearizability tests.

## Test Plan

Local run, making sure correct PHC is used for operations.

For example, managed device setup:
```
> ptpcheck map
No PHC support for lo
/dev/ptp0 -> eth8
/dev/ptp1 -> eth5
/dev/ptp2 -> eth0
/dev/ptp3 -> eth11
/dev/ptp4 -> eth4
/dev/ptp5 -> eth1
/dev/ptp6 -> eth6
/dev/ptp7 -> eth7
/dev/ptp8 -> eth2
/dev/ptp9 -> eth9
/dev/ptp10 -> eth10
/dev/ptp11 -> eth3
```
notice that `/dev/ptp2 -> eth0` line.

Now let's make sure we set up the device correctly:
```
> ls -lhi /dev/ptp2
698 crw-r--r-- 2 root root 249, 2 Sep 26 21:26 /dev/ptp2
> ls -lhi /dev/fbclock/ptp
698 crw-r--r-- 2 root root 249, 2 Sep 26 21:26 /dev/fbclock/ptp
```
inodes match, so the setup was done correctly.
