### PR TITLE
improve sptp logging

### DIFF
--- a/ptp/sptp/client/sptp_test.go
+++ b/ptp/sptp/client/sptp_test.go
@@ -95,6 +95,7 @@ func TestProcessResultsSingle(t *testing.T) {
 		clock: mockClock,
 		pi:    mockServo,
 		stats: mockStatsServer,
+		cfg:   DefaultConfig(),
 	}
 	results := map[string]*RunResult{
 		"iamthebest": {
@@ -143,6 +144,7 @@ func TestProcessResultsMulti(t *testing.T) {
 		clock: mockClock,
 		pi:    mockServo,
 		stats: mockStatsServer,
+		cfg:   DefaultConfig(),
 	}
 	announce0 := announcePkt(0)
 	announce0.GrandmasterIdentity = ptp.ClockIdentity(0x001)


### PR DESCRIPTION
Summary:
Less verbose, easier to digest for humans thanks to NS output and alignment.
Inspired by `ptp4l` logs we know too well.

Reviewed By: pmazzini

Differential Revision: D44256773

