### PR TITLE
update reading the footer of FW

### DIFF
--- a/sa53fw/firmware/firmware.go
+++ b/sa53fw/firmware/firmware.go
@@ -99,7 +99,7 @@ func (f *Firmware) ParseVersion() error {
 		return fmt.Errorf("cannot find firmware footer")
 	}
 
-	if _, err := f.fd.ReadAt(buf, idx); err != nil {
+	if n, err := f.fd.ReadAt(buf, idx); err != nil && n == 0 {
 		return err
 	}
 	if _, err := f.fd.Seek(0, 0); err != nil {


### PR DESCRIPTION
Summary: The check added to make linter happy had side effect of trying to read the exact buffer instead of reading the amount that really need to parse metadata and failing because the buffer is more than metadata. Fix the check to avoid the problem

Reviewed By: t3lurid3

Differential Revision: D43438669

