### PR TITLE
Extend calnex tool to report firmware upgrade progress

### DIFF
--- a/calnex/export/export_test.go
+++ b/calnex/export/export_test.go
@@ -62,7 +62,7 @@ func TestExport(t *testing.T) {
 		} else if strings.Contains(r.URL.Path, "measure/ch9/ptp_synce/ntp/server_ip") {
 			// FetchChannelTarget NTP
 			fmt.Fprintln(w, "measure/ch9/ptp_synce/ntp/server_ip=127.0.0.1")
-		} else if r.URL.Query().Get("channel") == "a" {
+		} else if r.URL.Query().Get("channel") == "A" {
 			// FetchCsv PPS
 			fmt.Fprintln(w, "1607961193.773740,-000.000000250501")
 		} else if r.URL.Query().Get("channel") == "VP1" {
@@ -78,7 +78,7 @@ func TestExport(t *testing.T) {
 
 	expected := []string{
 		fmt.Sprintf("{\"double\":{\"value\":-2.50504e-7},\"int\":{\"time\":1607961194},\"normal\":{\"channel\":\"VP1\",\"target\":\"127.0.0.1\",\"protocol\":\"ntp\",\"source\":\"%s\"}}\n", parsed.Host),
-		fmt.Sprintf("{\"double\":{\"value\":-2.50501e-7},\"int\":{\"time\":1607961193},\"normal\":{\"channel\":\"a\",\"target\":\"127.0.0.1\",\"protocol\":\"pps\",\"source\":\"%s\"}}\n", parsed.Host),
+		fmt.Sprintf("{\"double\":{\"value\":-2.50501e-7},\"int\":{\"time\":1607961193},\"normal\":{\"channel\":\"A\",\"target\":\"127.0.0.1\",\"protocol\":\"pps\",\"source\":\"%s\"}}\n", parsed.Host),
 	}
 	err := Export(parsed.Host, true, true, []api.Channel{}, l)
 	require.NoError(t, err)

--- a/calnex/firmware/firmware_test.go
+++ b/calnex/firmware/firmware_test.go
@@ -59,6 +59,8 @@ func TestFirmware(t *testing.T) {
 		} else if strings.Contains(r.URL.Path, "updatefirmware") {
 			// PushVersion
 			fmt.Fprintln(w, "{\n\"result\": true\n}")
+		} else if strings.Contains(r.URL.Path, "instrument/status") {
+			fmt.Fprintln(w, "{\"Channels\":{\"1\":{\"Progress\":-1,\"Slot\":\"1\",\"State\":\"Ready\",\"Type\":\"10G Packet Module (V2)\"},\"2\":{\"Progress\":-1,\"Slot\":\"1\",\"State\":\"Ready\",\"Type\":\"10G Packet Module (V2)\"},\"C\":{\"Progress\":-1,\"Slot\":\"C\",\"State\":\"Ready\",\"Type\":\"Clock Module\"},\"D\":{\"Progress\":-1,\"Slot\":\"C\",\"State\":\"Ready\",\"Type\":\"Clock Module\"}},\"Modules\":{\"1\":{\"Channels\":[\"1\",\"2\"],\"Progress\":-1,\"State\":\"Ready\",\"Type\":\"Packet Module (V2)\"},\"C\":{\"Channels\":[\"C\",\"D\"],\"Progress\":-1,\"State\":\"Ready\",\"Type\":\"Clock Module\"}}}")
 		}
 	}))
 	defer ts.Close()


### PR DESCRIPTION
Summary: Update API to add type for instrument/status response, add API method for get instrument status and add test. Update firmware to call instrument/status endpoint and check if progress is not -1.

Differential Revision: D44715461

