### PR TITLE
push misbehaving GMs to the back of the list

### DIFF
--- a/ptp/sptp/client/sptp_test.go
+++ b/ptp/sptp/client/sptp_test.go
@@ -577,3 +577,33 @@ func TestPTPing(t *testing.T) {
 	err = p.ptping(ip, 1234, response, time.Time{})
 	require.Nil(t, err)
 }
+
+func TestShiftPriorities(t *testing.T) {
+	p := &SPTP{
+		priorities: map[string]int{
+			"O": 1,
+			"L": 2,
+			"E": 3,
+			"G": 4,
+		},
+	}
+
+	p.reprioritize("L")
+	require.Equal(t, 1, p.priorities["L"])
+	require.Equal(t, 2, p.priorities["E"])
+	require.Equal(t, 3, p.priorities["G"])
+	require.Equal(t, 4, p.priorities["O"])
+
+	p.reprioritize("O")
+	require.Equal(t, 1, p.priorities["O"])
+	require.Equal(t, 2, p.priorities["L"])
+	require.Equal(t, 3, p.priorities["E"])
+	require.Equal(t, 4, p.priorities["G"])
+
+	// Shift by 0 (no change)
+	p.reprioritize("O")
+	require.Equal(t, 1, p.priorities["O"])
+	require.Equal(t, 2, p.priorities["L"])
+	require.Equal(t, 3, p.priorities["E"])
+	require.Equal(t, 4, p.priorities["G"])
+}


### PR DESCRIPTION
Summary:
Credit to yarikk for suggesting this idea.
Because we trust local priority (when everything else is equal) we often end up jumping between time appliances.
For instance when 1st in the list is unavailable we jump to a 2nd. However, once the 1st is available we switch back to it. This creates unnecessary noise and in some cases leads to offset oscillations.

This diff will push 1st appliance to the end of the list and shift the rest of list up by 1.
As a result we will keep running on 2nd appliance until and never fallback to 1st.

Since we don't modify the config, restart will restore the order.

Reviewed By: t3lurid3

Differential Revision: D53191500


