### PR TITLE
skip responder test if we can't bind to a port

### DIFF
--- a/ntp/responder/server/server_darwin_test.go
+++ b/ntp/responder/server/server_darwin_test.go
@@ -44,9 +44,3 @@ func TestCheckIPFalse(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, assigned)
 }
-
-func TestConfigPHCOffset(t *testing.T) {
-	offset, err := tc.PHCOffset()
-	require.Nil(t, err)
-	require.Equal(t, 0, offset)
-}

--- a/ntp/responder/server/server_freebsd_test.go
+++ b/ntp/responder/server/server_freebsd_test.go
@@ -44,9 +44,3 @@ func TestCheckIPFalse(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, assigned)
 }
-
-func TestConfigPHCOffset(t *testing.T) {
-	offset, err := tc.PHCOffset()
-	require.Nil(t, err)
-	require.Equal(t, 0, offset)
-}


### PR DESCRIPTION
Summary:
Avoids failure on Github CI.
```
2024-06-19T12:58:52.4053342Z === RUN   TestServer
2024-06-19T12:58:52.4074565Z     server_test.go:173:
2024-06-19T12:58:52.4075930Z         	Error Trace:	/home/runner/work/time/time/ntp/responder/server/server_test.go:173
2024-06-19T12:58:52.4078272Z         	Error:      	Expected nil, but got: &net.OpError{Op:"listen", Net:"udp", Source:net.Addr(nil), Addr:(*net.UDPAddr)(0xc00011c030), Err:(*os.SyscallError)(0xc000134000)}
2024-06-19T12:58:52.4080083Z         	Test:       	TestServer
2024-06-19T12:58:52.4080739Z --- FAIL: TestServer (0.00s)
2024-06-19T12:58:52.4081199Z FAIL
```
Also remove clearly broken (not even compiling) tests for darwin and freebsd:
```
~/d/time-fork go test github.com/facebook/time/ntp/responder/server/...
# github.com/facebook/time/ntp/responder/server [github.com/facebook/time/ntp/responder/server.test]
ntp/responder/server/server_darwin_test.go:49:17: undefined: tc
FAIL	github.com/facebook/time/ntp/responder/server [build failed]
FAIL
```

Reviewed By: deathowl

Differential Revision: D58785363
