### PR TITLE
support configuration of antenna_delay property

### DIFF
--- a/calnex/cmd/config.go
+++ b/calnex/cmd/config.go
@@ -40,7 +40,7 @@ func init() {
 	}
 }
 
-type devices map[string]config.CalnexConfig
+type calnexes map[string]config.CalnexConfig
 
 var configCmd = &cobra.Command{
 	Use:   "config",
@@ -56,18 +56,18 @@ var configCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		var d devices
-		err = json.Unmarshal(b, &d)
+		var cs calnexes
+		err = json.Unmarshal(b, &cs)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		dc, ok := d[target]
+		dc, ok := cs[target]
 		if !ok {
 			log.Fatalf("Failed to find config for %s in %s", target, source)
 		}
 
-		if err := config.Config(target, insecureTLS, dc, apply); err != nil {
+		if err := config.Config(target, insecureTLS, &dc, apply); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/calnex/cmd/config_test.go
+++ b/calnex/cmd/config_test.go
@@ -29,40 +29,46 @@ func TestUnmarshalConfig(t *testing.T) {
 	testConfig := `
 	{
 		"calnex01.example.com": {
-			"a": {
-				"target": "fd00::d",
-				"probe": "pps"
-			},
-			"VP1": {
-				"target": "fd00::d",
-				"probe": "ntp"
-			},
-			"VP22": {
-				"target": "fd00::d",
-				"probe": "ptp"
+			"antennaDelayNS": 42,
+			"measure": {
+				"a": {
+					"target": "fd00::d",
+					"probe": "pps"
+				},
+				"VP1": {
+					"target": "fd00::d",
+					"probe": "ntp"
+				},
+				"VP22": {
+					"target": "fd00::d",
+					"probe": "ptp"
+				}
 			}
 		}
 	}
 `
 
-	var d devices
-	err := json.Unmarshal([]byte(testConfig), &d)
+	var cs calnexes
+	err := json.Unmarshal([]byte(testConfig), &cs)
 	require.NoError(t, err)
 
-	expected := devices{}
+	expected := calnexes{}
 	expected["calnex01.example.com"] = config.CalnexConfig{
-		api.ChannelA: config.MeasureConfig{
-			Target: "fd00::d",
-			Probe:  api.ProbePPS,
-		},
-		api.ChannelVP1: config.MeasureConfig{
-			Target: "fd00::d",
-			Probe:  api.ProbeNTP,
-		},
-		api.ChannelVP22: config.MeasureConfig{
-			Target: "fd00::d",
-			Probe:  api.ProbePTP,
+		AntennaDelayNS: 42,
+		Measure: map[api.Channel]config.MeasureConfig{
+			api.ChannelA: {
+				Target: "fd00::d",
+				Probe:  api.ProbePPS,
+			},
+			api.ChannelVP1: {
+				Target: "fd00::d",
+				Probe:  api.ProbeNTP,
+			},
+			api.ChannelVP22: {
+				Target: "fd00::d",
+				Probe:  api.ProbePTP,
+			},
 		},
 	}
-	require.Equal(t, expected, d)
+	require.Equal(t, expected, cs)
 }

--- a/calnex/testdata/config.json
+++ b/calnex/testdata/config.json
@@ -1,16 +1,19 @@
 {
     "calnex01.example.com": {
-        "a": {
-            "target": "fd00::d",
-            "probe": "pps"
-        },
-        "VP1": {
-            "target": "fd00::d",
-            "probe": "ntp"
-        },
-        "VP22": {
-            "target": "fd00::d",
-            "probe": "ptp"
+        "antennaDelayNS": 42,
+        "measure": {
+            "a": {
+                "target": "fd00::d",
+                "probe": "pps"
+            },
+            "VP1": {
+                "target": "fd00::d",
+                "probe": "ntp"
+            },
+            "VP22": {
+                "target": "fd00::d",
+                "probe": "ptp"
+            }
         }
     }
 }


### PR DESCRIPTION
Summary: We need to be able to set `antenna_delay` therefore changing the API and config format.

Reviewed By: abulimov

Differential Revision: D42228455

