### PR TITLE
linting to keep golang-ci happy

### DIFF
--- a/calnex/api/api.go
+++ b/calnex/api/api.go
@@ -520,7 +520,7 @@ func (a *API) FetchCsv(channel Channel, allData bool) ([][]string, error) {
 	// Check for empty response
 	r := &Result{}
 	if err = json.Unmarshal(b, r); err == nil {
-		return nil, fmt.Errorf(r.Message)
+		return nil, errors.New(r.Message)
 	}
 
 	var res [][]string

--- a/calnex/cmd/cert.go
+++ b/calnex/cmd/cert.go
@@ -76,7 +76,7 @@ func certFunc() error {
 	}
 
 	r, err := api.PushCert(certData)
-	log.Infof(r.Message)
+	log.Info(r.Message)
 	return err
 }
 

--- a/calnex/cmd/clear.go
+++ b/calnex/cmd/clear.go
@@ -34,7 +34,7 @@ func init() {
 	}
 }
 
-func clear() error {
+func clearDevice() error {
 	if !apply {
 		log.Info("dry run. Exiting")
 		return nil
@@ -54,7 +54,7 @@ var clearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clear device data",
 	Run: func(_ *cobra.Command, _ []string) {
-		if err := clear(); err != nil {
+		if err := clearDevice(); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/cmd/ziffy/node/print.go
+++ b/cmd/ziffy/node/print.go
@@ -51,13 +51,6 @@ type keyPair struct {
 	hop  int
 }
 
-func min(x int, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // getHostNoPrefix has ip as input and returns device hostname without interface prefix
 func getHostNoPrefix(ip string) string {
 	lun := getLookUpName(ip)

--- a/cmd/ziffy/node/print_test.go
+++ b/cmd/ziffy/node/print_test.go
@@ -24,14 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMin(t *testing.T) {
-	require.Equal(t, 2, min(2, 3))
-	require.Equal(t, 2, min(2, 100))
-	require.Equal(t, -3, min(2, -3))
-	require.Equal(t, 1, min(1, 1))
-	require.Equal(t, -4, min(-2, -4))
-}
-
 func TestComputeInfo(t *testing.T) {
 	s := Sender{
 		Config: &Config{},

--- a/fbclock/daemon/daemon.go
+++ b/fbclock/daemon/daemon.go
@@ -468,11 +468,11 @@ func (s *Daemon) runLinearizabilityTests(ctx context.Context) {
 		for _, res := range currentResults {
 			good, err := res.Good()
 			if err != nil {
-				log.Errorf(res.Explain())
+				log.Error(res.Explain())
 				continue
 			}
 			if !good {
-				log.Warningf(res.Explain())
+				log.Warning(res.Explain())
 			}
 			log.Debugf("got linearizability result: %s", res.Explain())
 			s.state.pushLinearizabilityTestResult(res)

--- a/ptp/linearizability/linearizability_sptp.go
+++ b/ptp/linearizability/linearizability_sptp.go
@@ -18,6 +18,7 @@ package linearizability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -134,7 +135,7 @@ func (lt *SPTPTester) RunTest(_ context.Context) TestResult {
 			result.Offset = s.Offset
 			result.ClockClass = s.ClockQuality.ClockClass
 			if s.Error != "" {
-				result.Error = fmt.Errorf(s.Error)
+				result.Error = errors.New(s.Error)
 			}
 			found = true
 			break

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -22,7 +22,6 @@ package server
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"sync"
 	"time"
 
@@ -97,7 +96,7 @@ func (sc *SubscriptionClient) Start(ctx context.Context) {
 	sc.runningInterval = sc.interval
 	sc.intervalTicker = time.NewTicker(sc.runningInterval)
 
-	defer log.Infof(fmt.Sprintf("Subscription %s is over for %s", sc.subscriptionType, timestamp.SockaddrToIP(sc.eclisa)))
+	defer log.Infof("Subscription %s is over for %s", sc.subscriptionType, timestamp.SockaddrToIP(sc.eclisa))
 	if sc.subscriptionType != ptp.MessageDelayReq {
 		defer sc.sendSignalingCancel()
 	}

--- a/ptp/simpleclient/client.go
+++ b/ptp/simpleclient/client.go
@@ -456,10 +456,10 @@ func (c *Client) setState(s state) {
 
 // couple of helpers to log nice lines about happening communication
 func (c *Client) logSent(t ptp.MessageType, msg string, v ...interface{}) {
-	log.Infof(color.GreenString("client -> %s (%s)", t, fmt.Sprintf(msg, v...)))
+	log.Info(color.GreenString("client -> %s (%s)", t, fmt.Sprintf(msg, v...)))
 }
 func (c *Client) logReceive(t ptp.MessageType, msg string, v ...interface{}) {
-	log.Infof(color.BlueString("server -> %s (%s)", t, fmt.Sprintf(msg, v...)))
+	log.Info(color.BlueString("server -> %s (%s)", t, fmt.Sprintf(msg, v...)))
 }
 
 // Run is the main function, it makes client talk to server provided in config

--- a/servo/pi.go
+++ b/servo/pi.go
@@ -105,7 +105,7 @@ type PiServo struct {
 	cfg *PiServoCfg
 }
 
-func max(a int64, b int64) int64 {
+func maximum(a int64, b int64) int64 {
 	if a > b {
 		return a
 	}
@@ -287,14 +287,14 @@ func (f *PiServoFilter) isSpike(offset int64, lastCorrection time.Time) filterSt
 	if offset < 0 {
 		offset *= -1
 	}
-	if offset > max(maxOffsetLocked, f.cfg.minOffsetLocked) && f.skippedCount < f.cfg.maxSkipCount {
+	if offset > maximum(maxOffsetLocked, f.cfg.minOffsetLocked) && f.skippedCount < f.cfg.maxSkipCount {
 		return filterSpike
 	}
 	return filterNoSpike
 }
 
-func inRange(value, min, max int64) bool {
-	if value >= min && value <= max {
+func inRange(value, minimum, maximum int64) bool {
+	if value >= minimum && value <= maximum {
 		return true
 	}
 	return false


### PR DESCRIPTION
Summary: Address `golang-ci` reported items.

Reviewed By: abulimov

Differential Revision: D61334701
