### PR TITLE
Fix the name of the chrony "falseticker" source state

### DIFF
--- a/cmd/ntpcheck/checker/peer.go
+++ b/cmd/ntpcheck/checker/peer.go
@@ -165,7 +165,7 @@ func NewPeerFromNTP(p *control.NTPControlMsg) (*Peer, error) {
 var chronyToPeerSelection = map[chrony.SourceStateType]uint8{
 	chrony.SourceStateSync:        control.SelSYSPeer,
 	chrony.SourceStateUnreach:     control.SelReject, // not a direct mapping
-	chrony.SourceStateFalseTicket: control.SelFalseTick,
+	chrony.SourceStateFalseTicker: control.SelFalseTick,
 	chrony.SourceStateJittery:     control.SelReject, // ditto
 	chrony.SourceStateCandidate:   control.SelCandidate,
 	chrony.SourceStateOutlier:     control.SelOutlier,

--- a/ntp/chrony/packet.go
+++ b/ntp/chrony/packet.go
@@ -103,10 +103,14 @@ const (
 const (
 	SourceStateSync        SourceStateType = 0
 	SourceStateUnreach     SourceStateType = 1
-	SourceStateFalseTicket SourceStateType = 2
+	SourceStateFalseTicker SourceStateType = 2
 	SourceStateJittery     SourceStateType = 3
 	SourceStateCandidate   SourceStateType = 4
 	SourceStateOutlier     SourceStateType = 5
+
+	// API backward compatibility for a misnamed
+	// constant. See issue #269
+	SourceStateFalseTicket SourceStateType = SourceStateFalseTicker
 )
 
 // source data flags
@@ -183,7 +187,7 @@ func (r ResponseStatusType) String() string {
 var SourceStateDesc = [6]string{
 	"sync",
 	"unreach",
-	"falseticket",
+	"falseticker",
 	"jittery",
 	"candidate",
 	"outlier",


### PR DESCRIPTION
This was accidentally called "falseticket" in both the ntp/chrony/packet.go SourceStateFalseTicket constant and in the text version of it in packet.go's SourceStateDesc. Because the constant is an exposed element of the API, we leave it as an alias for the new constant name of SourceStateFalseTicker.

Closes #269.

## Summary

This fixes issue #269, a misnamed constant in the chrony client code.

## Test Plan

I have built https://github.com/SuperQ/chrony_exporter using a version of the time package (in a Go workspace) with this change and verified that it works and reports falsetickers as that in its Prometheus metrics output. I've run the Go tests in both ntp/chrony and cmd/ntpcheck/checker and they didn't report anything, although this is not surprising as they don't test this state as far as I can see from the code.