### PR TITLE
sptp: add ptp.sptp.servo.state metric

### DIFF
--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -423,6 +423,7 @@ func (p *SPTP) processResults(results map[netip.Addr]*RunResult) {
 	} else {
 		freqAdj, state = p.pi.Sample(bmOffset, uint64(bm.Timestamp.UnixNano()))
 	}
+	p.stats.SetServoState(int(state))
 	log.Infof("offset %10d s%d freq %+7.0f path delay %10d (%6d:%6d)", bmOffset, state, freqAdj, bmDelay, bm.C2SDelay, bm.S2CDelay)
 	switch state {
 	case servo.StateJump:

--- a/ptp/sptp/client/sptp_test.go
+++ b/ptp/sptp/client/sptp_test.go
@@ -114,6 +114,7 @@ func TestProcessResultsSingle(t *testing.T) {
 	mockStatsServer.EXPECT().SetGmsTotal(1)
 	mockStatsServer.EXPECT().SetGmsAvailable(100)
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
+	mockStatsServer.EXPECT().SetServoState(gomock.Any()).MinTimes(1)
 
 	cfg := DefaultConfig()
 	cfg.Servers = map[string]int{
@@ -173,6 +174,7 @@ func TestProcessResultsFastSamples(t *testing.T) {
 	mockStatsServer.EXPECT().SetGmsTotal(1)
 	mockStatsServer.EXPECT().SetGmsAvailable(100)
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
+	mockStatsServer.EXPECT().SetServoState(gomock.Any()).MinTimes(1)
 
 	cfg := DefaultConfig()
 	cfg.Servers = map[string]int{
@@ -230,6 +232,7 @@ func TestProcessResultsMulti(t *testing.T) {
 	mockStatsServer.EXPECT().SetGmsAvailable(50)
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
+	mockStatsServer.EXPECT().SetServoState(gomock.Any()).MinTimes(1)
 
 	cfg := DefaultConfig()
 	cfg.Servers = map[string]int{
@@ -353,6 +356,7 @@ func TestRunFiltered(t *testing.T) {
 	mockStatsServer.EXPECT().SetGmsTotal(1)
 	mockStatsServer.EXPECT().SetGmsAvailable(100)
 	mockStatsServer.EXPECT().SetGMStats(gomock.Any())
+	mockStatsServer.EXPECT().SetServoState(gomock.Any()).MinTimes(1)
 
 	cfg := DefaultConfig()
 	cfg.Servers = map[string]int{

--- a/ptp/sptp/client/stats.go
+++ b/ptp/sptp/client/stats.go
@@ -33,6 +33,7 @@ type StatsServer interface {
 	SetGmsTotal(gmsTotal int)
 	SetGmsAvailable(gmsAvailable int)
 	SetTickDuration(tickDuration time.Duration)
+	SetServoState(state int)
 	IncFiltered()
 	IncRXSync()
 	IncRXAnnounce()
@@ -67,6 +68,7 @@ type clientStats struct {
 	rxDelayReq   int64
 	txDelayReq   int64
 	unsupported  int64
+	servoState   int64
 }
 
 // sysStats is just a grouping, don't use directly
@@ -103,6 +105,11 @@ func (s *Stats) SetGmsAvailable(gmsAvailable int) {
 // SetTickDuration atomically sets the gmsTotal
 func (s *Stats) SetTickDuration(tickDuration time.Duration) {
 	atomic.StoreInt64(&s.tickDuration, tickDuration.Nanoseconds())
+}
+
+// SetServoState atomically sets the servoState
+func (s *Stats) SetServoState(state int) {
+	atomic.StoreInt64(&s.servoState, int64(state))
 }
 
 // IncFiltered atomically adds 1 to the rxsync
@@ -151,6 +158,7 @@ func (s *Stats) GetCounters() map[string]int64 {
 		"ptp.sptp.portstats.rx.delay_req":   s.rxDelayReq,
 		"ptp.sptp.portstats.tx.delay_req":   s.txDelayReq,
 		"ptp.sptp.portstats.rx.unsupported": s.unsupported,
+		"ptp.sptp.servo.state":              s.servoState,
 		// sysStats
 		"ptp.sptp.runtime.gc.pause_ns.sum.60":    s.gcPauseNs,
 		"ptp.sptp.runtime.mem.gc.pause_total_ns": s.gcPauseTotalNs,

--- a/ptp/sptp/client/stats_mock_test.go
+++ b/ptp/sptp/client/stats_mock_test.go
@@ -182,3 +182,15 @@ func (mr *MockStatsServerMockRecorder) SetTickDuration(tickDuration interface{})
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTickDuration", reflect.TypeOf((*MockStatsServer)(nil).SetTickDuration), tickDuration)
 }
+
+// SetServoState mocks base method.
+func (m *MockStatsServer) SetServoState(state int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetServoState", state)
+}
+
+// SetServoState indicates an expected call of SetServoState.
+func (mr *MockStatsServerMockRecorder) SetServoState(state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetServoState", reflect.TypeOf((*MockStatsServer)(nil).SetServoState), state)
+}


### PR DESCRIPTION
Summary: Export the servo state: we want to filter out data coming from servo in S3 state, to avoid noise.

Reviewed By: leoleovich

Differential Revision: D60523795
