### PR TITLE
[time] fix fblock-daemon oss build.

### DIFF
--- a/cmd/fbclock-daemon/main.go
+++ b/cmd/fbclock-daemon/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	flag.StringVar(&cfg.Iface, "iface", "eth0", "Network interface to use PHC device from. Used for linearizability tests as well. Must match what ptp4l is configured to use")
-	flag.StringVar(&cfg.PTP4Lsock, "ptp4lsock", "/var/run/ptp4l", "Path to ptp4l unix socket")
+	flag.StringVar(&cfg.PTPClientAddress, "ptp4lsock", "/var/run/ptp4l", "Path to ptp4l unix socket")
 	flag.IntVar(&monitoringPort, "monitoringport", 21039, "Port to run monitoring server on")
 	flag.IntVar(&cfg.RingSize, "buffer", daemon.MathDefaultHistory, "Size of ring buffers, must be at least size of largest num of samples used in M and W formulas")
 	flag.StringVar(&cfg.Math.M, "m", daemon.MathDefaultM, "Math expression for M")


### PR DESCRIPTION
Changes made to fbclock/daemon/config.go were not fully ported to main fbclock executable. 
Make it build again
![image](https://www.keebtalk.com/uploads/db8059/original/3X/d/f/df9f313bde98a9fea7835aa41e034b98f25226c5.jpeg)
