### PR TITLE
use netip.Addr in sptp to reduce heap allocations

### DIFF
--- a/cmd/ptpcheck/cmd/ptping.go
+++ b/cmd/ptpcheck/cmd/ptping.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/facebook/time/dscp"
@@ -65,7 +66,7 @@ func (t *timestamps) reset() {
 type ptping struct {
 	iface  string
 	dscp   int
-	target string
+	target netip.Addr
 
 	clockID   ptp.ClockIdentity
 	eventConn client.UDPConnWithTS
@@ -171,9 +172,13 @@ func (p *ptping) runReader() error {
 func ptpingRun(iface string, dscp int, server string, count int, timeout time.Duration) error {
 	var err error
 	p := &ptping{
-		iface:  iface,
-		dscp:   dscp,
-		target: server,
+		iface: iface,
+		dscp:  dscp,
+	}
+
+	p.target, err = netip.ParseAddr(server)
+	if err != nil {
+		return err
 	}
 
 	if err = p.init(); err != nil {

--- a/ptp/sptp/client/bmca.go
+++ b/ptp/sptp/client/bmca.go
@@ -17,12 +17,14 @@ limitations under the License.
 package client
 
 import (
+	"net/netip"
+
 	ptp "github.com/facebook/time/ptp/protocol"
 
 	"github.com/facebook/time/ptp/sptp/bmc"
 )
 
-func bmca(results map[string]*RunResult, prios map[ptp.ClockIdentity]int, cfg *Config) *ptp.Announce {
+func bmca(results map[netip.Addr]*RunResult, prios map[ptp.ClockIdentity]int, cfg *Config) *ptp.Announce {
 	if len(results) == 0 {
 		return nil
 	}

--- a/ptp/sptp/client/client.go
+++ b/ptp/sptp/client/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	rnd "math/rand"
 	"net"
+	"net/netip"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -71,14 +72,14 @@ func ReqAnnounce(clockID ptp.ClockIdentity, portID uint16, ts time.Time) *ptp.An
 
 // RunResult is what we return from single client-server interaction
 type RunResult struct {
-	Server      string
+	Server      netip.Addr
 	Measurement *MeasurementResult
 	Error       error
 }
 
 // Client is a part of PTPNG that talks to only one server
 type Client struct {
-	server string
+	server netip.Addr
 	// packet sequence counter
 	eventSequence uint16
 	// mask for sequence ID value
@@ -153,10 +154,10 @@ func (c *Client) SendAnnounce(p *ptp.Announce) (uint16, error) {
 }
 
 // NewClient initializes sptp client
-func NewClient(target string, targetPort int, clockID ptp.ClockIdentity, eventConn UDPConnWithTS, cfg *Config, stats StatsServer) (*Client, error) {
+func NewClient(target netip.Addr, targetPort int, clockID ptp.ClockIdentity, eventConn UDPConnWithTS, cfg *Config, stats StatsServer) (*Client, error) {
 	// addresses
 	// where to send to
-	eventAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(target, fmt.Sprintf("%d", targetPort)))
+	eventAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(target.String(), fmt.Sprintf("%d", targetPort)))
 	if err != nil {
 		return nil, err
 	}

--- a/ptp/sptp/client/client_test.go
+++ b/ptp/sptp/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -80,7 +81,7 @@ func TestClientRun(t *testing.T) {
 		},
 	}
 	statsServer := NewMockStatsServer(ctrl)
-	c, err := NewClient("127.0.0.1", ptp.PortEvent, cid, eventConn, &cfg, statsServer)
+	c, err := NewClient(netip.MustParseAddr("127.0.0.1"), ptp.PortEvent, cid, eventConn, &cfg, statsServer)
 	require.NoError(t, err)
 
 	// put stuff into measurements to make sure it got cleaned before the run
@@ -116,7 +117,7 @@ func TestClientRun(t *testing.T) {
 	runResult := c.RunOnce(ctx, defaultTestTimeout)
 	require.NotNil(t, runResult)
 	require.NoError(t, runResult.Error, "full client run should succeed")
-	require.Equal(t, "127.0.0.1", runResult.Server, "run result should have correct server")
+	require.Equal(t, netip.MustParseAddr("127.0.0.1"), runResult.Server, "run result should have correct server")
 	require.NotNil(t, runResult.Measurement, "run result should have measurements")
 	require.Equal(t, *announce, runResult.Measurement.Announce)
 	require.NotEqual(t, 0, runResult.Measurement.Delay)
@@ -143,7 +144,7 @@ func TestClientTimeout(t *testing.T) {
 		},
 	}
 	statsServer := NewMockStatsServer(ctrl)
-	c, err := NewClient("127.0.0.1", ptp.PortEvent, cid, eventConn, &cfg, statsServer)
+	c, err := NewClient(netip.MustParseAddr("127.0.0.1"), ptp.PortEvent, cid, eventConn, &cfg, statsServer)
 	require.NoError(t, err)
 	statsServer.EXPECT().IncTXDelayReq()
 	eventConn.EXPECT().WriteToWithTS(gomock.Any(), gomock.Any())
@@ -169,7 +170,7 @@ func TestClientBadPacket(t *testing.T) {
 		},
 	}
 	statsServer := NewMockStatsServer(ctrl)
-	c, err := NewClient("127.0.0.1", ptp.PortEvent, cid, eventConn, &cfg, statsServer)
+	c, err := NewClient(netip.MustParseAddr("127.0.0.1"), ptp.PortEvent, cid, eventConn, &cfg, statsServer)
 	require.NoError(t, err)
 
 	// handle whatever client is sending over eventConn
@@ -187,7 +188,7 @@ func TestClientBadPacket(t *testing.T) {
 	runResult := c.RunOnce(ctx, defaultTestTimeout)
 	require.NotNil(t, runResult)
 	require.Error(t, runResult.Error, "full client run should fail")
-	require.Equal(t, "127.0.0.1", runResult.Server, "run result should have correct server")
+	require.Equal(t, netip.MustParseAddr("127.0.0.1"), runResult.Server, "run result should have correct server")
 }
 
 func TestClientIncrementSequence(t *testing.T) {
@@ -207,7 +208,7 @@ func TestClientIncrementSequence(t *testing.T) {
 		SequenceIDMaskValue: 3,
 	}
 	statsServer := NewMockStatsServer(ctrl)
-	c, err := NewClient("127.0.0.1", ptp.PortEvent, cid, eventConn, &cfg, statsServer)
+	c, err := NewClient(netip.MustParseAddr("127.0.0.1"), ptp.PortEvent, cid, eventConn, &cfg, statsServer)
 	require.NoError(t, err)
 	require.Equal(t, uint16(0x3FFF), c.sequenceIDMask)
 	require.Equal(t, uint16(0xC000), c.sequenceIDValue)

--- a/ptp/sptp/client/connection.go
+++ b/ptp/sptp/client/connection.go
@@ -19,6 +19,7 @@ package client
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -31,7 +32,7 @@ import (
 // UDPConnNoTS describes what functionality we expect from UDP connection
 type UDPConnNoTS interface {
 	WriteTo(b []byte, addr net.Addr) (int, error)
-	ReadPacketBuf(buf []byte) (int, string, error)
+	ReadPacketBuf(buf []byte) (int, netip.Addr, error)
 	Close() error
 }
 
@@ -141,11 +142,11 @@ func (c *UDPConnTS) ReadPacketWithRXTimestampBuf(buf, oob []byte) (int, unix.Soc
 }
 
 // ReadPacketBuf reads bytes from underlying fd
-func (c *UDPConn) ReadPacketBuf(buf []byte) (int, string, error) {
+func (c *UDPConn) ReadPacketBuf(buf []byte) (int, netip.Addr, error) {
 	n, saddr, err := unix.Recvfrom(c.connFd, buf, 0)
 	if err != nil {
-		return 0, "", err
+		return 0, netip.Addr{}, err
 	}
 
-	return n, timestamp.SockaddrToIP(saddr).String(), err
+	return n, timestamp.SockaddrToAddr(saddr), err
 }

--- a/ptp/sptp/client/stats.go
+++ b/ptp/sptp/client/stats.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"net/netip"
 	"os"
 	"runtime"
 	"sync"
@@ -203,9 +204,9 @@ func (s *Stats) CollectSysStats() {
 	s.gcPauseTotalNs = int64(s.memstats.PauseTotalNs)
 }
 
-func runResultToGMStats(address string, r *RunResult, p3 int, selected bool) *gmstats.Stat {
+func runResultToGMStats(address netip.Addr, r *RunResult, p3 int, selected bool) *gmstats.Stat {
 	s := &gmstats.Stat{
-		GMAddress: address,
+		GMAddress: address.String(),
 		Priority3: uint8(p3),
 	}
 

--- a/ptp/sptp/client/stats_test.go
+++ b/ptp/sptp/client/stats_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"encoding/binary"
 	"fmt"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -30,10 +31,10 @@ import (
 
 func TestRunResultToStatsError(t *testing.T) {
 	r := &RunResult{
-		Server: "192.168.0.10",
+		Server: netip.MustParseAddr("192.168.0.10"),
 		Error:  fmt.Errorf("ooops"),
 	}
-	got := runResultToGMStats("192.168.0.10", r, 1, false)
+	got := runResultToGMStats(netip.MustParseAddr("192.168.0.10"), r, 1, false)
 	want := &gmstats.Stat{
 		GMAddress: "192.168.0.10",
 		Priority3: 1,
@@ -67,7 +68,7 @@ func TestRunResultToStats(t *testing.T) {
 	ts, err := time.Parse(time.RFC3339, "2021-05-21T13:32:05+01:00")
 	require.Nil(t, err)
 	r := &RunResult{
-		Server: "192.168.0.10",
+		Server: netip.MustParseAddr("192.168.0.10"),
 		Measurement: &MeasurementResult{
 			Delay:             299995 * time.Microsecond,
 			S2CDelay:          10 * time.Microsecond,
@@ -101,12 +102,12 @@ func TestRunResultToStats(t *testing.T) {
 	}
 
 	t.Run("not selected", func(t *testing.T) {
-		got := runResultToGMStats("192.168.0.10", r, 3, false)
+		got := runResultToGMStats(netip.MustParseAddr("192.168.0.10"), r, 3, false)
 		require.Equal(t, want, got)
 	})
 	want.Selected = true
 	t.Run("selected", func(t *testing.T) {
-		got := runResultToGMStats("192.168.0.10", r, 3, true)
+		got := runResultToGMStats(netip.MustParseAddr("192.168.0.10"), r, 3, true)
 		require.Equal(t, want, got)
 	})
 }

--- a/ptp/sptp/client/udpconn_mock_test.go
+++ b/ptp/sptp/client/udpconn_mock_test.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	net "net"
+	netip "net/netip"
 	reflect "reflect"
 	time "time"
 
@@ -67,11 +68,11 @@ func (mr *MockUDPConnNoTSMockRecorder) Close() *gomock.Call {
 }
 
 // ReadPacketBuf mocks base method.
-func (m *MockUDPConnNoTS) ReadPacketBuf(buf []byte) (int, string, error) {
+func (m *MockUDPConnNoTS) ReadPacketBuf(buf []byte) (int, netip.Addr, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadPacketBuf", buf)
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(string)
+	ret1, _ := ret[1].(netip.Addr)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -21,6 +21,7 @@ package timestamp
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -221,6 +222,18 @@ func SockaddrToIP(sa unix.Sockaddr) net.IP {
 		return sa.Addr[0:]
 	}
 	return nil
+}
+
+// SockaddrToAddr converts socket address to a netip.Addr
+// Somewhat copy from https://github.com/golang/go/blob/658b5e66ecbc41a49e6fb5aa63c5d9c804cf305f/src/net/udpsock_posix.go#L15
+func SockaddrToAddr(sa unix.Sockaddr) netip.Addr {
+	switch sa := sa.(type) {
+	case *unix.SockaddrInet4:
+		return netip.AddrFrom4(sa.Addr)
+	case *unix.SockaddrInet6:
+		return netip.AddrFrom16(sa.Addr)
+	}
+	return netip.Addr{}
 }
 
 // SockaddrToPort converts socket address to an IP


### PR DESCRIPTION
Summary:
new cool netip package provides better version of IP type, which is fixed length, can be passed by value, is comparable and thus can be used as map keys.
We save plenty of allocations by not converting IPs to strings to use as map keys.

Reviewed By: leoleovich, deathowl

Differential Revision: D58733846
