### PR TITLE
sptp fix panic

### DIFF
--- a/ptp/sptp/client/json_stats.go
+++ b/ptp/sptp/client/json_stats.go
@@ -49,7 +49,7 @@ func (s *JSONStats) Start(monitoringport int) {
 
 // handleRootRequest is a handler used for all http monitoring requests
 func (s *JSONStats) handleRootRequest(w http.ResponseWriter, r *http.Request) {
-	js, err := json.Marshal(s.gmStats)
+	js, err := json.Marshal(s.GetStats())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -62,7 +62,7 @@ func (s *JSONStats) handleRootRequest(w http.ResponseWriter, r *http.Request) {
 
 // handleCountersRequest is a handler used for all http monitoring requests
 func (s *JSONStats) handleCountersRequest(w http.ResponseWriter, r *http.Request) {
-	js, err := json.Marshal(s.counters)
+	js, err := json.Marshal(s.GetCounters())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/ptp/sptp/client/stats.go
+++ b/ptp/sptp/client/stats.go
@@ -60,13 +60,22 @@ func (s *Stats) SetCounter(key string, val int64) {
 	s.mux.Unlock()
 }
 
-// Get returns an map of counters
-func (s *Stats) Get() map[string]int64 {
+// GetCounters returns an map of counters
+func (s *Stats) GetCounters() map[string]int64 {
 	ret := make(map[string]int64)
 	s.mux.Lock()
 	for key, val := range s.counters {
 		ret[key] = val
 	}
+	s.mux.Unlock()
+	return ret
+}
+
+// GetStats returns an all gm stats
+func (s *Stats) GetStats() gmstats.Stats {
+	ret := make(gmstats.Stats, len(s.gmStats))
+	s.mux.Lock()
+	copy(ret, s.gmStats)
 	s.mux.Unlock()
 	return ret
 }

--- a/ptp/sptp/client/stats_test.go
+++ b/ptp/sptp/client/stats_test.go
@@ -32,13 +32,13 @@ func TestStatsReset(t *testing.T) {
 	stats := NewStats()
 
 	stats.SetCounter("some.counter", 123)
-	got := stats.Get()
+	got := stats.GetCounters()
 	want := map[string]int64{
 		"some.counter": 123,
 	}
 	require.Equal(t, want, got)
 	stats.Reset()
-	got = stats.Get()
+	got = stats.GetCounters()
 	want = map[string]int64{
 		"some.counter": 0,
 	}
@@ -136,5 +136,5 @@ func TestSetGMStats(t *testing.T) {
 	want := gmstats.Stats{
 		gm,
 	}
-	require.Equal(t, want, s.gmStats)
+	require.Equal(t, want, s.GetStats())
 }


### PR DESCRIPTION
Summary:
Fix panic with concurrent counters update:
```
fatal error: concurrent map iteration and map write
...
github.com/facebook/time/ptp/sptp/client.(*JSONStats).handleCountersRequest(0x0?, {0x315490, 0xc00028ad20}, 0x573d89?)
        time/ptp/sptp/client/json_stats.go:65 +0x49 fp=0xc0005519c0 sp=0xc000551930 pc=0x743f29
```

Differential Revision: D43658496

