### PR TITLE
format antenna delay to microseconds if necessary

### DIFF
--- a/calnex/config/config.go
+++ b/calnex/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/facebook/time/calnex/api"
@@ -148,7 +149,11 @@ func (c *config) baseConfig(measure *ini.Section, gnss *ini.Section, target stri
 	c.set(measure, "device_name", target)
 
 	// gnss antenna compensation
-	c.set(gnss, "antenna_delay", fmt.Sprintf("%d ns", antennaDelayNS))
+	if antennaDelayNS < 1000 {
+		c.set(gnss, "antenna_delay", fmt.Sprintf("%d ns", antennaDelayNS))
+	} else {
+		c.set(gnss, "antenna_delay", fmt.Sprintf("%s us", strconv.FormatFloat(float64(antennaDelayNS)/1000, 'f', -1, 64)))
+	}
 
 	// continuous measurement
 	c.set(measure, "continuous", api.ON)

--- a/calnex/config/config_test.go
+++ b/calnex/config/config_test.go
@@ -422,7 +422,7 @@ ch30\ptp_synce\ptp\domain=0
 
 func TestConfig(t *testing.T) {
 	expectedConfig := `[gnss]
-antenna_delay=42 ns
+antenna_delay=4.2 us
 [measure]
 device_name=%s
 continuous=On
@@ -599,7 +599,7 @@ ch30\ptp_synce\ptp\domain=0
 	expectedConfig = fmt.Sprintf(expectedConfig, parsed.Host)
 
 	cc := &CalnexConfig{
-		AntennaDelayNS: 42,
+		AntennaDelayNS: 4200,
 		Measure: map[api.Channel]MeasureConfig{
 			api.ChannelA: {
 				Target: "fd00:3226:301b::1f",


### PR DESCRIPTION
Summary:
Temporarily add a hack to match Calnex microseconds format.

Apparently, the device is trying to be smart and after setting the values returns `antenna_delay=3.042 us`, which in turn triggers our automation to set the value again and again.
It's a bit painful to match this string especially because golang is using proper unicode characters https://go.dev/play/p/_awe7ecCSuq
```
3.042µs
```

Differential Revision: D54415146


