### PR TITLE
[chrony] Add support for new serverstats format introduced in chrony 4.4

### DIFF
--- a/cmd/ntpcheck/checker/chrony.go
+++ b/cmd/ntpcheck/checker/chrony.go
@@ -182,6 +182,8 @@ func (n *ChronyCheck) ServerStats() (*ServerStats, error) {
 		serverStats = NewServerStatsFromChrony2(stats)
 	case *chrony.ReplyServerStats3:
 		serverStats = NewServerStatsFromChrony3(stats)
+	case *chrony.ReplyServerStats4:
+		serverStats = NewServerStatsFromChrony4(stats)
 	default:
 		return nil, errors.Errorf("Got wrong 'serverstats' response %+v", packet)
 	}

--- a/cmd/ntpcheck/checker/serverstats.go
+++ b/cmd/ntpcheck/checker/serverstats.go
@@ -79,3 +79,11 @@ func NewServerStatsFromChrony3(s *chrony.ReplyServerStats3) *ServerStats {
 		PacketsDropped:  uint64(s.NTPDrops),
 	}
 }
+
+// NewServerStatsFromChrony4 constructs ServerStats from chrony ServerStats4 packet
+func NewServerStatsFromChrony4(s *chrony.ReplyServerStats4) *ServerStats {
+	return &ServerStats{
+		PacketsReceived: s.NTPHits,
+		PacketsDropped:  s.NTPDrops,
+	}
+}

--- a/ntp/chrony/packet.go
+++ b/ntp/chrony/packet.go
@@ -92,6 +92,7 @@ const (
 	rpyNTPSourceName ReplyType = 19
 	rpyServerStats2  ReplyType = 22
 	rpyServerStats3  ReplyType = 24
+	rpyServerStats4  ReplyType = 25
 )
 
 // source modes
@@ -697,6 +698,33 @@ type ReplyServerStats3 struct {
 	ServerStats3
 }
 
+// ServerStats4 contains parsed version of 'serverstats4' reply
+type ServerStats4 struct {
+	NTPHits               uint64
+	NKEHits               uint64
+	CMDHits               uint64
+	NTPDrops              uint64
+	NKEDrops              uint64
+	CMDDrops              uint64
+	LogDrops              uint64
+	NTPAuthHits           uint64
+	NTPInterleavedHits    uint64
+	NTPTimestamps         uint64
+	NTPSpanSeconds        uint64
+	NTPDaemonRxtimestamps uint64
+	NTPDaemonTxtimestamps uint64
+	NTPKernelRxtimestamps uint64
+	NTPKernelTxtimestamps uint64
+	NTPHwRxTimestamps     uint64
+	NTPHwTxTimestamps     uint64
+}
+
+// ReplyServerStats4 is a usable version of 'serverstats4' response
+type ReplyServerStats4 struct {
+	ReplyHead
+	ServerStats4
+}
+
 // here go request constructors
 
 // NewSourcesPacket creates new packet to request number of sources (peers)
@@ -911,6 +939,16 @@ func decodePacket(response []byte) (ResponsePacket, error) {
 		return &ReplyServerStats3{
 			ReplyHead:    *head,
 			ServerStats3: *data,
+		}, nil
+	case rpyServerStats4:
+		data := new(ServerStats4)
+		if err = binary.Read(r, binary.BigEndian, data); err != nil {
+			return nil, err
+		}
+		log.Debugf("response data: %+v", data)
+		return &ReplyServerStats4{
+			ReplyHead:    *head,
+			ServerStats4: *data,
 		}, nil
 	default:
 		return nil, fmt.Errorf("not implemented reply type %d from %+v", head.Reply, head)


### PR DESCRIPTION
Adds support for the new serverstats format `RPY_SERVER_STATS4` introduced in commits [0845df76](https://gitlab.com/chrony/chrony/-/commit/0845df7684f4597ab9ff7a6e9aadf01895b93887)  and [5508b01b](https://gitlab.com/chrony/chrony/-/commit/5508b01bd8802cdd0b731fcafd42b7f64e1f18c5) in the `chrony` repository and included in `chrony` [release 4.4](https://gitlab.com/chrony/chrony/-/blob/master/NEWS#L15-39):

```
New in version 4.4
==================
...
* Add timestamp sources to serverstats report and make its fields 64-bit
...
```

Resolves #363.