### PR TITLE
[chore] replace control character with space

### DIFF
--- a/ptp/protocol/types.go
+++ b/ptp/protocol/types.go
@@ -98,7 +98,7 @@ const (
 	TLVAcknowledgeCancelUnicastTransmission TLVType = 0x0007
 	TLVPathTrace                            TLVType = 0x0008
 	TLVAlternateTimeOffsetIndicator         TLVType = 0x0009
-	// Remaining 52tlvType TLVs not implemented
+	// Remaining 52 tlvType TLVs not implemented
 )
 
 // TLVTypeToString is a map from TLVType to string


### PR DESCRIPTION
## Summary

`file` does not like `ptp/protocol/types.go`:
```
$ file ptp/protocol/types.go
ptp/protocol/types.go: data
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->

```sh
$ file ptp/protocol/types.go
ptp/protocol/types.go: ASCII text
```