### PR TITLE
fetch firmware version once

### DIFF
--- a/calnex/cmd/firmware.go
+++ b/calnex/cmd/firmware.go
@@ -41,8 +41,9 @@ var firmwareCmd = &cobra.Command{
 	Use:   "firmware",
 	Short: "update the device firmware",
 	Run: func(_ *cobra.Command, _ []string) {
-		fw := &firmware.OSSFW{
-			Filepath: source,
+		fw, err := firmware.NewOSSFW(source)
+		if err != nil {
+			log.Fatal(err)
 		}
 		if err := firmware.Firmware(target, insecureTLS, fw, apply, force); err != nil {
 			log.Fatal(err)

--- a/calnex/firmware/firmware.go
+++ b/calnex/firmware/firmware.go
@@ -28,7 +28,7 @@ import (
 // FW is an interface of the Firmware Version
 type FW interface {
 	// Version returns latest fw version available
-	Version() (*version.Version, error)
+	Version() *version.Version
 	// Path returns local FW path
 	Path() (string, error)
 }
@@ -44,13 +44,8 @@ func ShouldUpgrade(target string, api *calnexAPI.API, fw FW, force bool) (bool, 
 		return false, err
 	}
 
-	v, err := fw.Version()
-	if err != nil {
-		return false, err
-	}
-
-	if calnexVersion.LessThan(v) || force {
-		log.Warningf("%s: is running %s, latest is %s. Needs an update", target, calnexVersion, v)
+	if calnexVersion.LessThan(fw.Version()) || force {
+		log.Warningf("%s: is running %s, latest is %s. Needs an update", target, calnexVersion, fw.Version())
 		return true, nil
 	}
 

--- a/calnex/firmware/firmware_test.go
+++ b/calnex/firmware/firmware_test.go
@@ -42,9 +42,8 @@ func TestFirmware(t *testing.T) {
 	require.NotNil(t, f)
 	f.Close()
 
-	fw := &OSSFW{
-		Filepath: filepath,
-	}
+	fw, err := NewOSSFW(filepath)
+	require.NoError(t, err)
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
@@ -85,9 +84,8 @@ func TestFirmwareForce(t *testing.T) {
 	require.NotNil(t, f)
 	f.Close()
 
-	fw := &OSSFW{
-		Filepath: filepath,
-	}
+	fw, err := NewOSSFW(filepath)
+	require.NoError(t, err)
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
@@ -128,9 +126,8 @@ func TestFirmwareInProgress(t *testing.T) {
 	require.NotNil(t, f)
 	f.Close()
 
-	fw := &OSSFW{
-		Filepath: filepath,
-	}
+	fw, err := NewOSSFW(filepath)
+	require.NoError(t, err)
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {

--- a/calnex/firmware/ossfirmware.go
+++ b/calnex/firmware/ossfirmware.go
@@ -25,19 +25,29 @@ import (
 
 // OSSFW is an open source implementation of the FW interface
 type OSSFW struct {
-	Filepath string
+	filepath string
+	version  *version.Version
+}
+
+// NewOSSFW returns initialized version of OSSFW
+func NewOSSFW(source string) (*OSSFW, error) {
+	fw := &OSSFW{
+		filepath: source,
+	}
+	basename := filepath.Base(fw.filepath)
+	vs := strings.ReplaceAll(strings.TrimSuffix(basename, filepath.Ext(basename)), "sentinel_fw_v", "")
+	v, err := version.NewVersion(strings.ToLower(vs))
+	fw.version = v
+	return fw, err
 }
 
 // Version downloads latest firmware version
 // sentinel_fw_v2.13.1.0.5583D-20210924.tar
-func (f *OSSFW) Version() (*version.Version, error) {
-	basename := filepath.Base(f.Filepath)
-	vs := strings.ReplaceAll(strings.TrimSuffix(basename, filepath.Ext(basename)), "sentinel_fw_v", "")
-	v, err := version.NewVersion(strings.ToLower(vs))
-	return v, err
+func (f *OSSFW) Version() *version.Version {
+	return f.version
 }
 
 // Path downloads latest firmware version
 func (f *OSSFW) Path() (string, error) {
-	return f.Filepath, nil
+	return f.filepath, nil
 }

--- a/calnex/firmware/ossfirmware_test.go
+++ b/calnex/firmware/ossfirmware_test.go
@@ -26,15 +26,14 @@ import (
 func TestOSSFW(t *testing.T) {
 	expectedFilePath := "/tmp/sentinel_fw_v2.13.1.0.5583D-20210924.tar"
 	expectedVersion, _ := version.NewVersion("2.13.1.0.5583d-20210924")
-	fw := OSSFW{
-		Filepath: expectedFilePath,
-	}
+	fw, err := NewOSSFW(expectedFilePath)
+	require.NoError(t, err)
 
 	p, err := fw.Path()
 	require.NoError(t, err)
 	require.Equal(t, expectedFilePath, p)
 
-	v, err := fw.Version()
+	v := fw.Version()
 	require.NoError(t, err)
 	require.Equal(t, expectedVersion, v)
 }


### PR DESCRIPTION
Summary:
Instead of parsing the firmware version every time we call `Version` lets parse it once when we initialize the firmware struct. This will save us some lookups especially when managing many devices.
Also it's much faster

Reviewed By: abulimov

Differential Revision: D58999323
