### PR TITLE
set default logging to debug

### DIFF
--- a/calnex/cert/cert.go
+++ b/calnex/cert/cert.go
@@ -105,12 +105,13 @@ func Parse(data []byte) (*Bundle, error) {
 			var key *rsa.PrivateKey
 			var err error
 
-			if block.Type == "RSA PRIVATE KEY" {
+			switch block.Type {
+			case "RSA PRIVATE KEY":
 				key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
 				if err != nil {
 					return nil, err
 				}
-			} else if block.Type == "PRIVATE KEY" {
+			case "PRIVATE KEY":
 				tmpKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 				if err != nil {
 					return nil, err
@@ -121,7 +122,7 @@ func Parse(data []byte) (*Bundle, error) {
 				if !ok {
 					return nil, ErrOnlyRSA
 				}
-			} else {
+			default:
 				return nil, ErrUnsupportedPEMBlock
 			}
 

--- a/calnex/cmd/cmd.go
+++ b/calnex/cmd/cmd.go
@@ -42,6 +42,7 @@ var (
 
 // Execute is the main entry point for CLI interface
 func Execute() {
+	log.SetLevel(log.DebugLevel)
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}

--- a/calnex/config/config.go
+++ b/calnex/config/config.go
@@ -61,7 +61,7 @@ func (c *config) set(target string, s *ini.Section, name, value string) {
 	k := s.Key(name)
 	if k.Value() != value {
 		k.SetValue(value)
-		log.Infof("%s: setting %s to %s", target, name, value)
+		log.Debugf("%s: setting %s to %s", target, name, value)
 		c.changed = true
 	}
 }
@@ -218,7 +218,7 @@ func Config(target string, insecureTLS bool, cc *CalnexConfig, apply bool) error
 
 	if c.changed {
 		if status.MeasurementActive {
-			log.Infof("%s: stopping measurement", target)
+			log.Debugf("%s: stopping measurement", target)
 			// stop measurement
 			if err = api.StopMeasure(); err != nil {
 				return err
@@ -231,11 +231,11 @@ func Config(target string, insecureTLS bool, cc *CalnexConfig, apply bool) error
 			return err
 		}
 	} else {
-		log.Infof("%s: no change needs to be applied", target)
+		log.Debugf("%s: no change needs to be applied", target)
 	}
 
 	if c.changed || !status.MeasurementActive {
-		log.Infof("%s: starting measurement", target)
+		log.Debugf("%s: starting measurement", target)
 		// start measurement
 		if err = api.StartMeasure(); err != nil {
 			return err

--- a/calnex/firmware/firmware.go
+++ b/calnex/firmware/firmware.go
@@ -50,11 +50,11 @@ func ShouldUpgrade(target string, api *calnexAPI.API, fw FW, force bool) (bool, 
 	}
 
 	if calnexVersion.LessThan(v) || force {
-		log.Infof("%s: is running %s, latest is %s. Needs an update", target, calnexVersion, v)
+		log.Warningf("%s: is running %s, latest is %s. Needs an update", target, calnexVersion, v)
 		return true, nil
 	}
 
-	log.Infof("%s: no firmware update is required", target)
+	log.Debugf("%s: no firmware update is required", target)
 	return false, nil
 }
 
@@ -99,7 +99,7 @@ func Firmware(target string, insecureTLS bool, fw FW, apply bool, force bool) er
 		return err
 	}
 	if status.MeasurementActive {
-		log.Infof("%s: stopping measurement", target)
+		log.Debugf("%s: stopping measurement", target)
 		// stop measurement
 		if err = api.StopMeasure(); err != nil {
 			return err

--- a/calnex/verify/verify.go
+++ b/calnex/verify/verify.go
@@ -42,7 +42,7 @@ func Verify(target string, insecureTLS bool, verify *VF, apply bool) error {
 				break
 			}
 		} else {
-			log.Infof("%s: %s check pass", target, c.Name())
+			log.Debugf("%s: %s check pass", target, c.Name())
 		}
 	}
 	return nil


### PR DESCRIPTION
Summary:
Rework logging verbocity to make calnex service logs more readable.

Moving many things to Debug verbocity (instead of Info) but setting Debug as a default level. This means effectively no change.
However, when required, loglevel could be set to Info to mute many Debug messages

Differential Revision: D55636650


