### PR TITLE
allow seting custom API timeouts

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -486,13 +486,13 @@ func parseResponse(response string) (string, error) {
 }
 
 // NewAPI returns an pointer of API struct with default values.
-func NewAPI(source string, insecureTLS bool) *API {
+func NewAPI(source string, insecureTLS bool, timeout time.Duration) *API {
 	return &API{
 		Client: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
 			},
-			Timeout: 4 * time.Minute,
+			Timeout: timeout,
 		},
 		source: source,
 	}

--- a/calnex/api/api_test.go
+++ b/calnex/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-ini/ini"
 	"github.com/stretchr/testify/require"
@@ -117,14 +118,14 @@ func TestCalnexName(t *testing.T) {
 }
 
 func TestTLSSetting(t *testing.T) {
-	calnexAPI := NewAPI("localhost", false)
+	calnexAPI := NewAPI("localhost", false, time.Second)
 	// Never ever ever allow insecure over https
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
 	}
 	require.Equal(t, transport, calnexAPI.Client.Transport)
 
-	calnexAPI = NewAPI("localhost", true)
+	calnexAPI = NewAPI("localhost", true, time.Second)
 	transport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
@@ -142,7 +143,7 @@ func TestFetchCsv(t *testing.T) {
 	legitChannelNames := []Channel{ChannelONE, ChannelTWO, ChannelC, ChannelD, ChannelVP22}
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 	for _, channel := range legitChannelNames {
 		lines, err := calnexAPI.FetchCsv(channel, true)
@@ -160,7 +161,7 @@ func TestFetchCsvNoData(t *testing.T) {
 	}))
 	defer ts.Close()
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 	lines, err := calnexAPI.FetchCsv(ChannelVP22, true)
 	require.Error(t, err)
@@ -176,7 +177,7 @@ func TestFetchChannelProtocol_NTP(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	probe, err := calnexAPI.FetchChannelProbe(ChannelVP1)
@@ -193,7 +194,7 @@ func TestFetchChannelProtocol_PTP(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	probe, err := calnexAPI.FetchChannelProbe(ChannelVP2)
@@ -210,7 +211,7 @@ func TestFetchChannelProtocol_PPS(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	probe, err := calnexAPI.FetchChannelProbe(ChannelA)
@@ -227,7 +228,7 @@ func TestFetchChannelTarget_NTP(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	target, err := calnexAPI.FetchChannelTarget(ChannelVP1, ProbeNTP)
@@ -244,7 +245,7 @@ func TestFetchChannelTarget_PTP(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	target, err := calnexAPI.FetchChannelTarget(ChannelVP1, ProbePTP)
@@ -261,7 +262,7 @@ func TestFetchChannelTarget_PPS(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	target, err := calnexAPI.FetchChannelTarget(ChannelA, ProbePPS)
@@ -278,7 +279,7 @@ func TestFetchUsedChannels(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	expected := []Channel{ChannelA, ChannelVP22}
@@ -296,7 +297,7 @@ func TestFetchSettings(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	f, err := calnexAPI.FetchSettings()
@@ -322,7 +323,7 @@ func TestFetchStatus(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	f, err := calnexAPI.FetchStatus()
@@ -389,7 +390,7 @@ func TestFetchInstumentStatus(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	f, err := calnexAPI.FetchInstrumentStatus()
@@ -406,7 +407,7 @@ func TestPushSettings(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	sampleConfig := "[measure]\nch0\\synce_enabled=Off\n"
@@ -430,7 +431,7 @@ func TestFetchVersion(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	f, err := calnexAPI.FetchVersion()
@@ -469,7 +470,7 @@ func TestPushVersion(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	r, err := calnexAPI.PushVersion(fw.Name())
@@ -504,7 +505,7 @@ func TestPost(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	buf := bytes.NewBuffer(postData)
@@ -527,7 +528,7 @@ func TestGet(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	err := calnexAPI.StartMeasure()
@@ -551,7 +552,7 @@ func TestHTTPError(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	f := ini.Empty()
@@ -568,7 +569,7 @@ func TestFetchProblemReport(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	dir, err := os.MkdirTemp("/tmp", "calnex")
@@ -609,7 +610,7 @@ func TestPushCert(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	r, err := calnexAPI.PushCert(cert)
@@ -670,7 +671,7 @@ func TestGnssStatus(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	g, err := calnexAPI.GnssStatus()
@@ -709,7 +710,7 @@ func TestPushLicense(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	r, err := calnexAPI.PushLicense(license.Name())
@@ -754,7 +755,7 @@ func TestPushLicenseError(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	r, err := calnexAPI.PushLicense(license.Name())
@@ -795,7 +796,7 @@ func TestPowerSupplyStatus(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	g, err := calnexAPI.PowerSupplyStatus()
@@ -816,7 +817,7 @@ func TestPowerSupplyStatusSentinel(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := NewAPI(parsed.Host, true)
+	calnexAPI := NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	g, err := calnexAPI.PowerSupplyStatus()

--- a/calnex/cmd/cert.go
+++ b/calnex/cmd/cert.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 func certFunc() error {
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, time.Minute)
 	certData, err := os.ReadFile(source)
 	if err != nil {
 		return err

--- a/calnex/cmd/clear.go
+++ b/calnex/cmd/clear.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"time"
+
 	"github.com/facebook/time/calnex/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,7 +40,7 @@ func clear() error {
 		return nil
 	}
 
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, time.Minute)
 	if err := api.ClearDevice(); err != nil {
 		return err
 	}

--- a/calnex/cmd/license.go
+++ b/calnex/cmd/license.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"time"
+
 	"github.com/facebook/time/calnex/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -37,7 +39,7 @@ func init() {
 }
 
 func licenseFunc() error {
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, time.Minute)
 	_, err := api.PushLicense(source)
 	return err
 }

--- a/calnex/cmd/reboot.go
+++ b/calnex/cmd/reboot.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"time"
+
 	"github.com/facebook/time/calnex/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,7 +40,7 @@ func reboot() error {
 		return nil
 	}
 
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, time.Minute)
 	if err := api.Reboot(); err != nil {
 		return err
 	}

--- a/calnex/cmd/report.go
+++ b/calnex/cmd/report.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"time"
+
 	"github.com/facebook/time/calnex/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,7 +35,7 @@ func init() {
 }
 
 func report() error {
-	api := api.NewAPI(source, insecureTLS)
+	api := api.NewAPI(source, insecureTLS, time.Minute)
 
 	reportFileName, err := api.FetchProblemReport(dir)
 	if err != nil {

--- a/calnex/config/config.go
+++ b/calnex/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/facebook/time/calnex/api"
 	"github.com/go-ini/ini"
@@ -192,10 +193,9 @@ func (c *config) baseConfig(measure *ini.Section, gnss *ini.Section, target stri
 // Config configures target Calnex with Network/Calnex configs if apply is specified
 func Config(target string, insecureTLS bool, cc *CalnexConfig, apply bool) error {
 	var c config
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, 4*time.Minute)
 
 	f, err := prepare(&c, api, target, cc)
-
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func Config(target string, insecureTLS bool, cc *CalnexConfig, apply bool) error
 // Save saves the Network/Calnex configs to file
 func Save(target string, insecureTLS bool, cc *CalnexConfig, saveConfig string) error {
 	var c config
-	calnexAPI := api.NewAPI(target, insecureTLS)
+	calnexAPI := api.NewAPI(target, insecureTLS, time.Minute)
 
 	f, err := prepare(&c, calnexAPI, target, cc)
 	if err != nil {

--- a/calnex/config/config_test.go
+++ b/calnex/config/config_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/facebook/time/calnex/api"
 	"github.com/go-ini/ini"
@@ -593,7 +594,7 @@ ch30\ptp_synce\ptp\domain=0
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := api.NewAPI(parsed.Host, true)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 	expectedConfig = fmt.Sprintf(expectedConfig, parsed.Host)
 
@@ -807,7 +808,7 @@ antenna_delay=42 ns
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := api.NewAPI(parsed.Host, true)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 	expectedConfig = fmt.Sprintf(expectedConfig, parsed.Host)
 	cc := &CalnexConfig{
@@ -1156,7 +1157,7 @@ ch6\virtual_channels_enabled=On
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := api.NewAPI(parsed.Host, true)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 	cc := &CalnexConfig{
 		AntennaDelayNS: 42,

--- a/calnex/export/export.go
+++ b/calnex/export/export.go
@@ -18,6 +18,7 @@ package export
 
 import (
 	"errors"
+	"time"
 
 	"github.com/facebook/time/calnex/api"
 	log "github.com/sirupsen/logrus"
@@ -29,7 +30,7 @@ var errNoTarget = errors.New("no target succeeds")
 // Export data from the device about specified channels to the specified output
 func Export(source string, insecureTLS bool, allData bool, channels []api.Channel, l Logger) (err error) {
 	var success bool
-	calnexAPI := api.NewAPI(source, insecureTLS)
+	calnexAPI := api.NewAPI(source, insecureTLS, 4*time.Minute)
 
 	if len(channels) == 0 {
 		channels, err = calnexAPI.FetchUsedChannels()

--- a/calnex/export/export_test.go
+++ b/calnex/export/export_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/facebook/time/calnex/api"
 	"github.com/stretchr/testify/require"
@@ -73,7 +74,7 @@ func TestExport(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := api.NewAPI(parsed.Host, true)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	expected := []string{

--- a/calnex/firmware/firmware.go
+++ b/calnex/firmware/firmware.go
@@ -18,6 +18,7 @@ package firmware
 
 import (
 	"strings"
+	"time"
 
 	calnexAPI "github.com/facebook/time/calnex/api"
 	version "github.com/hashicorp/go-version"
@@ -34,7 +35,7 @@ type FW interface {
 
 // Firmware checks target Calnex firmware version and upgrades if apply is specified
 func Firmware(target string, insecureTLS bool, fw FW, apply bool) error {
-	api := calnexAPI.NewAPI(target, insecureTLS)
+	api := calnexAPI.NewAPI(target, insecureTLS, 4*time.Minute)
 	cv, err := api.FetchVersion()
 	if err != nil {
 		return err

--- a/calnex/firmware/firmware_test.go
+++ b/calnex/firmware/firmware_test.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/facebook/time/calnex/api"
 	"github.com/stretchr/testify/require"
@@ -66,7 +67,7 @@ func TestFirmware(t *testing.T) {
 	defer ts.Close()
 
 	parsed, _ := url.Parse(ts.URL)
-	calnexAPI := api.NewAPI(parsed.Host, true)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
 	err = Firmware(parsed.Host, true, fw, true)

--- a/calnex/verify/checks/gnss.go
+++ b/calnex/verify/checks/gnss.go
@@ -18,6 +18,8 @@ package checks
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/facebook/time/calnex/api"
 )
 
@@ -35,7 +37,7 @@ func (p *GNSS) Name() string {
 
 // Run executes the check
 func (p *GNSS) Run(target string, insecureTLS bool) error {
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, 10*time.Second)
 
 	g, err := api.GnssStatus()
 	if err != nil {

--- a/calnex/verify/checks/http.go
+++ b/calnex/verify/checks/http.go
@@ -18,6 +18,7 @@ package checks
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/facebook/time/calnex/api"
 )
@@ -34,7 +35,7 @@ func (p *HTTP) Name() string {
 
 // Run executes the check
 func (p *HTTP) Run(target string, insecureTLS bool) error {
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, 10*time.Second)
 
 	_, err := api.FetchStatus()
 	if err != nil {

--- a/calnex/verify/checks/psu.go
+++ b/calnex/verify/checks/psu.go
@@ -18,6 +18,8 @@ package checks
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/facebook/time/calnex/api"
 )
 
@@ -33,7 +35,7 @@ func (p *PSU) Name() string {
 
 // Run executes the check
 func (p *PSU) Run(target string, insecureTLS bool) error {
-	api := api.NewAPI(target, insecureTLS)
+	api := api.NewAPI(target, insecureTLS, 10*time.Second)
 
 	pu, err := api.PowerSupplyStatus()
 	if err != nil {


### PR DESCRIPTION
Summary:
For config push, firmware upgrade and metrics export we have to have large timeout values (4 minutes). But for the rest we don't.
In real world it results in tests being slow running up to 4 minutes per test:
```
# go test github.com/facebook/time/calnex/verify/checks -v
=== RUN   TestGNSS
--- PASS: TestGNSS (75.00s)
=== RUN   TestHTTP
--- PASS: TestHTTP (75.01s)
=== RUN   TestPing
--- PASS: TestPing (1.01s)
=== RUN   TestPSU
--- PASS: TestPSU (75.00s)
PASS
ok  	github.com/facebook/time/calnex/verify/checks	226.514s
```
Lowering most timeouts expect for aforementioned.

Reviewed By: deathowl

Differential Revision: D52661410


