### PR TITLE
support both ptp4l and sptp in ptpcheck

### DIFF
--- a/cmd/ptpcheck/checker/checker.go
+++ b/cmd/ptpcheck/checker/checker.go
@@ -17,14 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
-	"net"
-	"os"
-	"path"
-	"time"
-
-	log "github.com/sirupsen/logrus"
-
 	ptp "github.com/facebook/time/ptp/protocol"
 )
 
@@ -34,146 +26,11 @@ type PTPCheckResult struct {
 	GrandmasterPresent  bool
 	StepsRemoved        int
 	MeanPathDelayNS     float64
-	ClockIdentity       string
 	GrandmasterIdentity string
 	IngressTimeNS       int64
+	CorrectionFieldTxNS int64
+	CorrectionFieldRxNS int64
 	PortStatsTX         map[string]uint64
 	PortStatsRX         map[string]uint64
 	PortServiceStats    *ptp.PortServiceStats
-}
-
-// Run will talk over conn and return PTPCheckResult
-func Run(c *ptp.MgmtClient) (*PTPCheckResult, error) {
-	var err error
-	currentDataSet, err := c.CurrentDataSet()
-	if err != nil {
-		return nil, fmt.Errorf("getting CURRENT_DATA_SET management TLV: %w", err)
-	}
-	log.Debugf("CurrentDataSet: %+v", currentDataSet)
-	defaultDataSet, err := c.DefaultDataSet()
-	if err != nil {
-		return nil, fmt.Errorf("getting DEFAULT_DATA_SET management TLV: %w", err)
-	}
-	log.Debugf("DefaultDataSet: %+v", defaultDataSet)
-	parentDataSet, err := c.ParentDataSet()
-	if err != nil {
-		return nil, fmt.Errorf("getting PARENT_DATA_SET management TLV: %w", err)
-	}
-	log.Debugf("ParentDataSet: %+v", parentDataSet)
-
-	/* gmPresent calculation from non-standard TIME_STATUS_NP
-
-	 if (cid_eq(&c->dad.pds.grandmasterIdentity, &c->dds.clockIdentity))
-	            tsn->gmPresent = 0;
-	        else
-				tsn->gmPresent = 1;
-
-	where dad.pds is PARENT_DATA_SET and dds is DEFAULT_DATA_SET
-	*/
-	gmPresent := defaultDataSet.ClockIdentity != parentDataSet.GrandmasterIdentity
-
-	result := &PTPCheckResult{
-		OffsetFromMasterNS:  currentDataSet.OffsetFromMaster.Nanoseconds(),
-		GrandmasterPresent:  gmPresent,
-		MeanPathDelayNS:     currentDataSet.MeanPathDelay.Nanoseconds(),
-		StepsRemoved:        int(currentDataSet.StepsRemoved),
-		ClockIdentity:       defaultDataSet.ClockIdentity.String(),
-		GrandmasterIdentity: parentDataSet.GrandmasterIdentity.String(),
-		PortStatsTX:         map[string]uint64{},
-		PortStatsRX:         map[string]uint64{},
-	}
-
-	portStats, err := c.PortStatsNP()
-	// it's a non-standard ptp4l thing, might be missing
-	if err != nil {
-		log.Warningf("couldn't get PortStatsNP: %v", err)
-	} else {
-		log.Debugf("PortStatsNP: %+v", portStats)
-		for k, v := range ptp.MessageTypeToString {
-			result.PortStatsRX[v] = portStats.PortStats.RXMsgType[k]
-			result.PortStatsTX[v] = portStats.PortStats.TXMsgType[k]
-		}
-	}
-
-	timeStatus, err := c.TimeStatusNP()
-	// it's a non-standard ptp4l thing, might be missing
-	if err != nil {
-		log.Warningf("couldn't get TimeStatusNP: %v", err)
-	} else {
-		log.Debugf("TimeStatusNP: %+v", timeStatus)
-		result.IngressTimeNS = timeStatus.IngressTimeNS
-	}
-
-	portServiceStats, err := c.PortServiceStatsNP()
-	// it's a non-standard ptp4l thing, might be missing
-	if err != nil {
-		log.Warningf("couldn't get PortServiceStatsNP: %v", err)
-	} else {
-		log.Debugf("PortServiceStatsNP: %+v", portServiceStats)
-		result.PortServiceStats = &portServiceStats.PortServiceStats
-	}
-	return result, nil
-}
-
-func prepareConn(address string) (conn *net.UnixConn, cleanup func(), err error) {
-	if address == "" {
-		cleanup = func() {}
-		return nil, cleanup, fmt.Errorf("preparing ptp4l connection: target address is empty")
-	}
-	base, _ := path.Split(address)
-	local := path.Join(base, fmt.Sprintf("ptpcheck.%d.sock", os.Getpid()))
-	// cleanup
-	cleanup = func() {
-		if conn != nil {
-			if err := conn.Close(); err != nil {
-				log.Warningf("closing connection: %v", err)
-			}
-		}
-		if err := os.RemoveAll(local); err != nil {
-			log.Warningf("removing socket: %v", err)
-		}
-	}
-	addr, err := net.ResolveUnixAddr("unixgram", address)
-	if err != nil {
-		return nil, cleanup, err
-	}
-	localAddr, _ := net.ResolveUnixAddr("unixgram", local)
-	conn, err = net.DialUnix("unixgram", localAddr, addr)
-	if err != nil {
-		return nil, cleanup, err
-	}
-
-	if err := os.Chmod(local, 0666); err != nil {
-		return nil, cleanup, err
-	}
-	return
-}
-
-// PrepareClient creates a ptp.MgmtClient with connection to ptp4l over unix socket
-func PrepareClient(address string) (c *ptp.MgmtClient, cleanup func(), err error) {
-	timeout := 5 * time.Second
-	deadline := time.Now().Add(timeout)
-	var conn *net.UnixConn
-	conn, cleanup, err = prepareConn(address)
-	if err != nil {
-		return nil, cleanup, err
-	}
-
-	if err := conn.SetReadDeadline(deadline); err != nil {
-		return nil, cleanup, err
-	}
-	return &ptp.MgmtClient{
-		Connection: conn,
-	}, cleanup, err
-}
-
-// RunCheck is a simple wrapper to connect to address and run Run()
-func RunCheck(address string) (*PTPCheckResult, error) {
-	c, cleanup, err := PrepareClient(address)
-	defer cleanup()
-	if err != nil {
-		return nil, err
-	}
-	log.Debugf("connected to %s", address)
-	return Run(c)
 }

--- a/cmd/ptpcheck/checker/ptp4l.go
+++ b/cmd/ptpcheck/checker/ptp4l.go
@@ -1,0 +1,153 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+func preparePTP4lConn(address string) (conn *net.UnixConn, cleanup func(), err error) {
+	if address == "" {
+		cleanup = func() {}
+		return nil, cleanup, fmt.Errorf("preparing ptp4l connection: target address is empty")
+	}
+	base, _ := path.Split(address)
+	local := path.Join(base, fmt.Sprintf("ptpcheck.%d.sock", os.Getpid()))
+	// cleanup
+	cleanup = func() {
+		if conn != nil {
+			if err = conn.Close(); err != nil {
+				log.Warningf("closing connection: %v", err)
+			}
+		}
+		if err = os.RemoveAll(local); err != nil {
+			log.Warningf("removing socket: %v", err)
+		}
+	}
+	addr, err := net.ResolveUnixAddr("unixgram", address)
+	if err != nil {
+		return nil, cleanup, err
+	}
+	localAddr, _ := net.ResolveUnixAddr("unixgram", local)
+	conn, err = net.DialUnix("unixgram", localAddr, addr)
+	if err != nil {
+		return nil, cleanup, err
+	}
+
+	if err := os.Chmod(local, 0666); err != nil {
+		return nil, cleanup, err
+	}
+	return
+}
+
+// PrepareMgmtClient creates a ptp.MgmtClient with connection to ptp4l over unix socket
+func PrepareMgmtClient(address string) (c *ptp.MgmtClient, cleanup func(), err error) {
+	timeout := 5 * time.Second
+	deadline := time.Now().Add(timeout)
+	var conn *net.UnixConn
+	conn, cleanup, err = preparePTP4lConn(address)
+	if err != nil {
+		return nil, cleanup, err
+	}
+
+	if err = conn.SetReadDeadline(deadline); err != nil {
+		return nil, cleanup, err
+	}
+	return &ptp.MgmtClient{
+		Connection: conn,
+	}, cleanup, err
+}
+
+// RunPTP4L will talk over conn and return PTPCheckResult
+func RunPTP4L(c *ptp.MgmtClient) (*PTPCheckResult, error) {
+	var err error
+	currentDataSet, err := c.CurrentDataSet()
+	if err != nil {
+		return nil, fmt.Errorf("getting CURRENT_DATA_SET management TLV: %w", err)
+	}
+	log.Debugf("CurrentDataSet: %+v", currentDataSet)
+	defaultDataSet, err := c.DefaultDataSet()
+	if err != nil {
+		return nil, fmt.Errorf("getting DEFAULT_DATA_SET management TLV: %w", err)
+	}
+	log.Debugf("DefaultDataSet: %+v", defaultDataSet)
+	parentDataSet, err := c.ParentDataSet()
+	if err != nil {
+		return nil, fmt.Errorf("getting PARENT_DATA_SET management TLV: %w", err)
+	}
+	log.Debugf("ParentDataSet: %+v", parentDataSet)
+
+	/* gmPresent calculation from non-standard TIME_STATUS_NP
+
+	 if (cid_eq(&c->dad.pds.grandmasterIdentity, &c->dds.clockIdentity))
+	            tsn->gmPresent = 0;
+	        else
+				tsn->gmPresent = 1;
+
+	where dad.pds is PARENT_DATA_SET and dds is DEFAULT_DATA_SET
+	*/
+	gmPresent := defaultDataSet.ClockIdentity != parentDataSet.GrandmasterIdentity
+
+	result := &PTPCheckResult{
+		OffsetFromMasterNS:  currentDataSet.OffsetFromMaster.Nanoseconds(),
+		GrandmasterPresent:  gmPresent,
+		MeanPathDelayNS:     currentDataSet.MeanPathDelay.Nanoseconds(),
+		StepsRemoved:        int(currentDataSet.StepsRemoved),
+		GrandmasterIdentity: parentDataSet.GrandmasterIdentity.String(),
+		PortStatsTX:         map[string]uint64{},
+		PortStatsRX:         map[string]uint64{},
+	}
+
+	portStats, err := c.PortStatsNP()
+	// it's a non-standard ptp4l thing, might be missing
+	if err != nil {
+		log.Warningf("couldn't get PortStatsNP: %v", err)
+	} else {
+		log.Debugf("PortStatsNP: %+v", portStats)
+		for k, v := range ptp.MessageTypeToString {
+			result.PortStatsRX[v] = portStats.PortStats.RXMsgType[k]
+			result.PortStatsTX[v] = portStats.PortStats.TXMsgType[k]
+		}
+	}
+
+	timeStatus, err := c.TimeStatusNP()
+	// it's a non-standard ptp4l thing, might be missing
+	if err != nil {
+		log.Warningf("couldn't get TimeStatusNP: %v", err)
+	} else {
+		log.Debugf("TimeStatusNP: %+v", timeStatus)
+		result.IngressTimeNS = timeStatus.IngressTimeNS
+	}
+
+	portServiceStats, err := c.PortServiceStatsNP()
+	// it's a non-standard ptp4l thing, might be missing
+	if err != nil {
+		log.Warningf("couldn't get PortServiceStatsNP: %v", err)
+	} else {
+		log.Debugf("PortServiceStatsNP: %+v", portServiceStats)
+		result.PortServiceStats = &portServiceStats.PortServiceStats
+	}
+	return result, nil
+}

--- a/cmd/ptpcheck/checker/runner.go
+++ b/cmd/ptpcheck/checker/runner.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+
+	ptp "github.com/facebook/time/ptp/protocol"
+)
+
+// Flavour is the type of PTP client
+type Flavour int
+
+// Supported PTP client flavours
+const (
+	FlavourPTP4L Flavour = iota
+	FlavourSPTP
+)
+
+func isPTP4lListening() bool {
+	var err error
+	if _, err = os.Stat(ptp.PTP4lSock); err == nil {
+		return true
+	}
+	log.Debugf("checking for ptp4l socket: %v", err)
+	return false
+}
+
+// GetFlavour returns detected flavour of ptp client
+func GetFlavour() Flavour {
+	if isPTP4lListening() {
+		log.Debug("Will use PTP4L")
+		return FlavourPTP4L
+	}
+	log.Debug("Will use SPTP")
+	return FlavourSPTP
+}
+
+// GetServerAddress returns the address to talk to the client, based on flavour and manual address override
+func GetServerAddress(address string, f Flavour) string {
+	if address != "" {
+		return address
+	}
+	if f == FlavourPTP4L {
+		return ptp.PTP4lSock
+	}
+	return "http://[::1]:4269"
+}
+
+// RunCheck is a simple wrapper to connect to address and run Run()
+func RunCheck(address string) (*PTPCheckResult, error) {
+	flavour := GetFlavour()
+	address = GetServerAddress(address, flavour)
+	log.Debugf("using address %q", address)
+	switch flavour {
+	case FlavourPTP4L:
+		c, cleanup, err := PrepareMgmtClient(address)
+		defer cleanup()
+		if err != nil {
+			return nil, err
+		}
+		log.Debugf("connected to %s", address)
+		return RunPTP4L(c)
+	case FlavourSPTP:
+		return RunSPTP(address)
+	}
+	return nil, fmt.Errorf("unknown PTP client flavour %v", flavour)
+}

--- a/cmd/ptpcheck/checker/sptp.go
+++ b/cmd/ptpcheck/checker/sptp.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"github.com/facebook/time/sptp/stats"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// RunSPTP will run checker against SPTP and return PTPCheckResult
+func RunSPTP(address string) (*PTPCheckResult, error) {
+	sm, err := stats.FetchStats(address)
+	if err != nil {
+		return nil, err
+	}
+	var selected *stats.Stats
+	for _, s := range sm {
+		if s.Selected {
+			selected = &s
+			break
+		}
+	}
+	result := &PTPCheckResult{
+		PortStatsTX: map[string]uint64{},
+		PortStatsRX: map[string]uint64{},
+	}
+	if selected != nil {
+		gmPresent := false
+		if selected.GMPresent != 0 {
+			gmPresent = true
+		}
+		result.OffsetFromMasterNS = selected.Offset
+		result.IngressTimeNS = selected.IngressTime
+		result.GrandmasterPresent = gmPresent
+		result.MeanPathDelayNS = selected.MeanPathDelay
+		result.StepsRemoved = selected.StepsRemoved
+		result.GrandmasterIdentity = selected.PortIdentity
+		result.CorrectionFieldRxNS = selected.CorrectionFieldRX
+		result.CorrectionFieldTxNS = selected.CorrectionFieldTX
+	}
+
+	// port stats
+	tx, rx, err := stats.FetchPortStats(address)
+	if err != nil {
+		log.Warningf("couldn't get SPTP counters: %v", err)
+	} else {
+		for k, v := range tx {
+			result.PortStatsTX[k] = v
+		}
+		for k, v := range rx {
+			result.PortStatsRX[k] = v
+		}
+	}
+
+	return result, nil
+}

--- a/cmd/ptpcheck/cmd/diag.go
+++ b/cmd/ptpcheck/cmd/diag.go
@@ -274,7 +274,7 @@ func runAllDiagnosers(r *checker.PTPCheckResult) int {
 
 func init() {
 	RootCmd.AddCommand(diagCmd)
-	diagCmd.Flags().StringVarP(&rootServerFlag, "server", "S", "/var/run/ptp4l", "server to connect to")
+	diagCmd.Flags().StringVarP(&rootClientFlag, "client", "C", "", rootClientFlagDesc)
 	diagCmd.Flags().StringVarP(&diagIfaceFlag, "iface", "i", "eth0", "Network interface to get time from")
 }
 
@@ -288,7 +288,7 @@ Exit code will be equal to sum of failed check, or 127 in case of critical probl
 	Run: func(cmd *cobra.Command, args []string) {
 		ConfigureVerbosity()
 
-		result, err := checker.RunCheck(rootServerFlag)
+		result, err := checker.RunCheck(rootClientFlag)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ptpcheck/cmd/diag_test.go
+++ b/cmd/ptpcheck/cmd/diag_test.go
@@ -87,11 +87,11 @@ func TestCheckAgainstThreshold(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			var (
-				status status
-				msg    string
+				st  status
+				msg string
 			)
 			if tt.failOnZero {
-				status, msg = checkAgainstThresholdNonZero(
+				st, msg = checkAgainstThresholdNonZero(
 					tt.name,
 					tt.value,
 					tt.warnThreshold,
@@ -99,7 +99,7 @@ func TestCheckAgainstThreshold(t *testing.T) {
 					tt.explanation,
 				)
 			} else {
-				status, msg = checkAgainstThreshold(
+				st, msg = checkAgainstThreshold(
 					tt.name,
 					tt.value,
 					tt.warnThreshold,
@@ -107,34 +107,34 @@ func TestCheckAgainstThreshold(t *testing.T) {
 					tt.explanation,
 				)
 			}
-			require.Equal(t, tt.wantStatus, status)
+			require.Equal(t, tt.wantStatus, st)
 			require.Equal(t, tt.wantMsg, msg)
 		})
 	}
 
 	// check with float now just to exercise generics
 	t.Run("ints", func(t *testing.T) {
-		status, msg := checkAgainstThreshold(
+		st, msg := checkAgainstThreshold(
 			"some int",
 			28,
 			10,
 			100,
 			"oh no",
 		)
-		require.Equal(t, WARN, status)
+		require.Equal(t, WARN, st)
 		require.Equal(t, "some int is 28, we expect it to be within 10. oh no", msg)
 	})
 
 	// check with float now just to exercise generics
 	t.Run("floats", func(t *testing.T) {
-		status, msg := checkAgainstThreshold(
+		st, msg := checkAgainstThreshold(
 			"some float",
 			3.14,
 			4.0,
 			10.1,
 			"oh no",
 		)
-		require.Equal(t, OK, status)
+		require.Equal(t, OK, st)
 		require.Equal(t, "some float is 3.14, we expect it to be within 4", msg)
 	})
 }
@@ -143,13 +143,13 @@ func TestCheckGMPresent(t *testing.T) {
 	r := &checker.PTPCheckResult{
 		GrandmasterPresent: true,
 	}
-	status, msg := checkGMPresent(r)
-	require.Equal(t, OK, status)
+	st, msg := checkGMPresent(r)
+	require.Equal(t, OK, st)
 	require.Equal(t, "GM is present", msg)
 
 	r.GrandmasterPresent = false
-	status, msg = checkGMPresent(r)
-	require.Equal(t, FAIL, status)
+	st, msg = checkGMPresent(r)
+	require.Equal(t, FAIL, st)
 	require.Equal(t, "GM is not present", msg)
 }
 
@@ -157,18 +157,18 @@ func TestCheckOffset(t *testing.T) {
 	r := &checker.PTPCheckResult{
 		OffsetFromMasterNS: 100.0,
 	}
-	status, msg := checkOffset(r)
-	require.Equal(t, OK, status)
+	st, msg := checkOffset(r)
+	require.Equal(t, OK, st)
 	require.Equal(t, "GM offset is 100ns, we expect it to be within 250µs", msg)
 
 	r.OffsetFromMasterNS = 251000.0
-	status, msg = checkOffset(r)
-	require.Equal(t, WARN, status)
+	st, msg = checkOffset(r)
+	require.Equal(t, WARN, st)
 	require.Equal(t, "GM offset is 251µs, we expect it to be within 250µs. Offset is the difference between our clock and remote server (time error).", msg)
 
 	r.OffsetFromMasterNS = -251000.0
-	status, msg = checkOffset(r)
-	require.Equal(t, WARN, status)
+	st, msg = checkOffset(r)
+	require.Equal(t, WARN, st)
 	require.Equal(t, "GM offset is 251µs, we expect it to be within 250µs. Offset is the difference between our clock and remote server (time error).", msg)
 }
 
@@ -176,18 +176,18 @@ func TestCheckPathDelay(t *testing.T) {
 	r := &checker.PTPCheckResult{
 		MeanPathDelayNS: 100.0,
 	}
-	status, msg := checkPathDelay(r)
-	require.Equal(t, OK, status)
+	st, msg := checkPathDelay(r)
+	require.Equal(t, OK, st)
 	require.Equal(t, "GM mean path delay is 100ns, we expect it to be within 100ms", msg)
 
 	r.MeanPathDelayNS = 151000000.0
-	status, msg = checkPathDelay(r)
-	require.Equal(t, WARN, status)
+	st, msg = checkPathDelay(r)
+	require.Equal(t, WARN, st)
 	require.Equal(t, "GM mean path delay is 151ms, we expect it to be within 100ms. Mean path delay is measured network delay between us and GM", msg)
 
 	r.MeanPathDelayNS = -151000000.0
-	status, msg = checkPathDelay(r)
-	require.Equal(t, FAIL, status)
+	st, msg = checkPathDelay(r)
+	require.Equal(t, FAIL, st)
 	require.Equal(t, "GM mean path delay is -151ms, we expect it to be positive and within 100ms. Mean path delay is measured network delay between us and GM", msg)
 }
 
@@ -211,17 +211,17 @@ func TestPortServiceStatsDiagnosers(t *testing.T) {
 	diagnosers := portServiceStatsDiagnosers(r)
 	require.Equal(t, 4, len(diagnosers))
 
-	status, msg := diagnosers[0](r)
-	assert.Equal(t, WARN, status)
+	st, msg := diagnosers[0](r)
+	assert.Equal(t, WARN, st)
 	assert.Equal(t, "Sync timeout count is 200, we expect it to be within 100. We expect to not skip sync packets", msg)
-	status, msg = diagnosers[1](r)
-	assert.Equal(t, OK, status)
+	st, msg = diagnosers[1](r)
+	assert.Equal(t, OK, st)
 	assert.Equal(t, "Announce timeout count is 10, we expect it to be within 100", msg)
-	status, msg = diagnosers[2](r)
-	assert.Equal(t, OK, status)
+	st, msg = diagnosers[2](r)
+	assert.Equal(t, OK, st)
 	assert.Equal(t, "Sync mismatch count is 0, we expect it to be within 100", msg)
-	status, msg = diagnosers[3](r)
-	assert.Equal(t, FAIL, status)
+	st, msg = diagnosers[3](r)
+	assert.Equal(t, FAIL, st)
 	assert.Equal(t, "FollowUp mismatch count is 2000, we expect it to be within 100. We expect FollowUp packets to arrive in correct order", msg)
 }
 

--- a/cmd/ptpcheck/cmd/oscillatord.go
+++ b/cmd/ptpcheck/cmd/oscillatord.go
@@ -73,7 +73,7 @@ func oscillatordRun(address string, jsonOut bool) error {
 	}
 	defer conn.Close()
 	deadline := time.Now().Add(timeout)
-	if err := conn.SetDeadline(deadline); err != nil {
+	if err = conn.SetDeadline(deadline); err != nil {
 		return fmt.Errorf("setting connection deadline: %w", err)
 	}
 

--- a/cmd/ptpcheck/cmd/portstats.go
+++ b/cmd/ptpcheck/cmd/portstats.go
@@ -48,7 +48,7 @@ func printPortStats(r *checker.PTPCheckResult) error {
 
 func init() {
 	RootCmd.AddCommand(portStatsCmd)
-	portStatsCmd.Flags().StringVarP(&rootServerFlag, "server", "S", "/var/run/ptp4l", "server to connect to")
+	portStatsCmd.Flags().StringVarP(&rootClientFlag, "client", "C", "", rootClientFlagDesc)
 }
 
 var portStatsCmd = &cobra.Command{
@@ -57,7 +57,7 @@ var portStatsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ConfigureVerbosity()
 
-		result, err := checker.RunCheck(rootServerFlag)
+		result, err := checker.RunCheck(rootClientFlag)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ptpcheck/cmd/root.go
+++ b/cmd/ptpcheck/cmd/root.go
@@ -32,7 +32,9 @@ var RootCmd = &cobra.Command{
 
 // flags
 var rootVerboseFlag bool
-var rootServerFlag string
+var rootClientFlag string
+
+var rootClientFlagDesc = "Address of PTP client to connect to. Can be either Unix socket for ptp4l or http endpoint for sptp. Empty means detect automatically."
 
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&rootVerboseFlag, "verbose", "v", false, "verbose output")

--- a/cmd/ptpcheck/cmd/stats.go
+++ b/cmd/ptpcheck/cmd/stats.go
@@ -29,19 +29,23 @@ import (
 
 func printStats(r *checker.PTPCheckResult) error {
 	type stats struct {
-		Offset        float64 `json:"ptp.offset_ns"`
-		OffsetAbs     float64 `json:"ptp.offset_abs_ns"`
-		MeanPathDelay float64 `json:"ptp.mean_path_delay_ns"`
-		StepsRemoved  int     `json:"ptp.steps_removed"`
-		GMPresent     int     `json:"ptp.gm_present"` // bool for ODS
+		Offset            float64 `json:"ptp.offset_ns"`
+		OffsetAbs         float64 `json:"ptp.offset_abs_ns"`
+		MeanPathDelay     float64 `json:"ptp.mean_path_delay_ns"`
+		StepsRemoved      int     `json:"ptp.steps_removed"`
+		GMPresent         int     `json:"ptp.gm_present"` // bool for ODS
+		CorrectionFieldRX int64   `json:"ptp.cf_rx,omitempty"`
+		CorrectionFieldTX int64   `json:"ptp.cf_tx,omitempty"`
 	}
 
 	output := stats{
-		Offset:        r.OffsetFromMasterNS,
-		OffsetAbs:     math.Abs(r.OffsetFromMasterNS),
-		MeanPathDelay: r.MeanPathDelayNS,
-		StepsRemoved:  r.StepsRemoved,
-		GMPresent:     0,
+		Offset:            r.OffsetFromMasterNS,
+		OffsetAbs:         math.Abs(r.OffsetFromMasterNS),
+		MeanPathDelay:     r.MeanPathDelayNS,
+		StepsRemoved:      r.StepsRemoved,
+		GMPresent:         0,
+		CorrectionFieldRX: r.CorrectionFieldRxNS,
+		CorrectionFieldTX: r.CorrectionFieldTxNS,
 	}
 	if r.GrandmasterPresent {
 		output.GMPresent = 1
@@ -57,7 +61,7 @@ func printStats(r *checker.PTPCheckResult) error {
 
 func init() {
 	RootCmd.AddCommand(statsCmd)
-	statsCmd.Flags().StringVarP(&rootServerFlag, "server", "S", "/var/run/ptp4l", "server to connect to")
+	statsCmd.Flags().StringVarP(&rootClientFlag, "client", "C", "", rootClientFlagDesc)
 }
 
 var statsCmd = &cobra.Command{
@@ -66,7 +70,7 @@ var statsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ConfigureVerbosity()
 
-		result, err := checker.RunCheck(rootServerFlag)
+		result, err := checker.RunCheck(rootClientFlag)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ptpcheck/cmd/trace.go
+++ b/cmd/ptpcheck/cmd/trace.go
@@ -38,7 +38,7 @@ var traceTimestampingFlag string
 
 func init() {
 	RootCmd.AddCommand(traceCmd)
-	traceCmd.Flags().StringVarP(&traceRemoteServerFlag, "server", "S", "", "server to connect to")
+	traceCmd.Flags().StringVarP(&traceRemoteServerFlag, "server", "S", "", "remote PTP server to connect to")
 	traceCmd.Flags().StringVarP(&traceIfaceFlag, "iface", "i", "eth0", "network interface to use")
 	traceCmd.Flags().StringVarP(&traceTimestampingFlag, "timestamping", "T", "", fmt.Sprintf("timestamping to use, either %q or %q. empty means auto-detection", client.HWTIMESTAMP, client.SWTIMESTAMP))
 	traceCmd.Flags().DurationVarP(&traceTimeoutFlag, "timeout", "t", 15*time.Second, "global timeout")

--- a/ptp/protocol/ptp4l.go
+++ b/ptp/protocol/ptp4l.go
@@ -28,6 +28,9 @@ import (
 	"github.com/facebook/time/hostendian"
 )
 
+// PTP4lSock is the default path to PTP4L socket
+const PTP4lSock = "/var/run/ptp4l"
+
 // ptp4l-specific management TLV ids
 const (
 	IDTimeStatusNP         ManagementID = 0xC000


### PR DESCRIPTION
Summary:
Teach `ptpcheck` to work with both sptp and ptp4l.

Most of the things got abstracted in a form of `PTPCheckResult`, except for data for `sources` subcommand where we want significantly different output which doesn't directly map from one to another (no sense for Unicast Master Status or time since last sync with sptp, no use for 'error', p3, CF, with ptp4l.

Differential Revision: D43272409

