### PR TITLE
use RX only timestamp in ntp/responder

### DIFF
--- a/cmd/ntpresponder/main.go
+++ b/cmd/ntpresponder/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.BoolVar(&s.Config.ShouldAnnounce, "announce", false, "Advertize IPs")
 	flag.DurationVar(&s.Config.ExtraOffset, "extraoffset", 0, "Extra offset to return to clients")
 	flag.BoolVar(&s.Config.ManageLoopback, "manage-loopback", true, "Add/remove IPs. If false, these must be managed elsewhere")
-	flag.StringVar(&s.Config.TimestampType, "timestamptype", timestamp.SWTIMESTAMP, fmt.Sprintf("Timestamp type. Can be: %s, %s", timestamp.HWTIMESTAMP, timestamp.SWTIMESTAMP))
+	flag.TextVar(&s.Config.TimestampType, "timestamptype", timestamp.SWRX, fmt.Sprintf("Timestamp type. Can be: %s, %s", timestamp.HWRX, timestamp.SWRX))
 
 	flag.Parse()
 	s.Config.IPs.SetDefault()

--- a/cmd/ptp4u/main.go
+++ b/cmd/ptp4u/main.go
@@ -58,7 +58,7 @@ func main() {
 	flag.StringVar(&c.Interface, "iface", "eth0", "Set the interface")
 	flag.StringVar(&c.LogLevel, "loglevel", "warning", "Set a log level. Can be: debug, info, warning, error")
 	flag.StringVar(&c.PidFile, "pidfile", "/var/run/ptp4u.pid", "Pid file location")
-	flag.StringVar(&c.TimestampType, "timestamptype", timestamp.HWTIMESTAMP, fmt.Sprintf("Timestamp type. Can be: %s, %s", timestamp.HWTIMESTAMP, timestamp.SWTIMESTAMP))
+	flag.TextVar(&c.TimestampType, "timestamptype", timestamp.HW, fmt.Sprintf("Timestamp type. Can be: %s, %s", timestamp.HW, timestamp.SW))
 	flag.StringVar(&ipaddr, "ip", "::", "IP to bind on")
 	flag.StringVar(&c.DrainFileName, "drainfile", "/var/tmp/kill_ptp4u", "ptp4u drain file location")
 	flag.StringVar(&c.UndrainFileName, "undrainfile", "/var/tmp/unkill_ptp4u", "ptp4u force undrain file location")
@@ -94,10 +94,10 @@ func main() {
 	}
 
 	switch c.TimestampType {
-	case timestamp.SWTIMESTAMP:
+	case timestamp.SW:
 		log.Warning("Software timestamps greatly reduce the precision")
 		fallthrough
-	case timestamp.HWTIMESTAMP:
+	case timestamp.HW:
 		log.Debugf("Using %s timestamps", c.TimestampType)
 	default:
 		log.Fatalf("Unrecognized timestamp type: %s", c.TimestampType)

--- a/cmd/ptpcheck/cmd/trace.go
+++ b/cmd/ptpcheck/cmd/trace.go
@@ -28,19 +28,20 @@ import (
 	"github.com/spf13/cobra"
 
 	client "github.com/facebook/time/ptp/simpleclient"
+	"github.com/facebook/time/timestamp"
 )
 
 var traceRemoteServerFlag string
 var traceDurationFlag time.Duration
 var traceTimeoutFlag time.Duration
 var traceIfaceFlag string
-var traceTimestampingFlag string
+var traceTimestampingFlag timestamp.Timestamp
 
 func init() {
 	RootCmd.AddCommand(traceCmd)
 	traceCmd.Flags().StringVarP(&traceRemoteServerFlag, "server", "S", "", "remote PTP server to connect to")
 	traceCmd.Flags().StringVarP(&traceIfaceFlag, "iface", "i", "eth0", "network interface to use")
-	traceCmd.Flags().StringVarP(&traceTimestampingFlag, "timestamping", "T", "", fmt.Sprintf("timestamping to use, either %q or %q. empty means auto-detection", client.HWTIMESTAMP, client.SWTIMESTAMP))
+	traceCmd.Flags().VarP(&traceTimestampingFlag, "timestamping", "T", fmt.Sprintf("timestamping to use, either %q or %q", timestamp.HW, timestamp.SW))
 	traceCmd.Flags().DurationVarP(&traceTimeoutFlag, "timeout", "t", 15*time.Second, "global timeout")
 	traceCmd.Flags().DurationVarP(&traceDurationFlag, "duration", "d", 10*time.Second, "duration of the exchange")
 }

--- a/ntp/responder/server/config.go
+++ b/ntp/responder/server/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	RefID          string
 	ShouldAnnounce bool
 	Stratum        int
-	TimestampType  string
+	TimestampType  timestamp.Timestamp
 	Workers        int
 	phcOffset      time.Duration
 }
@@ -80,8 +80,8 @@ func (c *Config) Validate() error {
 	if c.Workers < 1 {
 		return fmt.Errorf("will not start without workers")
 	}
-	if c.TimestampType != timestamp.HWTIMESTAMP && c.TimestampType != timestamp.SWTIMESTAMP {
-		return fmt.Errorf("invalid timestamp type %s", c.TimestampType)
+	if c.TimestampType != timestamp.HWRX && c.TimestampType != timestamp.SWRX {
+		return fmt.Errorf("unsupported timestamp type %s", c.TimestampType)
 	}
 	return nil
 }

--- a/ntp/responder/server/config_test.go
+++ b/ntp/responder/server/config_test.go
@@ -64,7 +64,7 @@ func TestConfigSetDefault(t *testing.T) {
 }
 
 func TestConfigValidate(t *testing.T) {
-	c := Config{Workers: 42, TimestampType: timestamp.SWTIMESTAMP}
+	c := Config{Workers: 42, TimestampType: timestamp.SWRX}
 	require.NoError(t, c.Validate())
 
 	// Workers
@@ -73,9 +73,9 @@ func TestConfigValidate(t *testing.T) {
 	c.Workers = 42
 
 	// Timestamp type
-	c.TimestampType = "bad"
+	c.TimestampType = 42
 	require.Error(t, c.Validate())
-	c.TimestampType = timestamp.HWTIMESTAMP
+	c.TimestampType = timestamp.HWRX
 
 	require.NoError(t, c.Validate())
 }

--- a/ntp/responder/server/server.go
+++ b/ntp/responder/server/server.go
@@ -100,7 +100,7 @@ func (s *Server) Start(ctx context.Context, cancelFunc context.CancelFunc) {
 	}()
 
 	// Run PHC-SYS offset periodically
-	if s.Config.TimestampType == timestamp.HWTIMESTAMP {
+	if s.Config.TimestampType == timestamp.HWRX {
 		log.Infof("Starting periodic measurement between phc and sysclock")
 		go func() {
 			for ; ; time.Sleep(time.Second) {
@@ -179,7 +179,7 @@ func (s *Server) startListener(conn *net.UDPConn) {
 			continue
 		}
 
-		if s.Config.TimestampType == timestamp.HWTIMESTAMP {
+		if s.Config.TimestampType == timestamp.HWRX {
 			rxTS = rxTS.Add(s.Config.phcOffset)
 		}
 

--- a/ntp/responder/server/server_test.go
+++ b/ntp/responder/server/server_test.go
@@ -114,7 +114,7 @@ func TestListener(t *testing.T) {
 			ExpectedListeners: 1,
 			ExpectedWorkers:   0,
 		},
-		Config: Config{Workers: 42, TimestampType: timestamp.SWTIMESTAMP},
+		Config: Config{Workers: 42, TimestampType: timestamp.SW},
 	}
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	require.Nil(t, err)
@@ -163,7 +163,7 @@ func TestServer(t *testing.T) {
 		},
 		Stats:  &stats.JSONStats{},
 		tasks:  make(chan task, workers),
-		Config: Config{Workers: workers, TimestampType: timestamp.SWTIMESTAMP},
+		Config: Config{Workers: workers, TimestampType: timestamp.SW},
 	}
 	// create workers
 	for i := 0; i < workers; i++ {

--- a/ptp/ptp4u/server/config.go
+++ b/ptp/ptp4u/server/config.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	ptp "github.com/facebook/time/ptp/protocol"
+	"github.com/facebook/time/timestamp"
 	"golang.org/x/sys/unix"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -54,7 +55,7 @@ type StaticConfig struct {
 	QueueSize       int
 	RecvWorkers     int
 	SendWorkers     int
-	TimestampType   string
+	TimestampType   timestamp.Timestamp
 	UndrainFileName string
 }
 

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -261,7 +261,7 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 			log.Errorf("Failed to read packet on %s: %v", eventConn.LocalAddr(), err)
 			continue
 		}
-		if s.Config.TimestampType != timestamp.HWTIMESTAMP {
+		if s.Config.TimestampType != timestamp.HW {
 			rxTS = rxTS.Add(s.Config.UTCOffset)
 		}
 

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -36,7 +36,7 @@ func TestFindWorker(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
-			TimestampType: timestamp.SWTIMESTAMP,
+			TimestampType: timestamp.SW,
 			SendWorkers:   10,
 		},
 	}
@@ -79,7 +79,7 @@ func TestStartEventListener(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
-			TimestampType: timestamp.SWTIMESTAMP,
+			TimestampType: timestamp.SW,
 			SendWorkers:   10,
 			RecvWorkers:   10,
 			IP:            net.ParseIP("127.0.0.1"),
@@ -99,7 +99,7 @@ func TestStartGeneralListener(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
-			TimestampType: timestamp.SWTIMESTAMP,
+			TimestampType: timestamp.SW,
 			SendWorkers:   10,
 			RecvWorkers:   10,
 			IP:            net.ParseIP("127.0.0.1"),

--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -174,7 +174,7 @@ func (s *sendWorker) Start() {
 					log.Warningf("Failed to read TX timestamp: %v", err)
 					continue
 				}
-				if s.config.TimestampType != timestamp.HWTIMESTAMP {
+				if s.config.TimestampType != timestamp.HW {
 					txTS = txTS.Add(s.config.UTCOffset)
 				}
 
@@ -248,7 +248,7 @@ func (s *sendWorker) Start() {
 					log.Warningf("Failed to read TX timestamp: %v", err)
 					continue
 				}
-				if s.config.TimestampType != timestamp.HWTIMESTAMP {
+				if s.config.TimestampType != timestamp.HW {
 					txTS = txTS.Add(s.config.UTCOffset)
 				}
 

--- a/ptp/ptp4u/server/worker_test.go
+++ b/ptp/ptp4u/server/worker_test.go
@@ -32,7 +32,7 @@ func TestWorkerQueue(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
-			TimestampType: timestamp.SWTIMESTAMP,
+			TimestampType: timestamp.SW,
 		},
 	}
 
@@ -87,7 +87,7 @@ func TestFindSubscription(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
-			TimestampType: timestamp.SWTIMESTAMP,
+			TimestampType: timestamp.SW,
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestFindClients(t *testing.T) {
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
-			TimestampType: timestamp.SWTIMESTAMP,
+			TimestampType: timestamp.SW,
 		},
 	}
 

--- a/ptp/simpleclient/client.go
+++ b/ptp/simpleclient/client.go
@@ -31,14 +31,6 @@ import (
 	"github.com/facebook/time/timestamp"
 )
 
-// re-export timestamping
-const (
-	// HWTIMESTAMP is a hardware timestamp
-	HWTIMESTAMP = timestamp.HWTIMESTAMP
-	// SWTIMESTAMP is a software timestamp
-	SWTIMESTAMP = timestamp.SWTIMESTAMP
-)
-
 type state int
 
 const (
@@ -117,7 +109,7 @@ type Config struct {
 	// for how long we'll request unicast transmission from server
 	Duration time.Duration
 	// what type of typestamping to use
-	Timestamping string
+	Timestamping timestamp.Timestamp
 }
 
 // Client is a very simplified PTPv2 unicast client.

--- a/ptp/sptp/client/config.go
+++ b/ptp/sptp/client/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	ptp "github.com/facebook/time/ptp/protocol"
+	"github.com/facebook/time/timestamp"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -76,7 +77,7 @@ func (c *MeasurementConfig) Validate() error {
 // Config specifies SPTP run options
 type Config struct {
 	Iface                    string
-	Timestamping             string
+	Timestamping             timestamp.Timestamp
 	MonitoringPort           int
 	Interval                 time.Duration
 	ExchangeTimeout          time.Duration
@@ -105,7 +106,7 @@ func DefaultConfig() *Config {
 		MetricsAggregationWindow: time.Duration(60) * time.Second,
 		AttemptsTXTS:             10,
 		TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-		Timestamping:             HWTIMESTAMP,
+		Timestamping:             timestamp.HW,
 		Measurement: MeasurementConfig{
 			PathDelayDiscardAbove: time.Second,
 		},
@@ -144,8 +145,8 @@ func (c *Config) Validate() error {
 	if len(c.Servers) == 0 {
 		return fmt.Errorf("at least one server must be specified")
 	}
-	if c.Timestamping != HWTIMESTAMP && c.Timestamping != SWTIMESTAMP {
-		return fmt.Errorf("only %q and %q timestamping is supported", HWTIMESTAMP, SWTIMESTAMP)
+	if c.Timestamping != timestamp.HW && c.Timestamping != timestamp.SW {
+		return fmt.Errorf("only %q and %q timestamping is supported", timestamp.HW, timestamp.SW)
 	}
 	if c.Iface == "" {
 		return fmt.Errorf("iface must be specified")

--- a/ptp/sptp/client/config_test.go
+++ b/ptp/sptp/client/config_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/facebook/time/timestamp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,7 @@ func TestReadConfigDefaults(t *testing.T) {
 		MetricsAggregationWindow: time.Duration(60) * time.Second,
 		AttemptsTXTS:             10,
 		TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-		Timestamping:             HWTIMESTAMP,
+		Timestamping:             timestamp.HW,
 		MaxClockClass:            7,
 		MaxClockAccuracy:         37,
 		Measurement: MeasurementConfig{
@@ -83,7 +84,7 @@ measurement:
 	require.NoError(t, err)
 	want := &Config{
 		Iface:                    "eth0",
-		Timestamping:             "hardware",
+		Timestamping:             timestamp.HW,
 		MonitoringPort:           4269,
 		Interval:                 time.Second,
 		ExchangeTimeout:          200 * time.Millisecond,
@@ -243,7 +244,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -261,7 +262,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -279,7 +280,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -299,7 +300,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -319,7 +320,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -339,7 +340,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -357,7 +358,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             -10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -375,7 +376,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(-50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -393,7 +394,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(-60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -411,7 +412,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -430,7 +431,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -449,7 +450,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             "blah",
+				Timestamping:             42,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -467,7 +468,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -485,7 +486,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -503,7 +504,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -524,7 +525,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -548,7 +549,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -569,7 +570,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            2,
 				MaxClockAccuracy:         37,
 				Servers: map[string]int{
@@ -590,7 +591,7 @@ func TestConfigValidate(t *testing.T) {
 				MetricsAggregationWindow: time.Duration(60) * time.Second,
 				AttemptsTXTS:             10,
 				TimeoutTXTS:              time.Duration(50) * time.Millisecond,
-				Timestamping:             HWTIMESTAMP,
+				Timestamping:             timestamp.HW,
 				MaxClockClass:            7,
 				MaxClockAccuracy:         10,
 				Servers: map[string]int{
@@ -648,7 +649,7 @@ measurement:
 	require.NoError(t, err)
 	want := &Config{
 		Iface:                    "eth1",
-		Timestamping:             "hardware",
+		Timestamping:             timestamp.HW,
 		MonitoringPort:           3456,
 		Interval:                 2 * time.Second,
 		ExchangeTimeout:          200 * time.Millisecond,
@@ -680,7 +681,7 @@ func TestPrepareConfigDefaults(t *testing.T) {
 	require.NoError(t, err)
 	want := &Config{
 		Iface:                    "eth1",
-		Timestamping:             "hardware",
+		Timestamping:             timestamp.HW,
 		MonitoringPort:           3456,
 		Interval:                 2 * time.Second,
 		ExchangeTimeout:          100 * time.Millisecond,

--- a/ptp/sptp/client/connection.go
+++ b/ptp/sptp/client/connection.go
@@ -27,14 +27,6 @@ import (
 	"github.com/facebook/time/timestamp"
 )
 
-// re-export timestamping
-const (
-	// HWTIMESTAMP is a hardware timestamp
-	HWTIMESTAMP = timestamp.HWTIMESTAMP
-	// SWTIMESTAMP is a software timestamp
-	SWTIMESTAMP = timestamp.SWTIMESTAMP
-)
-
 // UDPConn describes what functionality we expect from UDP connection
 type UDPConn interface {
 	ReadFromUDP(b []byte) (int, *net.UDPAddr, error)

--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -157,7 +157,7 @@ func (p *SPTP) init() error {
 		log.Warningf("operating in FreeRunning mode, will NOT adjust clock")
 		p.clock = &FreeRunningClock{}
 	} else {
-		if p.cfg.Timestamping == HWTIMESTAMP {
+		if p.cfg.Timestamping == timestamp.HW {
 			phcDev, err := NewPHC(p.cfg.Iface)
 			if err != nil {
 				return err

--- a/timestamp/timestamp_darwin.go
+++ b/timestamp/timestamp_darwin.go
@@ -68,9 +68,9 @@ func EnableSWTimestampsRx(connFd int) error {
 }
 
 // EnableTimestamps enables timestamps on the socket based on requested type
-func EnableTimestamps(ts string, connFd int, _ string) error {
+func EnableTimestamps(ts Timestamp, connFd int, _ string) error {
 	switch ts {
-	case SWTIMESTAMP:
+	case SW:
 		if err := EnableSWTimestampsRx(connFd); err != nil {
 			return fmt.Errorf("Cannot enable software timestamps: %w", err)
 		}

--- a/timestamp/timestamp_darwin_test.go
+++ b/timestamp/timestamp_darwin_test.go
@@ -67,7 +67,7 @@ func TestEnableTimestamps(t *testing.T) {
 
 	// SOFTWARE
 	// Allow reading of kernel timestamps via socket
-	err = EnableTimestamps(SWTIMESTAMP, connFd, "lo")
+	err = EnableTimestamps(SW, connFd, "lo")
 	require.NoError(t, err)
 
 	// Check that socket option is set
@@ -78,8 +78,8 @@ func TestEnableTimestamps(t *testing.T) {
 	require.Greater(t, kernelTimestampsEnabled, 0, "Kernel timestamps are not enabled")
 
 	// HARDWARE
-	err = EnableTimestamps(HWTIMESTAMP, connFd, "lo")
-	require.Equal(t, fmt.Errorf("Unrecognized timestamp type: %s", HWTIMESTAMP), err)
+	err = EnableTimestamps(HW, connFd, "lo")
+	require.Equal(t, fmt.Errorf("Unrecognized timestamp type: %s", HW), err)
 }
 
 func TestReadPacketWithRXTimestamp(t *testing.T) {

--- a/timestamp/timestamp_freebsd.go
+++ b/timestamp/timestamp_freebsd.go
@@ -68,9 +68,9 @@ func EnableSWTimestampsRx(connFd int) error {
 }
 
 // EnableTimestamps enables timestamps on the socket based on requested type
-func EnableTimestamps(ts string, connFd int, _ string) error {
+func EnableTimestamps(ts Timestamp, connFd int, _ string) error {
 	switch ts {
-	case SWTIMESTAMP:
+	case SW:
 		if err := EnableSWTimestampsRx(connFd); err != nil {
 			return fmt.Errorf("Cannot enable software timestamps: %w", err)
 		}

--- a/timestamp/timestamp_freebsd_test.go
+++ b/timestamp/timestamp_freebsd_test.go
@@ -67,7 +67,7 @@ func TestEnableTimestamps(t *testing.T) {
 
 	// SOFTWARE
 	// Allow reading of kernel timestamps via socket
-	err = EnableTimestamps(SWTIMESTAMP, connFd, "lo")
+	err = EnableTimestamps(SW, connFd, "lo")
 	require.NoError(t, err)
 
 	// Check that socket option is set
@@ -78,8 +78,8 @@ func TestEnableTimestamps(t *testing.T) {
 	require.Greater(t, kernelTimestampsEnabled, 0, "Kernel timestamps are not enabled")
 
 	// HARDWARE
-	err = EnableTimestamps(HWTIMESTAMP, connFd, "lo")
-	require.Equal(t, fmt.Errorf("Unrecognized timestamp type: %s", HWTIMESTAMP), err)
+	err = EnableTimestamps(HW, connFd, "lo")
+	require.Equal(t, fmt.Errorf("Unrecognized timestamp type: %s", HW), err)
 }
 
 func TestReadPacketWithRXTimestamp(t *testing.T) {

--- a/timestamp/timestamp_linux_test.go
+++ b/timestamp/timestamp_linux_test.go
@@ -207,7 +207,7 @@ func TestEnableTimestamps(t *testing.T) {
 
 	// SOFTWARE
 	// Allow reading of kernel timestamps via socket
-	err = EnableTimestamps(SWTIMESTAMP, connFd, "lo")
+	err = EnableTimestamps(SW, connFd, "lo")
 	require.NoError(t, err)
 
 	// Check that socket option is set
@@ -217,8 +217,20 @@ func TestEnableTimestamps(t *testing.T) {
 	// At least one of them should be set, which it > 0
 	require.Greater(t, timestampsEnabled+newTimestampsEnabled, 0, "None of the socket options is set")
 
+	// SOFTWARE_RX
+	// Allow reading of kernel timestamps via socket
+	err = EnableTimestamps(SWRX, connFd, "lo")
+	require.NoError(t, err)
+
+	// Check that socket option is set
+	timestampsEnabled, _ = unix.GetsockoptInt(connFd, unix.SOL_SOCKET, unix.SO_TIMESTAMPING)
+	newTimestampsEnabled, _ = unix.GetsockoptInt(connFd, unix.SOL_SOCKET, unix.SO_TIMESTAMPING_NEW)
+
+	// At least one of them should be set, which it > 0
+	require.Greater(t, timestampsEnabled+newTimestampsEnabled, 0, "None of the socket options is set")
+
 	// Unsupported
-	err = EnableTimestamps("Unsupported", connFd, "lo")
+	err = EnableTimestamps(42, connFd, "lo")
 	require.Equal(t, fmt.Errorf("Unrecognized timestamp type: Unsupported"), err)
 }
 

--- a/timestamp/timestamp_test.go
+++ b/timestamp/timestamp_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package timestamp
 
 import (
+	"errors"
 	"net"
 	"testing"
 
@@ -87,4 +88,57 @@ func TestSockaddrToPort(t *testing.T) {
 
 	require.Equal(t, port, SockaddrToPort(sa4))
 	require.Equal(t, port, SockaddrToPort(sa6))
+}
+
+func TestTimestampUnmarshalText(t *testing.T) {
+	var ts Timestamp
+	require.Equal(t, "timestamp", ts.Type())
+
+	err := ts.UnmarshalText([]byte("hardware"))
+	require.NoError(t, err)
+	require.Equal(t, HW, ts)
+	require.Equal(t, HW.String(), ts.String())
+
+	err = ts.UnmarshalText([]byte("hardware_rx"))
+	require.NoError(t, err)
+	require.Equal(t, HWRX, ts)
+	require.Equal(t, HWRX.String(), ts.String())
+
+	err = ts.UnmarshalText([]byte("software"))
+	require.NoError(t, err)
+	require.Equal(t, SW, ts)
+	require.Equal(t, SW.String(), ts.String())
+
+	err = ts.UnmarshalText([]byte("software_rx"))
+	require.NoError(t, err)
+	require.Equal(t, SWRX, ts)
+	require.Equal(t, SWRX.String(), ts.String())
+
+	err = ts.UnmarshalText([]byte("nope"))
+	require.Equal(t, errors.New("unknown timestamp type \"nope\""), err)
+	// Check we didn't change the value
+	require.Equal(t, SWRX, ts)
+}
+
+func TestTimestampMarshalText(t *testing.T) {
+	text, err := HW.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "hardware", string(text))
+
+	text, err = HWRX.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "hardware_rx", string(text))
+
+	text, err = SW.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "software", string(text))
+
+	text, err = SWRX.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "software_rx", string(text))
+
+	require.Equal(t, Unsupported, Timestamp(42).String())
+	text, err = Timestamp(42).MarshalText()
+	require.Equal(t, errors.New("unknown timestamp type \"Unsupported\""), err)
+	require.Equal(t, "Unsupported", string(text))
 }


### PR DESCRIPTION
Summary:
Responder doesn't need TX timestamps which only slows it down.
Instead, make Timestamp a type

Reviewed By: abulimov, yarikk

Differential Revision: D56465553


