### PR TITLE
fix tiny harmless race in sptp

### DIFF
--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -199,7 +199,6 @@ func (p *SPTP) init() error {
 // RunListener starts a listener, must be run before any client-server interactions happen
 func (p *SPTP) RunListener(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
-	var err error
 	// get packets from general port
 	eg.Go(func() error {
 		// it's done in non-blocking way, so if context is cancelled we exit correctly
@@ -229,7 +228,7 @@ func (p *SPTP) RunListener(ctx context.Context) error {
 		case <-ctx.Done():
 			log.Debugf("cancelled general port receiver")
 			return ctx.Err()
-		case err = <-doneChan:
+		case err := <-doneChan:
 			return err
 		}
 	})
@@ -258,7 +257,7 @@ func (p *SPTP) RunListener(ctx context.Context) error {
 		case <-ctx.Done():
 			log.Debugf("cancelled event port receiver")
 			return ctx.Err()
-		case err = <-doneChan:
+		case err := <-doneChan:
 			return err
 		}
 	})


### PR DESCRIPTION
Summary:
```
WARNING: DATA RACE
Write at 0x00c00016e4c0 by goroutine 10:
  github.com/facebook/time/ptp/sptp/client.(*SPTP).RunListener.func2()
      /home/runner/work/time/time/ptp/sptp/client/sptp.go:261 +0x2a4
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20220513210516-0976fa681c29/errgroup/errgroup.go:74 +0x86

Previous write at 0x00c00016e4c0 by goroutine 8:
  github.com/facebook/time/ptp/sptp/client.(*SPTP).RunListener.func1()
      /home/runner/work/time/time/ptp/sptp/client/sptp.go:232 +0x2a4
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20220513210516-0976fa681c29/errgroup/errgroup.go:74 +0x86

Goroutine 10 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20220513210516-0976fa681c29/errgroup/errgroup.go:71 +0x12e
  github.com/facebook/time/ptp/sptp/client.(*SPTP).RunListener()
      /home/runner/work/time/time/ptp/sptp/client/sptp.go:237 +0x31b
  github.com/facebook/time/ptp/sptp/client.TestRunListenerError()
      /home/runner/work/time/time/ptp/sptp/client/sptp_test.go:301 +0xed1
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1486 +0x47

Goroutine 8 (finished) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20220513210516-0976fa681c29/errgroup/errgroup.go:71 +0x12e
  github.com/facebook/time/ptp/sptp/client.(*SPTP).RunListener()
      /home/runner/work/time/time/ptp/sptp/client/sptp.go:204 +0x21c
time="2023-03-08T10:55:08Z" level=warning msg="ignoring packets from server <nil>"
  github.com/facebook/time/ptp/sptp/client.TestRunListenerError()
      /home/runner/work/time/time/ptp/sptp/client/sptp_test.go:301 +0xed1
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1486 +0x47
==================
```

Reviewed By: deathowl

Differential Revision: D43905939

