### PR TITLE
sptp use timer instead of ticker

### DIFF
--- a/ptp/sptp/client/measurements.go
+++ b/ptp/sptp/client/measurements.go
@@ -78,6 +78,10 @@ type MeasurementResult struct {
 	CorrectionFieldTX  time.Duration
 	Timestamp          time.Time
 	Announce           ptp.Announce
+	T1                 time.Time
+	T2                 time.Time
+	T3                 time.Time
+	T4                 time.Time
 }
 
 // measurements abstracts away tracking and calculation of various packet timestamps
@@ -206,6 +210,10 @@ func (m *measurements) latest() (*MeasurementResult, error) {
 		CorrectionFieldRX:  lastData.c1,
 		CorrectionFieldTX:  lastData.c2,
 		Timestamp:          lastData.t2,
+		T1:                 lastData.t1,
+		T2:                 lastData.t2,
+		T3:                 lastData.t3,
+		T4:                 lastData.t4,
 		Announce:           m.announce,
 	}, nil
 }

--- a/ptp/sptp/client/measurements_test.go
+++ b/ptp/sptp/client/measurements_test.go
@@ -66,6 +66,10 @@ func TestMeasurementsFullRun(t *testing.T) {
 			ClientToServerDiff: netDelayBack,
 			Offset:             0,
 			Timestamp:          timeSyncReceived,
+			T1:                 timeSyncSent,
+			T2:                 timeSyncReceived,
+			T3:                 timeDelaySent,
+			T4:                 timeDelayReceived,
 		}
 		assert.Equal(t, want, got)
 	})
@@ -108,6 +112,10 @@ func TestMeasurementsFullRun(t *testing.T) {
 			ClientToServerDiff: netDelayBack,
 			Offset:             -100 * time.Millisecond,
 			Timestamp:          timeSyncReceived,
+			T1:                 timeSyncSent,
+			T2:                 timeSyncReceived,
+			T3:                 timeDelaySent,
+			T4:                 timeDelayReceived,
 		}
 		assert.Equal(t, want, got)
 	})
@@ -154,6 +162,10 @@ func TestMeasurementsFullRun(t *testing.T) {
 			CorrectionFieldRX:  6 * time.Microsecond,
 			CorrectionFieldTX:  4 * time.Microsecond,
 			Timestamp:          timeSyncReceived,
+			T1:                 timeSyncSent,
+			T2:                 timeSyncReceived,
+			T3:                 timeDelaySent,
+			T4:                 timeDelayReceived,
 		}
 		assert.Equal(t, want, got)
 	})
@@ -209,6 +221,10 @@ func TestMeasurementsPathDelayFilter(t *testing.T) {
 		CorrectionFieldRX:  6 * time.Microsecond,
 		CorrectionFieldTX:  4 * time.Microsecond,
 		Timestamp:          timeSyncReceived,
+		T1:                 timeSyncSent,
+		T2:                 timeSyncReceived,
+		T3:                 timeDelaySent,
+		T4:                 timeDelayReceived,
 	}
 	assert.Equal(t, want, got, "initial measurements check")
 
@@ -243,6 +259,10 @@ func TestMeasurementsPathDelayFilter(t *testing.T) {
 		CorrectionFieldRX:  6 * time.Microsecond,
 		CorrectionFieldTX:  4 * time.Microsecond,
 		Timestamp:          timeSyncReceived,
+		T1:                 timeSyncSent,
+		T2:                 timeSyncReceived,
+		T3:                 timeDelaySent,
+		T4:                 timeDelayReceived,
 	}
 	assert.Equal(t, want, got, "measurements after 6 more exchanges")
 
@@ -259,6 +279,10 @@ func TestMeasurementsPathDelayFilter(t *testing.T) {
 		CorrectionFieldRX:  6 * time.Microsecond,
 		CorrectionFieldTX:  4 * time.Microsecond,
 		Timestamp:          timeSyncReceived,
+		T1:                 timeSyncSent,
+		T2:                 timeSyncReceived,
+		T3:                 timeDelaySent,
+		T4:                 timeDelayReceived,
 	}
 	assert.Equal(t, want, got, "measurements with median path delay filter")
 
@@ -274,6 +298,10 @@ func TestMeasurementsPathDelayFilter(t *testing.T) {
 		CorrectionFieldRX:  6 * time.Microsecond,
 		CorrectionFieldTX:  4 * time.Microsecond,
 		Timestamp:          timeSyncReceived,
+		T1:                 timeSyncSent,
+		T2:                 timeSyncReceived,
+		T3:                 timeDelaySent,
+		T4:                 timeDelayReceived,
 	}
 	assert.Equal(t, want, got, "measurements with mean path delay filter")
 
@@ -301,6 +329,10 @@ func TestMeasurementsPathDelayFilter(t *testing.T) {
 		CorrectionFieldRX:  6 * time.Microsecond,
 		CorrectionFieldTX:  4 * time.Microsecond,
 		Timestamp:          timeSyncReceived,
+		T1:                 timeSyncSent,
+		T2:                 timeSyncReceived,
+		T3:                 timeDelaySent,
+		T4:                 timeDelayReceived,
 	}
 	assert.Equal(t, want, got, "measurements with mean path delay filter and skipped path delay sample")
 }

--- a/ptp/sptp/client/sptp_test.go
+++ b/ptp/sptp/client/sptp_test.go
@@ -114,6 +114,7 @@ func TestProcessResultsSingle(t *testing.T) {
 	// we adj here
 	mockStatsServer.EXPECT().SetCounter("ptp.sptp.gms.total", int64(1))
 	mockStatsServer.EXPECT().SetCounter("ptp.sptp.gms.available_pct", int64(100))
+	mockStatsServer.EXPECT().SetCounter("ptp.sptp.tick_duration_ns", gomock.Any())
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
 	p.processResults(results)
 	require.Equal(t, "iamthebest", p.bestGM)
@@ -181,6 +182,7 @@ func TestProcessResultsMulti(t *testing.T) {
 	// we adj here, while also switching to new best GM
 	mockStatsServer.EXPECT().SetCounter("ptp.sptp.gms.total", int64(2))
 	mockStatsServer.EXPECT().SetCounter("ptp.sptp.gms.available_pct", int64(100))
+	mockStatsServer.EXPECT().SetCounter("ptp.sptp.tick_duration_ns", gomock.Any())
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
 	p.processResults(results)
@@ -200,6 +202,7 @@ func TestRunInternalAllDead(t *testing.T) {
 	mockStatsServer := NewMockStatsServer(ctrl)
 	mockStatsServer.EXPECT().SetCounter("ptp.sptp.gms.total", int64(2)).Times(2)
 	mockStatsServer.EXPECT().SetCounter("ptp.sptp.gms.available_pct", int64(0)).Times(2)
+	mockStatsServer.EXPECT().SetCounter("ptp.sptp.tick_duration_ns", gomock.Any())
 	mockStatsServer.EXPECT().UpdateCounterBy("ptp.sptp.portstats.tx.delay_req", int64(1)).Times(4)
 	mockStatsServer.EXPECT().SetGMStats(&gmstats.Stat{GMAddress: "192.168.0.10", Error: context.DeadlineExceeded.Error(), Priority3: 1}).Times(2)
 	mockStatsServer.EXPECT().SetGMStats(&gmstats.Stat{GMAddress: "192.168.0.11", Error: context.DeadlineExceeded.Error(), Priority3: 2}).Times(2)


### PR DESCRIPTION
Summary:
We want the servo adjustment interval to be as stable as possible, and 'ticker' in Go is too smart, it adjusts the interval if previous tick was too short or too long.

Also expose T1 to T4 in measurement result, just if we would like to use it/log it.

Differential Revision: D43622416

