### PR TITLE
reset servo on filter overflow

### DIFF
--- a/servo/pi_test.go
+++ b/servo/pi_test.go
@@ -88,7 +88,8 @@ func TestPiServoFilterSample(t *testing.T) {
 	pi := NewPiServo(DefaultServoConfig(), DefaultPiServoCfg(), -111288.406372)
 	pi.SyncInterval(1)
 	piFilterCfg := DefaultPiServoFilterCfg()
-	piFilterCfg.ringSize = 2
+	piFilterCfg.ringSize = 4
+	piFilterCfg.maxSkipCount = 2
 	f := NewPiServoFilter(pi, piFilterCfg)
 
 	require.InEpsilon(t, -111288.406372, pi.lastFreq, 0.00001)
@@ -109,15 +110,27 @@ func TestPiServoFilterSample(t *testing.T) {
 	freq, state = pi.Sample(919, 1674148533671484215)
 	require.InEpsilon(t, -110984.463816, freq, 0.00001)
 	require.Equal(t, StateLocked, state)
+	require.Equal(t, 0, pi.filter.skippedCount)
 
 	freq, state = pi.Sample(919000, 1674148534671684215)
-	require.InEpsilon(t, -111034.463816, freq, 0.00001)
+	require.InEpsilon(t, -111441.130482, freq, 0.00001)
 	require.InEpsilon(t, f.freqMean, freq, 0.00001)
 	require.Equal(t, StateLocked, state)
 	require.Equal(t, 1, f.skippedCount)
 
+	freq, state = pi.Sample(9190000, 1674148535671684215)
+	require.InEpsilon(t, -111441.130482, freq, 0.00001)
+	require.InEpsilon(t, f.freqMean, freq, 0.00001)
+	require.Equal(t, StateLocked, state)
+	require.Equal(t, 2, f.skippedCount)
+
 	freq = pi.MeanFreq()
-	require.InEpsilon(t, -111034.463816, freq, 0.00001)
+	require.InEpsilon(t, -111441.130482, freq, 0.00001)
+
+	freq, state = pi.Sample(921000, 1674148535771674067)
+	require.InEpsilon(t, -111441.130482, freq, 0.00001)
+	require.Equal(t, f.freqMean, 0.0)
+	require.Equal(t, StateInit, state)
 }
 
 func TestPiServoSetFreq(t *testing.T) {


### PR DESCRIPTION
Summary:
Filter logic should reset the servo if the amount of consequential spikes reaches the limit.
Also the spike filter should take in account the amount of seconds passed after the last frequency update because any oscillator has a holdover drift.

Reviewed By: abulimov

Differential Revision: D43676554

