### PR TITLE
configure TX timestamp attempts and timeout

### DIFF
--- a/ptp/sptp/README.md
+++ b/ptp/sptp/README.md
@@ -80,6 +80,8 @@ monitoringport: 4269
 dscp: 35
 firststepthreshold: 1s
 metricsaggregationwindow: 60s
+attemptstxts: 100
+timeouttxts: 1ms
 servers:
   "192.168.0.10": 1
   "192.168.0.11": 2

--- a/ptp/sptp/client/config.go
+++ b/ptp/sptp/client/config.go
@@ -42,11 +42,17 @@ type Config struct {
 	Servers                  map[string]int
 	Measurement              MeasurementConfig
 	MetricsAggregationWindow time.Duration
+	AttemptsTXTS             int
+	TimeoutTXTS              time.Duration
 }
 
 // ReadConfig reads config from the file
 func ReadConfig(path string) (*Config, error) {
-	c := &Config{MetricsAggregationWindow: time.Duration(60) * time.Second}
+	c := &Config{
+		MetricsAggregationWindow: time.Duration(60) * time.Second,
+		AttemptsTXTS:             10,
+		TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+	}
 	cData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -149,6 +149,10 @@ func (p *SPTP) init() error {
 	}
 	p.eventConn = newUDPConnTS(eventConn)
 
+	// Configure TX timestamp attempts and timemouts
+	timestamp.AttemptsTXTS = p.cfg.AttemptsTXTS
+	timestamp.TimeoutTXTS = p.cfg.TimeoutTXTS
+
 	phcDev, err := NewPHC(p.cfg.Iface)
 	if err != nil {
 		return err

--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -44,7 +44,7 @@ const (
 	// PayloadSizeBytes is a size of maximum ptp packet which is usually up to 66 bytes
 	PayloadSizeBytes = 128
 	// look only for X sequential TS
-	maxTXTS = 100
+	defaultTXTS = 100
 	// Socket Control Message Header Offset on Linux
 )
 
@@ -67,6 +67,12 @@ type hwtstampConfig struct {
 	txType   int32
 	rxFilter int32
 }
+
+// AttemptsTXTS is configured amount of attempts to read TX timestamp
+var AttemptsTXTS = defaultTXTS
+
+// TimeoutTXTS is configured timeout to read TX timestamp
+var TimeoutTXTS = time.Millisecond
 
 // ConnFd returns file descriptor of a connection
 func ConnFd(conn *net.UDPConn) (int, error) {

--- a/timestamp/timestamp_linux_test.go
+++ b/timestamp/timestamp_linux_test.go
@@ -59,10 +59,24 @@ func Test_ReadTXtimestamp(t *testing.T) {
 	err = EnableSWTimestamps(connFd)
 	require.Nil(t, err)
 
+	start := time.Now()
 	txts, attempts, err := ReadTXtimestamp(connFd)
+	duration := time.Since(start)
 	require.Equal(t, time.Time{}, txts)
-	require.Equal(t, maxTXTS, attempts)
-	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", maxTXTS), err)
+	require.Equal(t, defaultTXTS, attempts)
+	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", defaultTXTS), err)
+	require.GreaterOrEqual(t, duration, time.Duration(AttemptsTXTS)*TimeoutTXTS)
+
+	AttemptsTXTS = 10
+	TimeoutTXTS = 5 * time.Millisecond
+
+	start = time.Now()
+	txts, attempts, err = ReadTXtimestamp(connFd)
+	duration = time.Since(start)
+	require.Equal(t, time.Time{}, txts)
+	require.Equal(t, 10, attempts)
+	require.Equal(t, fmt.Errorf("no TX timestamp found after %d tries", 10), err)
+	require.GreaterOrEqual(t, duration, time.Duration(AttemptsTXTS)*TimeoutTXTS)
 
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
 	_, err = conn.WriteTo([]byte{}, addr)


### PR DESCRIPTION
Summary: Configure reading of TX timestamp more suitable for clients (CX4 can postpone TX timestamp up to 500ms)

Reviewed By: leoleovich

Differential Revision: D43502103

