### PR TITLE
sptp config validation, configurable timeout

### DIFF
--- a/ptp/sptp/README.md
+++ b/ptp/sptp/README.md
@@ -75,6 +75,7 @@ Example config:
 $ cat /etc/sptp.yaml
 iface: eth0
 interval: 1s
+exchangetimeout: 100ms
 timestamping: hardware
 monitoringport: 4269
 dscp: 35

--- a/ptp/sptp/client/config_test.go
+++ b/ptp/sptp/client/config_test.go
@@ -36,9 +36,12 @@ func TestReadConfigDefaults(t *testing.T) {
 	cfg, err := ReadConfig(f.Name())
 	require.NoError(t, err)
 	want := &Config{
-		MetricsAggregationWindow: 60 * time.Second,
+		Interval:                 time.Second,
+		ExchangeTimeout:          100 * time.Millisecond,
+		MetricsAggregationWindow: time.Duration(60) * time.Second,
 		AttemptsTXTS:             10,
 		TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+		Timestamping:             HWTIMESTAMP,
 	}
 	require.Equal(t, want, cfg)
 }
@@ -49,6 +52,7 @@ func TestReadConfig(t *testing.T) {
 	defer os.Remove(f.Name()) // clean up
 	_, err = f.Write([]byte(`iface: eth0
 interval: 1s
+exchangetimeout: 200ms
 timestamping: hardware
 monitoringport: 4269
 dscp: 35
@@ -74,6 +78,7 @@ measurement:
 		Timestamping:             "hardware",
 		MonitoringPort:           4269,
 		Interval:                 time.Second,
+		ExchangeTimeout:          200 * time.Millisecond,
 		DSCP:                     35,
 		FirstStepThreshold:       time.Second,
 		MetricsAggregationWindow: 10 * time.Second,
@@ -89,6 +94,351 @@ measurement:
 			PathDelayFilter:               "median",
 			PathDelayDiscardFilterEnabled: true,
 			PathDelayDiscardBelow:         2 * time.Microsecond,
+		},
+	}
+	require.Equal(t, want, cfg)
+}
+
+func TestMeasurementConfigValidate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      MeasurementConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			in:      MeasurementConfig{},
+			wantErr: false,
+		},
+		{
+			name: "negative path_delay_filter_length",
+			in: MeasurementConfig{
+				PathDelayFilterLength: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported filter",
+			in: MeasurementConfig{
+				PathDelayFilter: "blah",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      Config
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			in:      Config{},
+			wantErr: true,
+		},
+		{
+			name:    "default, no servers",
+			in:      *DefaultConfig(),
+			wantErr: true,
+		},
+		{
+			name: "default, one server, no iface",
+			in: Config{
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "default, one server, iface",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative interval",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 -1 * time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative attemptstxts",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             -10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative timeouttxts",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(-50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative metricsaggregationwindow",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(-60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative monitoringport",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+				MonitoringPort: -10,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative DSCP",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+				DSCP: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad timestamping",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             "blah",
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative exchangetimeout",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          -100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong exchangetimeout",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          2 * time.Second,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad measurement config",
+			in: Config{
+				Iface:                    "eth0",
+				Interval:                 time.Second,
+				ExchangeTimeout:          100 * time.Millisecond,
+				MetricsAggregationWindow: time.Duration(60) * time.Second,
+				AttemptsTXTS:             10,
+				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
+				Timestamping:             HWTIMESTAMP,
+				Servers: map[string]int{
+					"192.168.0.10": 0,
+				},
+				Measurement: MeasurementConfig{
+					PathDelayFilterLength: -1,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPrepareConfig(t *testing.T) {
+	f, err := os.CreateTemp("", "sptp")
+	require.NoError(t, err)
+	defer os.Remove(f.Name()) // clean up
+	_, err = f.Write([]byte(`iface: eth0
+interval: 1s
+exchangetimeout: 200ms
+timestamping: hardware
+monitoringport: 4269
+dscp: 35
+firststepthreshold: 1s
+metricsaggregationwindow: 10s
+attemptstxts: 12
+timeouttxts: 40ms
+servers:
+  192.168.0.10: 2
+  192.168.0.13: 3
+  192.168.0.15: 1
+measurement:
+  path_delay_filter_length: 59
+  path_delay_filter: "median"
+  path_delay_discard_filter_enabled: true
+  path_delay_discard_below: 2us
+`))
+	require.NoError(t, err)
+	cfg, err := PrepareConfig(f.Name(), nil, "eth1", 3456, 2*time.Second, 42)
+	require.NoError(t, err)
+	want := &Config{
+		Iface:                    "eth1",
+		Timestamping:             "hardware",
+		MonitoringPort:           3456,
+		Interval:                 2 * time.Second,
+		ExchangeTimeout:          200 * time.Millisecond,
+		DSCP:                     42,
+		FirstStepThreshold:       time.Second,
+		MetricsAggregationWindow: 10 * time.Second,
+		Servers: map[string]int{
+			"192.168.0.10": 2,
+			"192.168.0.13": 3,
+			"192.168.0.15": 1,
+		},
+		AttemptsTXTS: 12,
+		TimeoutTXTS:  time.Duration(40) * time.Millisecond,
+		Measurement: MeasurementConfig{
+			PathDelayFilterLength:         59,
+			PathDelayFilter:               "median",
+			PathDelayDiscardFilterEnabled: true,
+			PathDelayDiscardBelow:         2 * time.Microsecond,
+		},
+	}
+	require.Equal(t, want, cfg)
+}
+
+func TestPrepareConfigDefaults(t *testing.T) {
+	cfg, err := PrepareConfig("", []string{"192.168.0.10"}, "eth1", 3456, 2*time.Second, 42)
+	require.NoError(t, err)
+	want := &Config{
+		Iface:                    "eth1",
+		Timestamping:             "hardware",
+		MonitoringPort:           3456,
+		Interval:                 2 * time.Second,
+		ExchangeTimeout:          100 * time.Millisecond,
+		DSCP:                     42,
+		FirstStepThreshold:       0,
+		MetricsAggregationWindow: 60 * time.Second,
+		Servers: map[string]int{
+			"192.168.0.10": 0,
+		},
+		AttemptsTXTS: 10,
+		TimeoutTXTS:  time.Duration(50) * time.Millisecond,
+		Measurement: MeasurementConfig{
+			PathDelayFilterLength:         0,
+			PathDelayFilter:               "",
+			PathDelayDiscardFilterEnabled: false,
+			PathDelayDiscardBelow:         0,
 		},
 	}
 	require.Equal(t, want, cfg)

--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -327,7 +327,6 @@ func (p *SPTP) processResults(results map[string]*RunResult) {
 }
 
 func (p *SPTP) runInternal(ctx context.Context, interval time.Duration) error {
-	timeout := time.Duration(0.1 * float64(interval))
 	p.pi.SyncInterval(interval.Seconds())
 	var lock sync.Mutex
 
@@ -338,7 +337,7 @@ func (p *SPTP) runInternal(ctx context.Context, interval time.Duration) error {
 			addr := addr
 			c := c
 			eg.Go(func() error {
-				res := c.RunOnce(ictx, timeout)
+				res := c.RunOnce(ictx, p.cfg.ExchangeTimeout)
 				lock.Lock()
 				defer lock.Unlock()
 				results[addr] = res


### PR DESCRIPTION
Summary:
* add config validation
* move config preparation/overrides to client package
* make exchange timeout configurable via `exchangetimeout` config option

Differential Revision: D43628732

