### PR TITLE
void filtered measurements

### DIFF
--- a/servo/pi.go
+++ b/servo/pi.go
@@ -202,7 +202,6 @@ func (s *PiServo) Sample(offset int64, localTs uint64) (float64, State) {
 			ppb = s.MeanFreq()
 			state = StateFilter
 			s.filter.skippedCount++ // it's safe because fState can only be filterNoSpike without filter
-			log.Warningf("servo filtered out offset %d", offset)
 			break
 		}
 		// if there were too many outstanding offsets, reset the filter and the servo
@@ -231,9 +230,7 @@ func (s *PiServo) Sample(offset int64, localTs uint64) (float64, State) {
 		s.filter.skippedCount = 0
 		s.lastCorrectionTime = time.Now()
 	}
-	if state == StateFilter {
-		state = StateLocked
-	}
+
 	return ppb, state
 }
 

--- a/servo/pi_test.go
+++ b/servo/pi_test.go
@@ -115,13 +115,13 @@ func TestPiServoFilterSample(t *testing.T) {
 	freq, state = pi.Sample(919000, 1674148534671684215)
 	require.InEpsilon(t, -111441.130482, freq, 0.00001)
 	require.InEpsilon(t, f.freqMean, freq, 0.00001)
-	require.Equal(t, StateLocked, state)
+	require.Equal(t, StateFilter, state)
 	require.Equal(t, 1, f.skippedCount)
 
 	freq, state = pi.Sample(9190000, 1674148535671684215)
 	require.InEpsilon(t, -111441.130482, freq, 0.00001)
 	require.InEpsilon(t, f.freqMean, freq, 0.00001)
-	require.Equal(t, StateLocked, state)
+	require.Equal(t, StateFilter, state)
 	require.Equal(t, 2, f.skippedCount)
 
 	freq = pi.MeanFreq()


### PR DESCRIPTION
Summary: When we filter the offset in servo we don't communicate it to the client, which means the huge offset is passed to fbclock which means it messes with WOU calculation and alert team.

Reviewed By: abulimov

Differential Revision: D46263631

