### PR TITLE
don't respond on Delay Requests while being drained

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -282,6 +282,11 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 
 		s.Stats.IncRX(msgType)
 
+		// Don't respond on event (delay) requests while being drained
+		if s.ctx.Err() != nil {
+			continue
+		}
+
 		switch msgType {
 		case ptp.MessageDelayReq:
 			if err := ptp.FromBytes(buf[:bbuf], dReq); err != nil {


### PR DESCRIPTION
Summary: With `sptp` we now need to reject delay request messages as well while being drained, not only signaling.

Reviewed By: abulimov

Differential Revision: D43506005

