### PR TITLE
don't return error on certificate match

### DIFF
--- a/calnex/cmd/cert.go
+++ b/calnex/cmd/cert.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"errors"
 	"net"
 	"os"
 	"time"
@@ -66,7 +65,8 @@ func certFunc() error {
 	}
 
 	if bundle.Equals(remoteBundle) {
-		return errors.New("new certificate matches existing certificate")
+		log.Debugf("%s: certificate is up to date", target)
+		return nil
 	}
 
 	if !apply {


### PR DESCRIPTION
Summary: Return nil (all good) if provisioned certificate is matching certificate from the system

Differential Revision: D56135420


