### PR TITLE
add syscall to get HW timestamping capabilities

### DIFF
--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -55,6 +55,9 @@ const (
 	SWTIMESTAMP = "software"
 )
 
+// EthtoolGetTSInfo is get time stamping and PHC info command
+const EthtoolGetTSInfo uint32 = 0x00000041
+
 // Ifreq is a struct for ioctl ethernet manipulation syscalls.
 type ifreq struct {
 	name [unix.IFNAMSIZ]byte
@@ -66,6 +69,21 @@ type hwtstampConfig struct {
 	flags    int32
 	txType   int32
 	rxFilter int32
+}
+
+// from include/uapi/linux/ethtool.h struct ethtool_ts_info
+type hwtstampCaps struct {
+	cmd             uint32
+	sofTimestamping uint32 /* SOF_TIMESTAMPING_* bitmask */
+	phcIndex        int32
+	txTypes         uint32 /* HWTSTAMP_TX_* */
+	txReserved0     uint32
+	txReserved1     uint32
+	txReserved2     uint32
+	rxFilters       uint32 /* HWTSTAMP_FILTER_ */
+	rxReserved0     uint32
+	rxReserved1     uint32
+	rxReserved2     uint32
 }
 
 // AttemptsTXTS is configured amount of attempts to read TX timestamp

--- a/timestamp/timestamp_linux_test.go
+++ b/timestamp/timestamp_linux_test.go
@@ -300,3 +300,20 @@ func TestReadPacketWithRXTXTimestamp(t *testing.T) {
 	require.Equal(t, 1, attempts)
 	require.Nil(t, err)
 }
+
+func TestReadHWTimestampCaps(t *testing.T) {
+	// listen to incoming udp packets
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("localhost"), Port: 0})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// get connection file descriptor
+	connFd, err := ConnFd(conn)
+	require.NoError(t, err)
+
+	rxFilters, txType, err := ioctlHWTimestampCaps(connFd, "lo")
+	require.Error(t, err)
+	// hw timestamps are disabled for lo
+	require.Equal(t, int32(0), txType)
+	require.Equal(t, int32(0), rxFilters)
+}


### PR DESCRIPTION
Summary: And use these capabilities to setup filter properly

Reviewed By: leoleovich

Differential Revision: D48782738

