### PR TITLE
sd_notify

### DIFF
--- a/cmd/c4u/main.go
+++ b/cmd/c4u/main.go
@@ -83,6 +83,9 @@ func main() {
 	if err := c4u.Run(c, rb, st); err != nil {
 		log.Fatal(err)
 	}
+	if err := c4u.SdNotify(); err != nil {
+		log.Errorf("failed to send sd_notify: %v", err)
+	}
 
 	for it := time.NewTicker(interval); !once; <-it.C {
 		if err := c4u.Run(c, rb, st); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 )
 
 require (
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/creack/goselect v0.1.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/cilium/ebpf v0.8.1 h1:bLSSEbBLqGPXxls55pGr5qWZaTqcmfDJHhou7t254ao=
 github.com/cilium/ebpf v0.8.1/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=

--- a/ptp/c4u/c4u.go
+++ b/ptp/c4u/c4u.go
@@ -19,6 +19,7 @@ package c4u
 import (
 	"time"
 
+	"github.com/coreos/go-systemd/daemon"
 	"github.com/facebook/time/ptp/c4u/clock"
 	"github.com/facebook/time/ptp/c4u/stats"
 	"github.com/facebook/time/ptp/c4u/utcoffset"
@@ -27,6 +28,23 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
+
+// SdNotify notifies systemd about service successful start
+func SdNotify() error {
+	// daemon.SdNotify returns one of the following:
+	// (false, nil) - notification not supported (i.e. NOTIFY_SOCKET is unset)
+	// (false, err) - notification supported, but failure happened (e.g. error connecting to NOTIFY_SOCKET or while sending data)
+	// (true, nil) - notification supported, data has been sent
+	supported, err := daemon.SdNotify(false, daemon.SdNotifyReady)
+	if !supported && err != nil {
+		return err
+	} else if !supported {
+		log.Warningf("sd_notify not supported")
+	} else {
+		log.Infof("successfully sent sd_notify event")
+	}
+	return nil
+}
 
 // Config is a struct representing the config of the c4u
 type Config struct {


### PR DESCRIPTION
Summary: Add sd_notify support so we notify `systemd` when we wrote the config at least once.

Reviewed By: vvfedorenko

Differential Revision: D50837749


