### PR TITLE
Make TX timestamp reading attempts and timeout configurable

### DIFF
--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -44,7 +44,7 @@ const (
 	// PayloadSizeBytes is a size of maximum ptp packet which is usually up to 66 bytes
 	PayloadSizeBytes = 128
 	// look only for X sequential TS
-	maxTXTS = 100
+	defaultTXTS = 100
 	// Socket Control Message Header Offset on Linux
 )
 
@@ -67,6 +67,12 @@ type hwtstampConfig struct {
 	txType   int32
 	rxFilter int32
 }
+
+// AttemptsTXTS is configured amount of attempts to read TX timestamp
+var AttemptsTXTS = defaultTXTS
+
+// TimeoutTXTS is configured timeout to read TX timestamp
+var TimeoutTXTS = time.Millisecond
 
 // ConnFd returns file descriptor of a connection
 func ConnFd(conn *net.UDPConn) (int, error) {

--- a/timestamp/timestamp_linux_test.go
+++ b/timestamp/timestamp_linux_test.go
@@ -59,10 +59,24 @@ func Test_ReadTXtimestamp(t *testing.T) {
 	err = EnableSWTimestamps(connFd)
 	require.Nil(t, err)
 
+	start := time.Now()
 	txts, attempts, err := ReadTXtimestamp(connFd)
+	duration := time.Since(start)
 	require.Equal(t, time.Time{}, txts)
-	require.Equal(t, maxTXTS, attempts)
-	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", maxTXTS), err)
+	require.Equal(t, defaultTXTS, attempts)
+	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", defaultTXTS), err)
+	require.GreaterOrEqual(t, duration, time.Duration(AttemptsTXTS)*TimeoutTXTS)
+
+	AttemptsTXTS = 10
+	TimeoutTXTS = 5 * time.Millisecond
+
+	start = time.Now()
+	txts, attempts, err = ReadTXtimestamp(connFd)
+	duration = time.Since(start)
+	require.Equal(t, time.Time{}, txts)
+	require.Equal(t, 10, attempts)
+	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", 10), err)
+	require.GreaterOrEqual(t, duration, time.Duration(AttemptsTXTS)*TimeoutTXTS)
 
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
 	_, err = conn.WriteTo([]byte{}, addr)


### PR DESCRIPTION
Summary: We had them constant while ptp4u was the only user. With sptp client running on different HW we have to make timeout and the amount of attempts configurable

Reviewed By: leoleovich

Differential Revision: D43501343

