### PR TITLE
minor optimizations

### DIFF
--- a/fbclock/cpp_test/test.cpp
+++ b/fbclock/cpp_test/test.cpp
@@ -180,8 +180,8 @@ TEST(fbclock_test, test_fbclock_calculate_time) {
       error_bound_ns, h_value_ns, ingress_time_ns, phctime_ns, &truetime);
   ASSERT_EQ(err, 0);
 
-  EXPECT_EQ(truetime.earliest_ns, 1647269091803102381);
-  EXPECT_EQ(truetime.latest_ns, 1647269091803103533);
+  EXPECT_EQ(truetime.earliest_ns, 1647269091803102338);
+  EXPECT_EQ(truetime.latest_ns, 1647269091803103576);
 
   // WOU is very big
   error_bound_ns = 1000.0;
@@ -189,8 +189,8 @@ TEST(fbclock_test, test_fbclock_calculate_time) {
   err = fbclock_calculate_time(
       error_bound_ns, h_value_ns, ingress_time_ns, phctime_ns, &truetime);
   ASSERT_EQ(err, 0);
-  EXPECT_EQ(truetime.earliest_ns, 1647290691802010772);
-  EXPECT_EQ(truetime.latest_ns, 1647290691804195180);
+  EXPECT_EQ(truetime.earliest_ns, 1647290691802010729);
+  EXPECT_EQ(truetime.latest_ns, 1647290691804195223);
 }
 
 int main(int argc, char** argv) {

--- a/fbclock/fbclock.c
+++ b/fbclock/fbclock.c
@@ -60,7 +60,7 @@ struct phc_time_res {
   int64_t delay; // mean delay of several requests
 };
 
-static uint64_t fbclock_clockdata_crc(fbclock_clockdata* value) {
+static inline uint64_t fbclock_clockdata_crc(fbclock_clockdata* value) {
   uint64_t counter = fbclock_crc64(value->ingress_time_ns, 0x04C11DB7);
   counter = fbclock_crc64(value->error_bound_ns, counter);
   counter = fbclock_crc64(value->holdover_multiplier_ns, counter);
@@ -86,8 +86,8 @@ int fbclock_clockdata_load_data(
     fbclock_clockdata* data) {
   for (int i = 0; i < FBCLOCK_MAX_READ_TRIES; i++) {
     memcpy(data, &shmp->data, FBCLOCK_CLOCKDATA_SIZE);
-    uint64_t our_crc = fbclock_clockdata_crc(data);
     uint64_t crc = atomic_load(&shmp->crc);
+    uint64_t our_crc = fbclock_clockdata_crc(data);
     if (our_crc == crc) {
       fbclock_debug_print("reading clock data took %d tries\n", i + 1);
       break;
@@ -96,7 +96,7 @@ int fbclock_clockdata_load_data(
   return 0;
 }
 
-static int64_t fbclock_pct2ns(const struct ptp_clock_time* ptc) {
+static inline int64_t fbclock_pct2ns(const struct ptp_clock_time* ptc) {
   return (int64_t)(ptc->sec * 1000000000) + (int64_t)ptc->nsec;
 }
 

--- a/fbclock/fbclock.c
+++ b/fbclock/fbclock.c
@@ -55,6 +55,11 @@ limitations under the License.
 #define fbclock_crc64(a, b) ({ a ^ b; })
 #endif
 
+struct phc_time_res {
+  int64_t ts; // last ts got from PHC
+  int64_t delay; // mean delay of several requests
+};
+
 static uint64_t fbclock_clockdata_crc(fbclock_clockdata* value) {
   uint64_t counter = fbclock_crc64(value->ingress_time_ns, 0x04C11DB7);
   counter = fbclock_crc64(value->error_bound_ns, counter);
@@ -95,23 +100,27 @@ static int64_t fbclock_pct2ns(const struct ptp_clock_time* ptc) {
   return (int64_t)(ptc->sec * 1000000000) + (int64_t)ptc->nsec;
 }
 
-static int64_t fbclock_read_ptp_offset_extended(int fd) {
+static int fbclock_read_ptp_offset_extended(int fd, struct phc_time_res* res) {
   struct ptp_sys_offset_extended psoe = {.n_samples = 5};
+  int64_t total_delay = 0;
+
   int r = ioctl(fd, PTP_SYS_OFFSET_EXTENDED, &psoe);
   if (r) {
     perror("PTP_SYS_OFFSET_EXTENDED");
     return -1;
   }
-  int64_t total_delay = 0;
 
   for (unsigned i = 0; i < psoe.n_samples; ++i) {
-    int64_t delay =
+    total_delay +=
         fbclock_pct2ns(&psoe.ts[i][2]) - fbclock_pct2ns(&psoe.ts[i][0]);
-    total_delay += delay;
   }
-  int64_t ts = fbclock_pct2ns(&psoe.ts[psoe.n_samples - 1][1]);
-  int64_t mean_delay = total_delay / psoe.n_samples;
-  return ts + mean_delay;
+  res->ts = fbclock_pct2ns(&psoe.ts[psoe.n_samples - 1][1]);
+  res->delay = total_delay / psoe.n_samples; // mean delay
+  if (total_delay < 0) {
+    perror("Negative request delay");
+    return -2;
+  }
+  return 0;
 }
 
 int fbclock_init(fbclock_lib* lib, const char* shm_path) {
@@ -181,6 +190,7 @@ int fbclock_calculate_time(
 }
 
 int fbclock_gettime(fbclock_lib* lib, fbclock_truetime* truetime) {
+  struct phc_time_res res;
   fbclock_clockdata state;
   int rcode = fbclock_clockdata_load_data(lib->shmp, &state);
   if (rcode != 0) {
@@ -199,15 +209,14 @@ int fbclock_gettime(fbclock_lib* lib, fbclock_truetime* truetime) {
     return FBCLOCK_E_WOU_TOO_BIG;
   }
 
-  int64_t phctime_ns = fbclock_read_ptp_offset_extended(lib->dev_fd);
-  if (phctime_ns <= 0) {
+  if (fbclock_read_ptp_offset_extended(lib->dev_fd, &res)) {
     return FBCLOCK_E_PTP_READ_OFFSET;
   }
 
-  double error_bound = (double)state.error_bound_ns;
+  double error_bound = (double)state.error_bound_ns + (double)res.delay;
   double h_value = (double)state.holdover_multiplier_ns / FBCLOCK_POW2_16;
   return fbclock_calculate_time(
-      error_bound, h_value, state.ingress_time_ns, phctime_ns, truetime);
+      error_bound, h_value, state.ingress_time_ns, res.ts, truetime);
 }
 
 const char* fbclock_strerror(int err_code) {

--- a/fbclock/fbclock.c
+++ b/fbclock/fbclock.c
@@ -157,14 +157,14 @@ int fbclock_destroy(fbclock_lib* lib) {
 }
 
 double fbclock_window_of_uncertainty(
-    int64_t seconds,
+    double seconds,
     double error_bound_ns,
     double holdover_multiplier_ns) {
   double h = holdover_multiplier_ns * seconds;
   double w = error_bound_ns + h;
   fbclock_debug_print("error_bound=%f\n", error_bound_ns);
   fbclock_debug_print("holdover_multiplier=%f\n", holdover_multiplier_ns);
-  fbclock_debug_print("%ld seconds holdover, h=%f\n", seconds, h);
+  fbclock_debug_print("%.3f seconds holdover, h=%f\n", seconds, h);
   fbclock_debug_print("w = %f ns\n", w);
   fbclock_debug_print("w = %f ms\n", w / 1000000.0);
   return w;
@@ -177,7 +177,8 @@ int fbclock_calculate_time(
     int64_t phctime_ns,
     fbclock_truetime* truetime) {
   // first, we check how long it was since last SYNC message from GM, in seconds
-  int64_t seconds = (double)(phctime_ns - ingress_time_ns) / 1000000000.0;
+  // with parts
+  double seconds = (double)(phctime_ns - ingress_time_ns) / 1000000000.0;
   if (seconds < 0) {
     return FBCLOCK_E_PHC_IN_THE_PAST;
   }

--- a/fbclock/fbclock.h
+++ b/fbclock/fbclock.h
@@ -76,7 +76,7 @@ typedef struct fbclock_truetime {
 int fbclock_clockdata_store_data(uint32_t fd, fbclock_clockdata* data);
 int fbclock_clockdata_load_data(fbclock_shmdata* shm, fbclock_clockdata* data);
 double fbclock_window_of_uncertainty(
-    int64_t seconds,
+    double seconds,
     double error_bound_ns,
     double holdover_multiplier_ns);
 int fbclock_calculate_time(


### PR DESCRIPTION
Summary:
1. We don't want to spend cycles on going into subroutine for 3-4 instructions, it's better to inline them.
2. Re-order CRC calculation and atomic reading to reduce the window of rescheduling

Reviewed By: leoleovich

Differential Revision: D43472996

