### PR TITLE
use EnableTimestamps library

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -182,17 +182,8 @@ func (s *Server) startEventListener() {
 	}
 
 	// Enable RX timestamps. Delay requests need to be timestamped by ptp4u on receipt
-	switch s.Config.TimestampType {
-	case timestamp.HWTIMESTAMP:
-		if err = timestamp.EnableHWTimestamps(s.eFd, s.Config.Interface); err != nil {
-			log.Fatalf("Cannot enable hardware RX timestamps: %v", err)
-		}
-	case timestamp.SWTIMESTAMP:
-		if err = timestamp.EnableSWTimestamps(s.eFd); err != nil {
-			log.Fatalf("Cannot enable software RX timestamps: %v", err)
-		}
-	default:
-		log.Fatalf("Unrecognized timestamp type: %s", s.Config.TimestampType)
+	if err := timestamp.EnableTimestamps(s.Config.TimestampType, s.eFd, s.Config.Interface); err != nil {
+		log.Fatal(err)
 	}
 
 	err = unix.SetNonblock(s.eFd, false)

--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -99,17 +99,8 @@ func (s *sendWorker) listen() (eventFD, generalFD int, err error) {
 	}
 
 	// Syncs sent from event port, so need to turn on timestamping here
-	switch s.config.TimestampType {
-	case timestamp.HWTIMESTAMP:
-		if err = timestamp.EnableHWTimestamps(eventFD, s.config.Interface); err != nil {
-			return -1, -1, fmt.Errorf("failed to enable RX hardware timestamps: %w", err)
-		}
-	case timestamp.SWTIMESTAMP:
-		if err = timestamp.EnableSWTimestamps(eventFD); err != nil {
-			return -1, -1, fmt.Errorf("unable to enable RX software timestamps: %w", err)
-		}
-	default:
-		return -1, -1, fmt.Errorf("unrecognized timestamp type: %s", s.config.TimestampType)
+	if err := timestamp.EnableTimestamps(s.config.TimestampType, eventFD, s.config.Interface); err != nil {
+		return -1, -1, err
 	}
 
 	// set up general connection

--- a/ptp/simpleclient/client.go
+++ b/ptp/simpleclient/client.go
@@ -240,27 +240,10 @@ func (c *Client) setup(ctx context.Context, eg *errgroup.Group) error {
 	}
 
 	// we need to enable HW or SW timestamps on event port
-	switch c.cfg.Timestamping {
-	case "": // auto-detection
-		if err := timestamp.EnableHWTimestamps(connFd, c.cfg.Iface); err != nil {
-			if err := timestamp.EnableSWTimestamps(connFd); err != nil {
-				return fmt.Errorf("failed to enable timestamps on port %d: %w", ptp.PortEvent, err)
-			}
-			log.Warningf("Failed to enable hardware timestamps on port %d, falling back to software timestamps", ptp.PortEvent)
-		} else {
-			log.Infof("Using hardware timestamps")
-		}
-	case HWTIMESTAMP:
-		if err := timestamp.EnableHWTimestamps(connFd, c.cfg.Iface); err != nil {
-			return fmt.Errorf("failed to enable hardware timestamps on port %d: %w", ptp.PortEvent, err)
-		}
-	case SWTIMESTAMP:
-		if err := timestamp.EnableSWTimestamps(connFd); err != nil {
-			return fmt.Errorf("failed to enable software timestamps on port %d: %w", ptp.PortEvent, err)
-		}
-	default:
-		return fmt.Errorf("unknown type of typestamping: %q", c.cfg.Timestamping)
+	if err := timestamp.EnableTimestamps(c.cfg.Timestamping, connFd, c.cfg.Iface); err != nil {
+		return err
 	}
+
 	// set it to blocking mode, otherwise recvmsg will just return with nothing most of the time
 	if err := unix.SetNonblock(connFd, false); err != nil {
 		return fmt.Errorf("failed to set event socket to blocking: %w", err)

--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -139,27 +139,10 @@ func (p *SPTP) init() error {
 	}
 
 	// we need to enable HW or SW timestamps on event port
-	switch p.cfg.Timestamping {
-	case "": // auto-detection
-		if err = timestamp.EnableHWTimestamps(connFd, p.cfg.Iface); err != nil {
-			if err = timestamp.EnableSWTimestamps(connFd); err != nil {
-				return fmt.Errorf("failed to enable timestamps on port %d: %w", ptp.PortEvent, err)
-			}
-			log.Warningf("Failed to enable hardware timestamps on port %d, falling back to software timestamps", ptp.PortEvent)
-		} else {
-			log.Infof("Using hardware timestamps")
-		}
-	case HWTIMESTAMP:
-		if err = timestamp.EnableHWTimestamps(connFd, p.cfg.Iface); err != nil {
-			return fmt.Errorf("failed to enable hardware timestamps on port %d: %w", ptp.PortEvent, err)
-		}
-	case SWTIMESTAMP:
-		if err = timestamp.EnableSWTimestamps(connFd); err != nil {
-			return fmt.Errorf("failed to enable software timestamps on port %d: %w", ptp.PortEvent, err)
-		}
-	default:
-		return fmt.Errorf("unknown type of typestamping: %q", p.cfg.Timestamping)
+	if err := timestamp.EnableTimestamps(p.cfg.Timestamping, connFd, p.cfg.Iface); err != nil {
+		return err
 	}
+
 	// set it to blocking mode, otherwise recvmsg will just return with nothing most of the time
 	if err = unix.SetNonblock(connFd, false); err != nil {
 		return fmt.Errorf("failed to set event socket to blocking: %w", err)


### PR DESCRIPTION
Summary:
Use the x-platform timestamp wrapper in PTP components as well and avoid code duplication.
Remove autodetection as well because it usually never a good idea.

Reviewed By: t3lurid3

Differential Revision: D56357939


