### PR TITLE
phc: introduce phc.Device abstraction

### DIFF
--- a/cmd/ptpcheck/cmd/adjfreq.go
+++ b/cmd/ptpcheck/cmd/adjfreq.go
@@ -44,14 +44,15 @@ func doAdjFreq(device string, freq float64) error {
 		return fmt.Errorf("opening device %q to read frequency: %w", device, err)
 	}
 	defer f.Close()
+	phcdev := phc.FromFile(f)
 
-	curFreq, err := phc.FrequencyPPBFromDevice(f)
+	curFreq, err := phcdev.FreqPPB()
 	if err != nil {
 		return err
 	}
 	log.Infof("Current device frequency: %f", curFreq)
 
-	maxFreq, err := phc.MaxFreqAdjPPBFromDevice(f)
+	maxFreq, err := phcdev.MaxFreqAdjPPB()
 	if err != nil {
 		return err
 	}
@@ -66,7 +67,7 @@ func doAdjFreq(device string, freq float64) error {
 	}
 
 	log.Infof("Setting new frequency value %f", freq)
-	err = phc.ClockAdjFreq(f, freq)
+	err = phcdev.AdjFreq(freq)
 
 	return err
 }

--- a/cmd/ptpcheck/cmd/phcdiff.go
+++ b/cmd/ptpcheck/cmd/phcdiff.go
@@ -57,18 +57,19 @@ func phcdiffRun(deviceA, deviceB string, isJSON bool) error {
 		return fmt.Errorf("opening device %q to set frequency: %w", deviceB, err)
 	}
 	defer b.Close()
+	adev, bdev := phc.FromFile(a), phc.FromFile(b)
 
-	extendedA, err := phc.ReadPTPSysOffsetExtended(a, phc.ExtendedNumProbes)
+	extendedA, err := adev.ReadSysoffExtended()
 	if err != nil {
 		return err
 	}
-	extendedB, err := phc.ReadPTPSysOffsetExtended(b, phc.ExtendedNumProbes)
+	extendedB, err := bdev.ReadSysoffExtended()
 	if err != nil {
 		return err
 	}
-	timeAndOffsetA := phc.SysoffEstimateExtended(extendedA)
-	timeAndOffsetB := phc.SysoffEstimateExtended(extendedB)
-	phcOffset := phc.OffsetBetweenExtendedReadings(extendedA, extendedB)
+	timeAndOffsetA := extendedA.BestSample()
+	timeAndOffsetB := extendedB.BestSample()
+	phcOffset := extendedB.Sub(extendedA)
 
 	if isJSON {
 		stats := phcStats{PHCOffset: phcOffset, PHC1Delay: timeAndOffsetA.Delay, PHC2Delay: timeAndOffsetB.Delay}

--- a/fbclock/daemon/daemon.go
+++ b/fbclock/daemon/daemon.go
@@ -205,10 +205,11 @@ func New(cfg *Config, stats stats.Server, l Logger) (*Daemon, error) {
 	if err != nil {
 		return nil, err
 	}
+	dev := phc.FromFile(f)
 
 	// function to get time from phc
-	s.getPHCTime = func() (time.Time, error) { return phc.TimeFromDevice(f) }
-	s.getPHCFreqPPB = func() (float64, error) { return phc.FrequencyPPBFromDevice(f) }
+	s.getPHCTime = func() (time.Time, error) { return dev.Time() }
+	s.getPHCFreqPPB = func() (float64, error) { return dev.FreqPPB() }
 	// calculated values
 	s.stats.SetCounter("m_ns", 0)
 	s.stats.SetCounter("w_ns", 0)

--- a/phc/device.go
+++ b/phc/device.go
@@ -85,6 +85,13 @@ type PTPClockCaps struct {
 	Rsv         [12]int32 /* Reserved for future use. */
 }
 
+func (caps *PTPClockCaps) maxAdj() float64 {
+	if caps == nil || caps.MaxAdj == 0 {
+		return DefaultMaxClockFreqPPB
+	}
+	return float64(caps.MaxAdj)
+}
+
 // IfaceInfo uses SIOCETHTOOL ioctl to get information for the give nic, i.e. eth0.
 func IfaceInfo(iface string) (*EthtoolTSinfo, error) {
 	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)

--- a/phc/offset_test.go
+++ b/phc/offset_test.go
@@ -37,7 +37,7 @@ func TestSysoffEstimateBasic(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
-func TestSysoffEstimateExtended(t *testing.T) {
+func TestSysoffBestSample(t *testing.T) {
 	extended := &PTPSysOffsetExtended{
 		NSamples: 3,
 		TS: [ptpMaxSamples][3]PTPClockTime{
@@ -46,7 +46,7 @@ func TestSysoffEstimateExtended(t *testing.T) {
 			{{Sec: 1667818190, NSec: 552297644}, {Sec: 1667818153, NSec: 552297661}, {Sec: 1667818190, NSec: 552297722}},
 		},
 	}
-	got := SysoffEstimateExtended(extended)
+	got := extended.BestSample()
 	want := SysoffResult{
 		SysTime: time.Unix(0, 1667818190552297683),
 		PHCTime: time.Unix(0, 1667818153552297661),
@@ -95,6 +95,6 @@ func TestOffsetBetweenExtendedReadings(t *testing.T) {
 			{{Sec: 1667818191, NSec: 552301866}, {Sec: 1667818154, NSec: 552297861}, {Sec: 1667818191, NSec: 552328912}},
 		},
 	}
-	offset := OffsetBetweenExtendedReadings(extendedA, extendedB)
+	offset := extendedB.Sub(extendedA)
 	require.Equal(t, time.Duration(-815), offset)
 }

--- a/phc/phc_test.go
+++ b/phc/phc_test.go
@@ -45,10 +45,10 @@ func TestMaxAdjFreq(t *testing.T) {
 		MaxAdj: 1000000000,
 	}
 
-	got := maxAdj(caps)
+	got := caps.maxAdj()
 	require.InEpsilon(t, 1000000000.0, got, 0.00001)
 
 	caps.MaxAdj = 0
-	got = maxAdj(caps)
+	got = caps.maxAdj()
 	require.InEpsilon(t, 500000.0, got, 0.00001)
 }

--- a/ptp/sptp/client/clock.go
+++ b/ptp/sptp/client/clock.go
@@ -38,7 +38,7 @@ type Clock interface {
 
 // PHC groups methods for interactions with PHC devices
 type PHC struct {
-	device *os.File
+	dev *phc.Device
 }
 
 // NewPHC creates new PHC device abstraction from network interface name
@@ -54,29 +54,27 @@ func NewPHC(iface string) (*PHC, error) {
 		return nil, fmt.Errorf("opening device %s error: %w", devicePath, err)
 	}
 
-	return &PHC{
-		device: f,
-	}, nil
+	return &PHC{dev: phc.FromFile(f)}, nil
 }
 
 // AdjFreqPPB adjusts PHC frequency
-func (p *PHC) AdjFreqPPB(freq float64) error {
-	return phc.ClockAdjFreq(p.device, freq)
+func (p *PHC) AdjFreqPPB(freqPPB float64) error {
+	return p.dev.AdjFreq(freqPPB)
 }
 
 // Step jumps time on PHC
 func (p *PHC) Step(step time.Duration) error {
-	return phc.ClockStep(p.device, step)
+	return p.dev.Step(step)
 }
 
 // FrequencyPPB returns current PHC frequency
 func (p *PHC) FrequencyPPB() (float64, error) {
-	return phc.FrequencyPPBFromDevice(p.device)
+	return p.dev.FreqPPB()
 }
 
 // MaxFreqPPB returns maximum frequency adjustment supported by PHC
 func (p *PHC) MaxFreqPPB() (float64, error) {
-	return phc.MaxFreqAdjPPBFromDevice(p.device)
+	return p.dev.MaxFreqAdjPPB()
 }
 
 // SetSync is a no-op for PHC


### PR DESCRIPTION
Summary:
Manage the number of package-level functions of mixed purpose, group the ones which deal with PHC devices as methods of a the new Device type.

Reasoning: with planned addition of the functionality of *testptp* to the `phc` package and utils, the more of the similar methods are upcoming, and if not addressed early, the set of package-level functions is going to oganically grow even more crowded.

Reviewed By: abulimov

Differential Revision: D60456794
