### PR TITLE
reduce heap allocations #11

### DIFF
--- a/cmd/ptpcheck/cmd/phcdiff.go
+++ b/cmd/ptpcheck/cmd/phcdiff.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/facebook/time/phc"
@@ -46,11 +47,22 @@ func init() {
 }
 
 func phcdiffRun(deviceA, deviceB string, isJSON bool) error {
-	extendedA, err := phc.ReadPTPSysOffsetExtended(deviceA, phc.ExtendedNumProbes)
+	a, err := os.Open(deviceA)
+	if err != nil {
+		return fmt.Errorf("opening device %q to set frequency: %w", deviceA, err)
+	}
+	defer a.Close()
+	b, err := os.Open(deviceB)
+	if err != nil {
+		return fmt.Errorf("opening device %q to set frequency: %w", deviceB, err)
+	}
+	defer b.Close()
+
+	extendedA, err := phc.ReadPTPSysOffsetExtended(a, phc.ExtendedNumProbes)
 	if err != nil {
 		return err
 	}
-	extendedB, err := phc.ReadPTPSysOffsetExtended(deviceB, phc.ExtendedNumProbes)
+	extendedB, err := phc.ReadPTPSysOffsetExtended(b, phc.ExtendedNumProbes)
 	if err != nil {
 		return err
 	}

--- a/ptp/c4u/clock/ts2phc.go
+++ b/ptp/c4u/clock/ts2phc.go
@@ -17,8 +17,10 @@ limitations under the License.
 package clock
 
 import (
-	"github.com/facebook/time/phc"
+	"os"
 	"time"
+
+	"github.com/facebook/time/phc"
 )
 
 const (
@@ -27,5 +29,17 @@ const (
 )
 
 func ts2phc() (time.Duration, error) {
-	return phc.OffsetBetweenDevices(phcTimeCardPath, phcNICPath)
+	a, err := os.Open(phcTimeCardPath)
+	if err != nil {
+		return 0, err
+	}
+	defer a.Close()
+
+	b, err := os.Open(phcNICPath)
+	if err != nil {
+		return 0, err
+	}
+	defer b.Close()
+
+	return phc.OffsetBetweenDevices(a, b)
 }

--- a/ptp/sptp/client/clock.go
+++ b/ptp/sptp/client/clock.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/facebook/time/clock"
@@ -37,38 +38,45 @@ type Clock interface {
 
 // PHC groups methods for interactions with PHC devices
 type PHC struct {
-	devicePath string
+	device *os.File
 }
 
 // NewPHC creates new PHC device abstraction from network interface name
 func NewPHC(iface string) (*PHC, error) {
-	device, err := phc.IfaceToPHCDevice(iface)
+	devicePath, err := phc.IfaceToPHCDevice(iface)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map iface to device: %w", err)
 	}
+
+	// Keep file open for the lifetime of the sptp
+	f, err := os.OpenFile(devicePath, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening device %s error: %w", devicePath, err)
+	}
+
 	return &PHC{
-		devicePath: device,
+		device: f,
 	}, nil
 }
 
 // AdjFreqPPB adjusts PHC frequency
 func (p *PHC) AdjFreqPPB(freq float64) error {
-	return phc.ClockAdjFreq(p.devicePath, freq)
+	return phc.ClockAdjFreq(p.device, freq)
 }
 
 // Step jumps time on PHC
 func (p *PHC) Step(step time.Duration) error {
-	return phc.ClockStep(p.devicePath, step)
+	return phc.ClockStep(p.device, step)
 }
 
 // FrequencyPPB returns current PHC frequency
 func (p *PHC) FrequencyPPB() (float64, error) {
-	return phc.FrequencyPPBFromDevice(p.devicePath)
+	return phc.FrequencyPPBFromDevice(p.device)
 }
 
 // MaxFreqPPB returns maximum frequency adjustment supported by PHC
 func (p *PHC) MaxFreqPPB() (float64, error) {
-	return phc.MaxFreqAdjPPBFromDevice(p.devicePath)
+	return phc.MaxFreqAdjPPBFromDevice(p.device)
 }
 
 // SetSync is a no-op for PHC


### PR DESCRIPTION
Summary: By not openning/closing device every time we read/adjust we will not just save tons of allocations, we will actually prevent "hangups" on the kernel IO open/close syscalls.

Reviewed By: abulimov, vvfedorenko

Differential Revision: D58465569
