### PR TITLE
reduce heap allocations #3

### DIFF
--- a/ptp/sptp/client/connection.go
+++ b/ptp/sptp/client/connection.go
@@ -39,7 +39,7 @@ type UDPConn interface {
 type UDPConnWithTS interface {
 	UDPConn
 	WriteToWithTS(b []byte, addr net.Addr) (int, time.Time, error)
-	ReadPacketWithRXTimestamp() ([]byte, unix.Sockaddr, time.Time, error)
+	ReadPacketWithRXTimestampBuf(buf, oob []byte) (int, unix.Sockaddr, time.Time, error)
 }
 
 // UDPConnTS is a wrapper around udp connection and a corresponding fd
@@ -110,7 +110,7 @@ func (c *UDPConnTS) WriteToWithTS(b []byte, addr net.Addr) (int, time.Time, erro
 	return n, hwts, nil
 }
 
-// ReadPacketWithRXTimestamp reads bytes and a timestamp from underlying fd
-func (c *UDPConnTS) ReadPacketWithRXTimestamp() ([]byte, unix.Sockaddr, time.Time, error) {
-	return timestamp.ReadPacketWithRXTimestamp(c.connFd)
+// ReadPacketWithRXTimestampBuf reads bytes and a timestamp from underlying fd
+func (c *UDPConnTS) ReadPacketWithRXTimestampBuf(buf, oob []byte) (int, unix.Sockaddr, time.Time, error) {
+	return timestamp.ReadPacketWithRXTimestampBuf(c.connFd, buf, oob)
 }

--- a/ptp/sptp/client/udpconn_mock_test.go
+++ b/ptp/sptp/client/udpconn_mock_test.go
@@ -150,21 +150,21 @@ func (mr *MockUDPConnWithTSMockRecorder) ReadFromUDP(b interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFromUDP", reflect.TypeOf((*MockUDPConnWithTS)(nil).ReadFromUDP), b)
 }
 
-// ReadPacketWithRXTimestamp mocks base method.
-func (m *MockUDPConnWithTS) ReadPacketWithRXTimestamp() ([]byte, unix.Sockaddr, time.Time, error) {
+// ReadPacketWithRXTimestampBuf mocks base method.
+func (m *MockUDPConnWithTS) ReadPacketWithRXTimestampBuf(buf, oob []byte) (int, unix.Sockaddr, time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPacketWithRXTimestamp")
-	ret0, _ := ret[0].([]byte)
+	ret := m.ctrl.Call(m, "ReadPacketWithRXTimestampBuf", buf, oob)
+	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(unix.Sockaddr)
 	ret2, _ := ret[2].(time.Time)
 	ret3, _ := ret[3].(error)
 	return ret0, ret1, ret2, ret3
 }
 
-// ReadPacketWithRXTimestamp indicates an expected call of ReadPacketWithRXTimestamp.
-func (mr *MockUDPConnWithTSMockRecorder) ReadPacketWithRXTimestamp() *gomock.Call {
+// ReadPacketWithRXTimestampBuf indicates an expected call of ReadPacketWithRXTimestampBuf.
+func (mr *MockUDPConnWithTSMockRecorder) ReadPacketWithRXTimestampBuf(buf, oob interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPacketWithRXTimestamp", reflect.TypeOf((*MockUDPConnWithTS)(nil).ReadPacketWithRXTimestamp))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPacketWithRXTimestampBuf", reflect.TypeOf((*MockUDPConnWithTS)(nil).ReadPacketWithRXTimestampBuf), buf, oob)
 }
 
 // WriteTo mocks base method.


### PR DESCRIPTION
Summary: Reuse buffer. Because we have async channels we have to use the buffer pool.

Reviewed By: abulimov

Differential Revision: D58257616
