### PR TITLE
avoid creating net.IP in ptp4u server

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -251,7 +251,6 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 	var msgType ptp.MessageType
 	var worker *sendWorker
 	var sc *SubscriptionClient
-	var ip net.IP
 	var gclisa unix.Sockaddr
 	var expire time.Time
 
@@ -290,8 +289,7 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 				expire = time.Now().Add(subscriptionDuration)
 				// SYNC DELAY_REQUEST and ANNOUNCE
 				if sc = worker.FindSubscription(dReq.Header.SourcePortIdentity, ptp.MessageDelayReq); sc == nil {
-					ip = timestamp.SockaddrToIP(eclisa)
-					gclisa = timestamp.IPToSockaddr(ip, ptp.PortGeneral)
+					gclisa = timestamp.NewSockaddrWithPort(eclisa, ptp.PortGeneral)
 					// Create a new subscription
 					sc = NewSubscriptionClient(worker.queue, worker.signalingQueue, eclisa, gclisa, ptp.MessageDelayReq, s.Config, subscriptionDuration, expire)
 					worker.RegisterSubscription(dReq.Header.SourcePortIdentity, ptp.MessageDelayReq, sc)

--- a/timestamp/timestamp.go
+++ b/timestamp/timestamp.go
@@ -247,3 +247,14 @@ func SockaddrToPort(sa unix.Sockaddr) int {
 	}
 	return 0
 }
+
+// NewSockaddrWithPort creates a new socket address with the same IP and new port
+func NewSockaddrWithPort(sa unix.Sockaddr, port int) unix.Sockaddr {
+	switch sa := sa.(type) {
+	case *unix.SockaddrInet4:
+		return &unix.SockaddrInet4{Addr: sa.Addr, Port: port}
+	case *unix.SockaddrInet6:
+		return &unix.SockaddrInet6{Addr: sa.Addr, Port: port}
+	}
+	return nil
+}

--- a/timestamp/timestamp_test.go
+++ b/timestamp/timestamp_test.go
@@ -142,3 +142,14 @@ func TestTimestampMarshalText(t *testing.T) {
 	require.Equal(t, errors.New("unknown timestamp type \"Unsupported\""), err)
 	require.Equal(t, "Unsupported", string(text))
 }
+
+func TestNewSockaddrWithPort(t *testing.T) {
+	oldSA := &unix.SockaddrInet4{Addr: [4]byte{1, 2, 3, 4}, Port: 4567}
+	newSA := NewSockaddrWithPort(oldSA, 8901)
+	newSA4 := newSA.(*unix.SockaddrInet4)
+	require.Equal(t, oldSA.Addr, newSA4.Addr)
+	require.Equal(t, 8901, newSA4.Port)
+	// changing the original should not change the new one
+	oldSA.Addr[0] = 42
+	require.NotEqual(t, oldSA.Addr, newSA4.Addr)
+}


### PR DESCRIPTION
Summary:
Simple optimization.
Instead of creating a net.IP from SockAddr, and then creating a SockAddr from this IP, just with different port, we simply copy the address and set a new port value.

Reviewed By: leoleovich

Differential Revision: D58814643
