### PR TITLE
Ignore EOPNOTSUPP for SIOCGHWTSTAMP

### DIFF
--- a/timestamp/timestamp_linux.go
+++ b/timestamp/timestamp_linux.go
@@ -126,7 +126,7 @@ func ioctlTimestamp(fd int, ifname string, filter int32) error {
 
 	i := &ifreq{data: uintptr(unsafe.Pointer(hw))}
 	copy(i.name[:unix.IFNAMSIZ-1], ifname)
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.SIOCGHWTSTAMP, uintptr(unsafe.Pointer(i))); errno != 0 {
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.SIOCGHWTSTAMP, uintptr(unsafe.Pointer(i))); errno != 0 && errno != unix.ENOTSUP {
 		return fmt.Errorf("failed to run ioctl SIOCGHWTSTAMP to see what is enabled: %s (%w)", unix.ErrnoName(errno), errno)
 	}
 


### PR DESCRIPTION
Summary: Some hardware doesn't have non-distructive SIOCGHWTSTAMP but can still do hardware timestamping. It's mostly about HW having ext PHY module. Let's ignore this error and allow setting values

Differential Revision: D56185343


