### PR TITLE
remove rate metrics

### DIFF
--- a/ptp/sptp/client/sysstats.go
+++ b/ptp/sptp/client/sysstats.go
@@ -32,14 +32,13 @@ type SysStats struct {
 	memstats *runtime.MemStats
 }
 
-// setRate is a helper function to make a crude rate/diff
-func setRate(name string, counts map[string]uint64, cur, prev uint64, interval time.Duration) {
+// setDiff is a helper function to make a crude diff
+func setDiff(name string, counts map[string]uint64, cur, prev uint64, interval time.Duration) {
 	if prev > cur {
 		return
 	}
 	secs := uint64(interval.Seconds())
 	counts[fmt.Sprintf("%s.sum.%d", name, secs)] = cur - prev
-	counts[fmt.Sprintf("%s.rate.%d", name, secs)] = (cur - prev) / secs
 }
 
 // CollectRuntimeStats gathers cpu, mem, gc statistics
@@ -106,14 +105,14 @@ func (s *SysStats) CollectRuntimeStats(interval time.Duration) (map[string]uint6
 	stats["runtime.mem.gc.pause"] = m.PauseNs[(m.NumGC+255)%256]
 	stats["runtime.mem.gc.count"] = uint64(m.NumGC)
 	if lastStats != nil {
-		setRate("runtime.lookups", stats, m.Lookups, lastStats.Lookups, interval)
+		setDiff("runtime.lookups", stats, m.Lookups, lastStats.Lookups, interval)
 
-		setRate("runtime.mem.total_alloc", stats, m.Mallocs, lastStats.Mallocs, interval)
-		setRate("runtime.mem.mallocs", stats, m.Mallocs, lastStats.Mallocs, interval)
-		setRate("runtime.mem.frees", stats, m.Frees, lastStats.Frees, interval)
+		setDiff("runtime.mem.total_alloc", stats, m.Mallocs, lastStats.Mallocs, interval)
+		setDiff("runtime.mem.mallocs", stats, m.Mallocs, lastStats.Mallocs, interval)
+		setDiff("runtime.mem.frees", stats, m.Frees, lastStats.Frees, interval)
 
-		setRate("runtime.gc.pause_ns", stats, m.PauseTotalNs, lastStats.PauseTotalNs, interval)
-		setRate("runtime.gc.count", stats, uint64(m.NumGC), uint64(lastStats.NumGC), interval)
+		setDiff("runtime.gc.pause_ns", stats, m.PauseTotalNs, lastStats.PauseTotalNs, interval)
+		setDiff("runtime.gc.count", stats, uint64(m.NumGC), uint64(lastStats.NumGC), interval)
 	}
 	s.memstats = m
 	return stats, nil

--- a/ptp/sptp/client/sysstats_test.go
+++ b/ptp/sptp/client/sysstats_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var expectedNonAggregateKeys = []string{"runtime.cpu.cgo_calls", "runtime.cpu.goroutines", "process.cpu_pct.avg.1", "runtime.mem.alloc", "runtime.mem.frees", "runtime.mem.gc.count", "runtime.mem.gc.last", "runtime.mem.gc.next", "runtime.mem.gc.pause", "runtime.mem.gc.pause_total", "runtime.mem.gc.sys", "runtime.mem.heap.alloc", "runtime.mem.heap.idle", "runtime.mem.heap.inuse", "runtime.mem.heap.objects", "runtime.mem.heap.released", "runtime.mem.heap.sys", "runtime.mem.lookups", "runtime.mem.malloc", "runtime.mem.othersys", "runtime.mem.stack.inuse", "runtime.mem.stack.mcache_inuse", "runtime.mem.stack.mcache_sys", "runtime.mem.stack.mspan_inuse", "runtime.mem.stack.mspan_sys", "runtime.mem.stack.sys", "runtime.mem.sys", "runtime.mem.total", "process.num_fds", "process.num_threads", "process.rss", "process.swap", "process.uptime", "process.vms"}
-var expectedAggKeys = []string{"runtime.mem.mallocs.rate.1", "runtime.mem.mallocs.sum.1", "runtime.mem.total_alloc.rate.1", "runtime.mem.total_alloc.sum.1", "runtime.gc.count.rate.1", "runtime.gc.count.sum.1", "runtime.gc.pause_ns.rate.1", "runtime.gc.pause_ns.sum.1", "runtime.lookups.rate.1", "runtime.lookups.sum.1", "runtime.mem.frees.rate.1", "runtime.mem.frees.sum.1"}
+var expectedAggKeys = []string{"runtime.mem.mallocs.sum.1", "runtime.mem.total_alloc.sum.1", "runtime.gc.count.sum.1", "runtime.gc.pause_ns.sum.1", "runtime.lookups.sum.1", "runtime.mem.frees.sum.1"}
 
 func TestSysStats(t *testing.T) {
 	stats := SysStats{}
@@ -46,11 +46,10 @@ func TestSysStats(t *testing.T) {
 func TestSetRate(t *testing.T) {
 	stats := make(map[string]uint64)
 	intervaltime := time.Second * time.Duration(5)
-	setRate("test", stats, 20, 1, intervaltime)
+	setDiff("test", stats, 20, 1, intervaltime)
 
 	expected := map[string]uint64{
-		"test.sum.5":  19,
-		"test.rate.5": 3,
+		"test.sum.5": 19,
 	}
 	require.Equal(t, expected, stats)
 }


### PR DESCRIPTION
Summary: Almost every monitoring solution can calculate *rate* from *sum* over an X interval (just need to divide by X).

Differential Revision: D49548841


