### PR TITLE
use proper type of error code for hard failure check

### DIFF
--- a/calnex/export/export.go
+++ b/calnex/export/export.go
@@ -19,6 +19,7 @@ package export
 import (
 	"errors"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/facebook/time/calnex/api"
@@ -31,8 +32,14 @@ var errNoTarget = errors.New("no target succeeds")
 // returns true if the error is a hard failure
 func isHardFailure(err error) bool {
 	var opErr *net.OpError
+	var urlErr *url.Error
 	if errors.As(err, &opErr) {
 		if opErr.Timeout() || !opErr.Temporary() {
+			return true
+		}
+	}
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() || !urlErr.Temporary() {
 			return true
 		}
 	}


### PR DESCRIPTION
Summary:
http.Client returns errors of type *url.Error which is no longer *net.OpErr
add check for this type of errors in isHardFailure() check

Differential Revision: D58670925
