### PR TITLE
[ptp4u] crash on TX timestamp unavailability

### DIFF
--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -192,8 +192,8 @@ func (s *sendWorker) Start() {
 				txTS, attempts, err = timestamp.ReadTXtimestampBuf(eFd, oob, toob)
 				s.stats.SetMaxTXTSAttempts(s.id, int64(attempts))
 				if err != nil {
-					log.Warningf("Failed to read TX timestamp: %v", err)
-					continue
+					log.Errorf("Failed to read TX timestamp: %v", err)
+					return
 				}
 				if s.config.TimestampType != timestamp.HWTIMESTAMP {
 					txTS = txTS.Add(s.config.UTCOffset)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
TX timestamp failures not recovering. It's better to crash than keep operating without a timestamp
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
