### PR TITLE
set device name

### DIFF
--- a/calnex/config/config.go
+++ b/calnex/config/config.go
@@ -138,7 +138,10 @@ func (c *config) measureConfig(s *ini.Section, mc map[api.Channel]MeasureConfig)
 	}
 }
 
-func (c *config) baseConfig(measure *ini.Section, gnss *ini.Section, antennaDelayNS int) {
+func (c *config) baseConfig(measure *ini.Section, gnss *ini.Section, target string, antennaDelayNS int) {
+	// device hostname
+	c.set(measure, "device_name", target)
+
 	// gnss antenna compensation
 	c.set(gnss, "antenna_delay", fmt.Sprintf("%d ns", antennaDelayNS))
 
@@ -196,7 +199,7 @@ func Config(target string, insecureTLS bool, cc *CalnexConfig, apply bool) error
 	g := f.Section("gnss")
 
 	// set base config
-	c.baseConfig(m, g, cc.AntennaDelayNS)
+	c.baseConfig(m, g, target, cc.AntennaDelayNS)
 
 	// set measure config
 	c.measureConfig(m, cc.Measure)

--- a/calnex/config/config_test.go
+++ b/calnex/config/config_test.go
@@ -82,6 +82,7 @@ reference=Internal
 meas_time=1 days 1 hours
 tie_mode=TIE + 1 PPS Alignment
 ch8\used=Yes
+device_name=leoleovich.com
 ch6\synce_enabled=Off
 ch7\synce_enabled=Off
 ch6\ptp_synce\ptp\dscp=0
@@ -106,7 +107,7 @@ ch6\virtual_channels_enabled=On
 	s := f.Section("measure")
 	g := f.Section("gnss")
 
-	c.baseConfig(s, g, 42)
+	c.baseConfig(s, g, "leoleovich.com", 42)
 	require.True(t, c.changed)
 
 	buf, err := api.ToBuffer(f)
@@ -418,6 +419,7 @@ func TestConfig(t *testing.T) {
 	expectedConfig := `[gnss]
 antenna_delay=42 ns
 [measure]
+device_name=%s
 continuous=On
 reference=Internal
 meas_time=1 days 1 hours
@@ -588,6 +590,7 @@ ch30\ptp_synce\ptp\domain=0
 	parsed, _ := url.Parse(ts.URL)
 	calnexAPI := api.NewAPI(parsed.Host, true)
 	calnexAPI.Client = ts.Client()
+	expectedConfig = fmt.Sprintf(expectedConfig, parsed.Host)
 
 	cc := &CalnexConfig{
 		AntennaDelayNS: 42,


### PR DESCRIPTION
Summary:
Applying patches provided by Calnex team (Fraser).
This diff will set the device name visible in UI.
Works with both - old and new FW versons

Reviewed By: deathowl

Differential Revision: D50500249


