### PR TITLE
don't crash on missing TX timestamp #2

### DIFF
--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -266,8 +266,8 @@ func (s *sendWorker) Start() {
 				txTS, attempts, err = timestamp.ReadTXtimestampBuf(eFd, oob, toob)
 				s.stats.SetMaxTXTSAttempts(s.id, int64(attempts))
 				if err != nil {
-					log.Errorf("Failed to read TX timestamp: %v", err)
-					return
+					log.Warningf("Failed to read TX timestamp: %v", err)
+					continue
 				}
 				if s.config.TimestampType != timestamp.HWTIMESTAMP {
 					txTS = txTS.Add(s.config.UTCOffset)


### PR DESCRIPTION
Summary:
Don't crash on sptp delay_req either
Missed in https://github.com/facebook/time/commit/19cd2f60a6218563c8a0e224da2f668f59577a65

Reviewed By: abulimov

Differential Revision: D43573383

