### PR TITLE
Fix compilation on 32bit platform

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,9 +24,9 @@ jobs:
   project: time
   targets:
     - fedora-all-aarch64
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2152259
-    # - fedora-all-armhfp
+    - fedora-all-i386
     - fedora-all-ppc64le
+    - fedora-all-x86_64
     - fedora-all-x86_64
 - job: copr_build
   trigger: pull_request
@@ -34,7 +34,6 @@ jobs:
   project: time
   targets:
     - fedora-all-aarch64
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2152259
-    # - fedora-all-armhfp
+    - fedora-all-i386
     - fedora-all-ppc64le
     - fedora-all-x86_64

--- a/clock/clock_386.go
+++ b/clock/clock_386.go
@@ -1,0 +1,35 @@
+//go:build 386
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setFreq(tx *unix.Timex, freqPPB float64) {
+	// man(2) clock_adjtime, turn ppb to ppm
+	tx.Freq = int32(freqPPB * PPBToTimexPPM)
+}
+
+func setTime(tx *unix.Timex, sec, usec time.Duration) {
+	tx.Time.Sec = int32(sec)
+	tx.Time.Usec = int32(usec)
+}

--- a/clock/clock_64bit.go
+++ b/clock/clock_64bit.go
@@ -1,0 +1,35 @@
+//go:build !386
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setFreq(tx *unix.Timex, freqPPB float64) {
+	// man(2) clock_adjtime, turn ppb to ppm
+	tx.Freq = int64(freqPPB * PPBToTimexPPM)
+}
+
+func setTime(tx *unix.Timex, sec, usec time.Duration) {
+	tx.Time.Sec = int64(sec)
+	tx.Time.Usec = int64(usec)
+}


### PR DESCRIPTION
## Summary

Fix compilation on 32bit GOARCH by extracting what is essentially platform-dependent `unix.Timex` setters to avoid code duplication.
```
~/g/time GOARCH=386 go build github.com/facebook/time/clock/...
# github.com/facebook/time/clock
clock/clock.go:82:12: cannot use int64(freqPPB * PPBToTimexPPM) (value of type int64) as int32 value in assignment
clock/clock.go:96:16: cannot use int64(float64(sign) * (float64(step) / float64(time.Second))) (value of type int64) as int32 value in assignment
clock/clock.go:97:17: cannot use int64(time.Duration(sign) * (step % time.Second)) (value of type int64) as int32 value in assignment
```

## Test Plan

```
~/g/time go build github.com/facebook/time/clock/...
~/g/time echo $?
0
~/g/time GOARCH=386 go build github.com/facebook/time/clock/...
~/g/time echo $?
0
```
