### PR TITLE
fail measurement if oscillatord is unavailable

### DIFF
--- a/ptp/c4u/clock/oscillatord.go
+++ b/ptp/c4u/clock/oscillatord.go
@@ -56,7 +56,7 @@ func oscillatord() (*oscillatorState, error) {
 	}
 	defer conn.Close()
 	deadline := time.Now().Add(timeout)
-	if err := conn.SetDeadline(deadline); err != nil {
+	if err = conn.SetDeadline(deadline); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Summary:
When `oscillatord` is stopped (crashed for example) `c4u` will not refresh the `ptp4u` config and we may end up serving bad time as a result.
This diff fixes this situation by assuming `nil` measurement means "uncalibrated"

Differential Revision: D52834697


