### PR TITLE
ptp/ptp4u: add default DomainNumber support #219

### DIFF
--- a/cmd/ptp4u/main.go
+++ b/cmd/ptp4u/main.go
@@ -52,6 +52,7 @@ func main() {
 	flag.IntVar(&c.QueueSize, "queue", 0, "Size of the queue to send out packets")
 	flag.IntVar(&c.RecvWorkers, "recvworkers", 10, "Set the number of receive workers")
 	flag.IntVar(&c.SendWorkers, "workers", 100, "Set the number of send workers")
+	flag.UintVar(&c.DomainNumber, "domainnumber", 0, "Set the PTP domain by its number. Valid values are [0-255]")
 	flag.StringVar(&c.ConfigFile, "config", "", "Path to a config with dynamic settings")
 	flag.StringVar(&c.DebugAddr, "pprofaddr", "", "host:port for the pprof to bind")
 	flag.StringVar(&c.Interface, "iface", "eth0", "Set the interface")
@@ -84,6 +85,10 @@ func main() {
 
 	if c.DSCP < 0 || c.DSCP > 63 {
 		log.Fatalf("Unsupported DSCP value %v", c.DSCP)
+	}
+
+	if c.DomainNumber > 255 {
+		log.Fatalf("Unsupported DomainNumber value %v", c.DomainNumber)
 	}
 
 	switch c.TimestampType {

--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -48,6 +48,7 @@ type StaticConfig struct {
 	IP             net.IP
 	LogLevel       string
 	MonitoringPort int
+	DomainNumber   uint
 	PidFile        string
 	QueueSize      int
 	RecvWorkers    int

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -202,7 +202,7 @@ func (sc *SubscriptionClient) initSync() {
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0),
 			Version:         ptp.Version,
 			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
-			DomainNumber:    0,
+			DomainNumber:    uint8(sc.serverConfig.DomainNumber),
 			FlagField:       ptp.FlagUnicast | ptp.FlagTwoStep,
 			SequenceID:      0,
 			SourcePortIdentity: ptp.PortIdentity{
@@ -231,7 +231,7 @@ func (sc *SubscriptionClient) initFollowup() {
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageFollowUp, 0),
 			Version:         ptp.Version,
 			MessageLength:   uint16(binary.Size(ptp.FollowUp{})),
-			DomainNumber:    0,
+			DomainNumber:    uint8(sc.serverConfig.DomainNumber),
 			FlagField:       ptp.FlagUnicast,
 			SequenceID:      0,
 			SourcePortIdentity: ptp.PortIdentity{
@@ -266,7 +266,7 @@ func (sc *SubscriptionClient) initAnnounce() {
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageAnnounce, 0),
 			Version:         ptp.Version,
 			MessageLength:   uint16(binary.Size(ptp.Header{}) + binary.Size(ptp.AnnounceBody{})),
-			DomainNumber:    0,
+			DomainNumber:    uint8(sc.serverConfig.DomainNumber),
 			FlagField:       ptp.FlagUnicast | ptp.FlagPTPTimescale,
 			SequenceID:      0,
 			SourcePortIdentity: ptp.PortIdentity{
@@ -314,7 +314,7 @@ func (sc *SubscriptionClient) initDelayResp() {
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageDelayResp, 0),
 			Version:         ptp.Version,
 			MessageLength:   uint16(binary.Size(ptp.DelayResp{})),
-			DomainNumber:    0,
+			DomainNumber:    uint8(sc.serverConfig.DomainNumber),
 			FlagField:       ptp.FlagUnicast,
 			SequenceID:      0,
 			SourcePortIdentity: ptp.PortIdentity{


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Added a default DomainNumber for subscriptions. 

Currently it is It's hardcoded to 0 in
https://github.com/facebook/time/blob/main/ptp/ptp4u/server/subscription.go#L205

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

Unit test and internal manual test on time servers

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
