### PR TITLE
replace go get with go install in README

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -24,5 +24,5 @@ NTPSHM library
 
 ### Quick Installation
 ```console
-go get github.com/facebook/time/cmd/ntpresponder
+go install github.com/facebook/time/cmd/ntpresponder@latest
 ```

--- a/ptp/README.md
+++ b/ptp/README.md
@@ -15,7 +15,7 @@ Scalable unicast PTP server supporting PTP and SPTP.
 
 ### Quick Installation
 ```console
-go get github.com/facebook/time/cmd/ptp4u@latest
+go install github.com/facebook/time/cmd/ptp4u@latest
 ```
 
 ## SPTP
@@ -23,7 +23,7 @@ Scalable unicast SPTP client.
 
 ### Quick Installation
 ```console
-go get github.com/facebook/time/cmd/sptp@latest
+go install github.com/facebook/time/cmd/sptp@latest
 ```
 
 ## Simpleclient

--- a/ptp/sptp/README.md
+++ b/ptp/sptp/README.md
@@ -65,7 +65,7 @@ Additionally, `originTimestamp` field contains **T1** (time when server sent *SY
 
 ## Quick Installation
 ```console
-go get github.com/facebook/time/cmd/sptp@latest
+go install github.com/facebook/time/cmd/sptp@latest
 ```
 
 ## Requirements


### PR DESCRIPTION
Summary: go get is no more, let's modernise

Reviewed By: pmazzini

Differential Revision: D56244379


