### PR TITLE
Add static lib target

### DIFF
--- a/fbclock/Makefile
+++ b/fbclock/Makefile
@@ -2,6 +2,8 @@ CC=gcc
 CFLAGS=-Wall -g -lrt -msse4.2 -std=gnu11
 CPP=g++
 CPPFLAGS=-fpermissive -lrt -lpthread -msse4.2 -lgtest -g
+AR=ar
+ARFLAGS=rcs
 
 .PHONY: clean test
 
@@ -10,6 +12,11 @@ BUILDDIR ?= .
 fbclock:
 	mkdir -p $(BUILDDIR)
 	$(CC) $(CFLAGS) -shared -o $(BUILDDIR)/fbclock.so -fPIC fbclock.c
+
+fbclock-static:
+	mkdir -p $(BUILDDIR)
+	$(CC) $(CFLAGS) -c -fPIC -o $(BUILDDIR)/fbclock.o fbclock.c
+	$(AR) $(ARFLAGS) $(BUILDDIR)/libfbclock.a $(BUILDDIR)/fbclock.o
 
 test:
 	$(CPP) $(CPPFLAGS) -o fbclock-test test/test.cpp fbclock.c


### PR DESCRIPTION
Summary:
Previous changes to conda build caused build breakages due to fbclock.so not being copied correctly. One of the suggestions was to make it static lib that further links to libnccl. So that all the upper layers only have to worry about managing libnccl.so, as they already do and not concern with managing other dependent libs.

In this take2, introduce static lib target for fbclock, that will be further be linked to libnccl.so in subsequent changes.

Differential Revision: D58930591
