### PR TITLE
allow applying older fw version

### DIFF
--- a/calnex/cmd/cmd.go
+++ b/calnex/cmd/cmd.go
@@ -33,10 +33,11 @@ var (
 	apply       bool
 	channels    api.Channels
 	dir         string
+	force       bool
 	insecureTLS bool
+	saveConfig  string
 	source      string
 	target      string
-	saveConfig  string
 )
 
 // Execute is the main entry point for CLI interface

--- a/calnex/cmd/firmware.go
+++ b/calnex/cmd/firmware.go
@@ -25,6 +25,7 @@ import (
 func init() {
 	RootCmd.AddCommand(firmwareCmd)
 	firmwareCmd.Flags().BoolVar(&apply, "apply", false, "apply the firmware upgrade")
+	firmwareCmd.Flags().BoolVar(&force, "force", false, "force apply same or lower firmware version")
 	firmwareCmd.Flags().BoolVar(&insecureTLS, "insecureTLS", false, "Ignore TLS certificate errors")
 	firmwareCmd.Flags().StringVar(&target, "target", "", "device to configure")
 	firmwareCmd.Flags().StringVar(&source, "file", "", "firmware file path")
@@ -43,7 +44,7 @@ var firmwareCmd = &cobra.Command{
 		fw := &firmware.OSSFW{
 			Filepath: source,
 		}
-		if err := firmware.Firmware(target, insecureTLS, fw, apply); err != nil {
+		if err := firmware.Firmware(target, insecureTLS, fw, apply, force); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/calnex/firmware/firmware.go
+++ b/calnex/firmware/firmware.go
@@ -34,7 +34,7 @@ type FW interface {
 }
 
 // Firmware checks target Calnex firmware version and upgrades if apply is specified
-func Firmware(target string, insecureTLS bool, fw FW, apply bool) error {
+func Firmware(target string, insecureTLS bool, fw FW, apply bool, force bool) error {
 	api := calnexAPI.NewAPI(target, insecureTLS, 4*time.Minute)
 	cv, err := api.FetchVersion()
 	if err != nil {
@@ -49,7 +49,7 @@ func Firmware(target string, insecureTLS bool, fw FW, apply bool) error {
 	if err != nil {
 		return err
 	}
-	if calnexVersion.GreaterThanOrEqual(v) {
+	if calnexVersion.GreaterThanOrEqual(v) && !force {
 		instrumentStatus, statusErr := api.FetchInstrumentStatus()
 		if statusErr != nil {
 			return statusErr

--- a/calnex/firmware/firmware_test.go
+++ b/calnex/firmware/firmware_test.go
@@ -70,6 +70,92 @@ func TestFirmware(t *testing.T) {
 	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
 	calnexAPI.Client = ts.Client()
 
-	err = Firmware(parsed.Host, true, fw, true)
+	err = Firmware(parsed.Host, true, fw, true, false)
+	require.NoError(t, err)
+}
+
+func TestFirmwareForce(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "calnex")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	filepath := path.Join(dir, "sentinel_fw_v2.13.1.0.5583D-20210924.tar")
+	f, err := os.Create(filepath)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f.Close()
+
+	fw := &OSSFW{
+		Filepath: filepath,
+	}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if strings.Contains(r.URL.Path, "version") {
+			// FetchVersion
+			fmt.Fprintln(w, "{ \"firmware\": \"2.13.1.0.5583D-20210924\" }")
+		} else if strings.Contains(r.URL.Path, "getstatus") {
+			// FetchStatus
+			fmt.Fprintln(w, "{\n\"referenceReady\": true,\n\"modulesReady\": true,\n\"measurementActive\": true\n}")
+		} else if strings.Contains(r.URL.Path, "stopmeasurement") {
+			// StopMeasure
+			fmt.Fprintln(w, "{\n\"result\": true\n}")
+		} else if strings.Contains(r.URL.Path, "updatefirmware") {
+			// PushVersion
+			fmt.Fprintln(w, "{\n\"result\": true\n}")
+		} else if strings.Contains(r.URL.Path, "instrument/status") {
+			fmt.Fprintln(w, "{\"Channels\":{\"1\":{\"Progress\":-1,\"Slot\":\"1\",\"State\":\"Ready\",\"Type\":\"10G Packet Module (V2)\"},\"2\":{\"Progress\":-1,\"Slot\":\"1\",\"State\":\"Ready\",\"Type\":\"10G Packet Module (V2)\"},\"C\":{\"Progress\":-1,\"Slot\":\"C\",\"State\":\"Ready\",\"Type\":\"Clock Module\"},\"D\":{\"Progress\":-1,\"Slot\":\"C\",\"State\":\"Ready\",\"Type\":\"Clock Module\"}},\"Modules\":{\"1\":{\"Channels\":[\"1\",\"2\"],\"Progress\":-1,\"State\":\"Ready\",\"Type\":\"Packet Module (V2)\"},\"C\":{\"Channels\":[\"C\",\"D\"],\"Progress\":-1,\"State\":\"Ready\",\"Type\":\"Clock Module\"}}}")
+		}
+	}))
+	defer ts.Close()
+
+	parsed, _ := url.Parse(ts.URL)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
+	calnexAPI.Client = ts.Client()
+
+	err = Firmware(parsed.Host, true, fw, true, true)
+	require.NoError(t, err)
+}
+
+func TestFirmwareInProgress(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "calnex")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	filepath := path.Join(dir, "sentinel_fw_v2.13.1.0.5583D-20210924.tar")
+	f, err := os.Create(filepath)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f.Close()
+
+	fw := &OSSFW{
+		Filepath: filepath,
+	}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if strings.Contains(r.URL.Path, "version") {
+			// FetchVersion
+			fmt.Fprintln(w, "{ \"firmware\": \"2.13.1.0.5583D-20210924\" }")
+		} else if strings.Contains(r.URL.Path, "getstatus") {
+			// FetchStatus
+			fmt.Fprintln(w, "{\n\"referenceReady\": true,\n\"modulesReady\": true,\n\"measurementActive\": true\n}")
+		} else if strings.Contains(r.URL.Path, "stopmeasurement") {
+			// StopMeasure
+			fmt.Fprintln(w, "{\n\"result\": true\n}")
+		} else if strings.Contains(r.URL.Path, "updatefirmware") {
+			// PushVersion
+			fmt.Fprintln(w, "{\n\"result\": true\n}")
+		} else if strings.Contains(r.URL.Path, "instrument/status") {
+			fmt.Fprintln(w, "{\"Channels\":{\"1\":{\"Progress\":42,\"Slot\":\"1\",\"State\":\"Ready\",\"Type\":\"10G Packet Module (V2)\"},\"2\":{\"Progress\":42,\"Slot\":\"1\",\"State\":\"Ready\",\"Type\":\"10G Packet Module (V2)\"},\"C\":{\"Progress\":42,\"Slot\":\"C\",\"State\":\"Ready\",\"Type\":\"Clock Module\"},\"D\":{\"Progress\":42,\"Slot\":\"C\",\"State\":\"Ready\",\"Type\":\"Clock Module\"}},\"Modules\":{\"1\":{\"Channels\":[\"1\",\"2\"],\"Progress\":42,\"State\":\"Ready\",\"Type\":\"Packet Module (V2)\"},\"C\":{\"Channels\":[\"C\",\"D\"],\"Progress\":42,\"State\":\"Ready\",\"Type\":\"Clock Module\"}}}")
+		}
+	}))
+	defer ts.Close()
+
+	parsed, _ := url.Parse(ts.URL)
+	calnexAPI := api.NewAPI(parsed.Host, true, time.Second)
+	calnexAPI.Client = ts.Client()
+
+	err = Firmware(parsed.Host, true, fw, true, false)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Summary:
Sometimes we manually upgrade the device to a higher version and to recover the older version we have to use `curl` instead of `calnex` cli.
This diff will add --force option which will allow pushing a fw version even if it's not > than the one running.

Differential Revision: D54303192


