### PR TITLE
Allow specifying build directory for fbclock.so

### DIFF
--- a/fbclock/Makefile
+++ b/fbclock/Makefile
@@ -5,8 +5,11 @@ CPPFLAGS=-fpermissive -lrt -lpthread -msse4.2 -lgtest -g
 
 .PHONY: clean test
 
+BUILDDIR ?= .
+
 fbclock:
-	$(CC) $(CFLAGS) -shared -o fbclock.so -fPIC fbclock.c 
+	mkdir -p $(BUILDDIR)
+	$(CC) $(CFLAGS) -shared -o $(BUILDDIR)/fbclock.so -fPIC fbclock.c
 
 test:
 	$(CPP) $(CPPFLAGS) -o fbclock-test test/test.cpp fbclock.c


### PR DESCRIPTION
Summary: This allows fbclock.so to be built in specified directory, which helps with later changes to build with nccl.

Differential Revision: D58228662
