### PR TITLE
[phc] better way to calculate PHC diff

### DIFF
--- a/cmd/ptpcheck/cmd/phcdiff.go
+++ b/cmd/ptpcheck/cmd/phcdiff.go
@@ -46,17 +46,17 @@ func init() {
 }
 
 func phcdiffRun(deviceA, deviceB string, isJSON bool) error {
-	timeAndOffsetA, err := phc.TimeAndOffsetFromDevice(deviceA, phc.MethodIoctlSysOffsetExtended)
+	extendedA, err := phc.ReadPTPSysOffsetExtended(deviceA, phc.ExtendedNumProbes)
 	if err != nil {
 		return err
 	}
-
-	timeAndOffsetB, err := phc.TimeAndOffsetFromDevice(deviceB, phc.MethodIoctlSysOffsetExtended)
+	extendedB, err := phc.ReadPTPSysOffsetExtended(deviceB, phc.ExtendedNumProbes)
 	if err != nil {
 		return err
 	}
-
-	phcOffset := phc.CalcPHCOffet(timeAndOffsetA, timeAndOffsetB)
+	timeAndOffsetA := phc.SysoffEstimateExtended(extendedA)
+	timeAndOffsetB := phc.SysoffEstimateExtended(extendedB)
+	phcOffset := phc.OffsetBetweenExtendedReadings(extendedA, extendedB)
 
 	if isJSON {
 		stats := phcStats{PHCOffset: phcOffset, PHC1Delay: timeAndOffsetA.Delay, PHC2Delay: timeAndOffsetB.Delay}

--- a/ptp/c4u/clock/ts2phc.go
+++ b/ptp/c4u/clock/ts2phc.go
@@ -27,15 +27,5 @@ const (
 )
 
 func ts2phc() (time.Duration, error) {
-	tcard, err := phc.TimeAndOffsetFromDevice(phcTimeCardPath, phc.MethodIoctlSysOffsetExtended)
-	if err != nil {
-		return 0, err
-	}
-
-	tnic, err := phc.TimeAndOffsetFromDevice(phcNICPath, phc.MethodIoctlSysOffsetExtended)
-	if err != nil {
-		return 0, err
-	}
-
-	return phc.CalcPHCOffet(tcard, tnic), nil
+	return phc.OffsetBetweenDevices(phcTimeCardPath, phcNICPath)
 }


### PR DESCRIPTION
## Summary

Greatly improve the way we calculate offset between two PHC devices.
The idea is that we collect N samples from each device, and then find the one where difference between system time is minimal, which allows us to better compensate the difference between PHC readings.

## Test Plan

Unittests, c4u canary, ptpcheck manual runs:

```
[root@time ~]# ./ptpcheck phcdiff
PHC offset: 3ns
Delay for PHC1: 356ns
Delay for PHC2: 2.592µs
```