### PR TITLE
report sys vs avg peers offset in stats

### DIFF
--- a/cmd/ntpcheck/checker/peer.go
+++ b/cmd/ntpcheck/checker/peer.go
@@ -68,6 +68,7 @@ type Peer struct {
 	FiltDelay  string
 	FiltOffset string
 	FiltDisp   string
+	NoSelect   bool
 }
 
 // sanityCheckPeerVars checks if we parsed enough info from NTPD response
@@ -171,6 +172,7 @@ func NewPeerFromNTP(p *control.NTPControlMsg) (*Peer, error) {
 		SRCPort:    srcport,
 		Xleave:     xleave,
 		RootDisp:   rootdisp,
+		NoSelect:   psWord.PeerSelection == control.SelReject && psWord.PeerStatus.Reachable, // that's how noselect peers are visible in sources
 	}
 	if err := sanityCheckPeerVars(&peer); err != nil {
 		return nil, err
@@ -216,6 +218,7 @@ func NewPeerFromChrony(s *chrony.ReplySourceData, p *chrony.ReplyNTPData, n *chr
 		Stratum:      int(s.Stratum),
 		SRCAdr:       s.IPAddr.String(),
 		Reach:        uint8(s.Reachability),
+		NoSelect:     s.State == chrony.SourceStateUnreach && s.Reachability == 255, // that's how noselect peers are visible in sources. Ideally we'd rather use Chrony SelectData, but it's not part of public API.
 	}
 	// populate data from ntpdata struct
 	if p != nil {

--- a/cmd/ntpcheck/checker/stats.go
+++ b/cmd/ntpcheck/checker/stats.go
@@ -18,6 +18,7 @@ package checker
 
 import (
 	"math"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -25,17 +26,61 @@ import (
 
 // NTPStats are metrics for upstream reporting
 type NTPStats struct {
-	PeerDelay   float64 `json:"ntp.peer.delay"`     // sys.peer delay in ms
-	PeerPoll    int     `json:"ntp.peer.poll"`      // sys.peer poll in seconds
-	PeerJitter  float64 `json:"ntp.peer.jitter"`    // sys.peer jitter in ms
-	PeerOffset  float64 `json:"ntp.peer.offset"`    // sys.peer offset in ms
-	PeerStratum int     `json:"ntp.peer.stratum"`   // sys.peer stratum
-	Frequency   float64 `json:"ntp.sys.frequency"`  // clock frequency in PPM
-	Offset      float64 `json:"ntp.sys.offset"`     // tracking clock offset in MS
-	RootDelay   float64 `json:"ntp.sys.root_delay"` // tracking root delay in MS
-	StatError   bool    `json:"ntp.stat.error"`     // error reported in Leap Status
-	Correction  float64 `json:"ntp.correction"`     // current correction
-	PeerCount   int     `json:"ntp.peer.count"`     // number of upstream peers
+	PeerDelay             float64 `json:"ntp.peer.delay"`                          // sys.peer delay in ms
+	PeerPoll              int     `json:"ntp.peer.poll"`                           // sys.peer poll in seconds
+	PeerJitter            float64 `json:"ntp.peer.jitter"`                         // sys.peer jitter in ms
+	PeerOffset            float64 `json:"ntp.peer.offset"`                         // sys.peer offset in ms
+	PeerStratum           int     `json:"ntp.peer.stratum"`                        // sys.peer stratum
+	Frequency             float64 `json:"ntp.sys.frequency"`                       // clock frequency in PPM
+	Offset                float64 `json:"ntp.sys.offset"`                          // tracking clock offset in MS
+	RootDelay             float64 `json:"ntp.sys.root_delay"`                      // tracking root delay in MS
+	StatError             bool    `json:"ntp.stat.error"`                          // error reported in Leap Status
+	Correction            float64 `json:"ntp.correction"`                          // current correction
+	PeerCount             int     `json:"ntp.peer.count"`                          // number of upstream peers
+	OffsetComparedToPeers float64 `json:"ntp.sys.offset_selected_vs_avg_peers_ms"` // sys peer offset vs avg peer offset in ms
+}
+
+type averages struct {
+	delay   float64
+	jitter  float64
+	offset  float64
+	poll    uint
+	stratum int
+}
+
+func peersAverages(peers []*Peer) (*averages, error) {
+	// calculate averages
+	total := len(peers)
+	if total == 0 {
+		return nil, errors.New("no peers detected to output stats")
+	}
+	totalDelay := 0.0
+	totalJitter := 0.0
+	totalOffset := 0.0
+	bestPPoll := 0
+	bestHPoll := 0
+	bestStratum := 0
+	for _, p := range peers {
+		totalDelay += p.Delay
+		totalJitter += p.Jitter
+		totalOffset += p.Offset
+		if bestPPoll == 0 || p.PPoll < bestPPoll {
+			bestPPoll = p.PPoll
+		}
+		if bestHPoll == 0 || p.HPoll < bestHPoll {
+			bestHPoll = p.HPoll
+		}
+		if bestStratum == 0 || p.Stratum < bestStratum {
+			bestStratum = p.Stratum
+		}
+	}
+	return &averages{
+		delay:   totalDelay / float64(total),
+		poll:    uint(math.Min(float64(bestPPoll), float64(bestHPoll))),
+		jitter:  totalJitter / float64(total),
+		offset:  totalOffset / float64(total),
+		stratum: bestStratum,
+	}, nil
 }
 
 // NewNTPStats constructs NTPStats from NTPCheckResult
@@ -43,46 +88,27 @@ func NewNTPStats(r *NTPCheckResult) (*NTPStats, error) {
 	if r.SysVars == nil {
 		return nil, errors.New("no system variables to output stats")
 	}
-	syspeer, err := r.FindSysPeer()
 	var delay, jitter, offset float64
 	var poll uint
 	var stratum int
+	var offsetComparedToPeers float64
+	syspeer, err := r.FindSysPeer()
 	if err != nil {
 		log.Warningf("Can't get system peer: %v", err)
-		// calculate averages like ntp_stats_ods.py did
-		total := len(r.Peers)
-		if total == 0 {
-			return nil, errors.New("no peers detected to output stats")
-		}
 		goodPeers, err := r.FindGoodPeers()
 		if err != nil {
 			return nil, errors.Wrap(err, "nothing to calculate stats from")
 		}
-		totalDelay := 0.0
-		totalJitter := 0.0
-		totalOffset := 0.0
-		bestPPoll := 0
-		bestHPoll := 0
-		bestStratum := 0
-		for _, p := range goodPeers {
-			totalDelay += p.Delay
-			totalJitter += p.Jitter
-			totalOffset += p.Offset
-			if bestPPoll == 0 || p.PPoll < bestPPoll {
-				bestPPoll = p.PPoll
-			}
-			if bestHPoll == 0 || p.HPoll < bestHPoll {
-				bestHPoll = p.HPoll
-			}
-			if bestStratum == 0 || p.Stratum < bestStratum {
-				bestStratum = p.Stratum
-			}
+		peerAvgs, err := peersAverages(goodPeers)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to calculate stats from peers")
 		}
-		delay = totalDelay / float64(total)
-		jitter = totalJitter / float64(total)
-		offset = totalOffset / float64(total)
-		stratum = bestStratum
-		poll = uint(math.Min(float64(bestPPoll), float64(bestHPoll)))
+
+		delay = peerAvgs.delay
+		jitter = peerAvgs.jitter
+		poll = peerAvgs.poll
+		stratum = peerAvgs.stratum
+		offset = peerAvgs.offset
 	} else {
 		delay = syspeer.Delay
 		jitter = syspeer.Jitter
@@ -90,19 +116,31 @@ func NewNTPStats(r *NTPCheckResult) (*NTPStats, error) {
 		stratum = syspeer.Stratum
 		offset = syspeer.Offset
 	}
+
+	// get averages from non-sys peers
+	okPeers, err := r.FindAcceptableNonSysPeers()
+	if err != nil {
+		log.Debugf("Can't get any peers for avg calculations: %v", err)
+	} else {
+		peerAvgs, err := peersAverages(okPeers)
+		if err == nil {
+			log.Debugf("Sys Offset: %v, Avg Peer Offset: %v", time.Duration(offset*float64(time.Millisecond)), time.Duration(peerAvgs.offset*float64(time.Millisecond)))
+			offsetComparedToPeers = math.Abs(math.Abs(offset) - math.Abs(peerAvgs.offset))
+		}
+	}
 	output := NTPStats{
-		PeerDelay:   delay,
-		PeerPoll:    1 << poll, // hpoll and ppoll are stored in seconds as a power of two
-		PeerJitter:  jitter,
-		PeerOffset:  offset,
-		Offset:      r.SysVars.Offset,
-		RootDelay:   r.SysVars.RootDelay,
-		PeerStratum: stratum,
-		Frequency:   r.SysVars.Frequency,
-		Correction:  r.Correction,
-		// that's how ntpstat defines unsynchronized
-		StatError: r.LI == 3,
-		PeerCount: len(r.Peers),
+		PeerDelay:             delay,
+		PeerPoll:              1 << poll, // hpoll and ppoll are stored in seconds as a power of two
+		PeerJitter:            jitter,
+		PeerOffset:            offset,
+		Offset:                r.SysVars.Offset,
+		RootDelay:             r.SysVars.RootDelay,
+		PeerStratum:           stratum,
+		Frequency:             r.SysVars.Frequency,
+		Correction:            r.Correction,
+		StatError:             r.LI == 3, // that's how ntpstat defines unsynchronized
+		PeerCount:             len(r.Peers),
+		OffsetComparedToPeers: offsetComparedToPeers,
 	}
 	return &output, nil
 }


### PR DESCRIPTION
Summary:
It seems useful to be able to monitor how much Sys Peer offset differs from other peers (which may or may not be in 'noselect' mode).

This change exposes `ntp.sys.offset_selected_vs_avg_peers_ms` data point in `stats` subcommand, which albeit being a mouthful correctly describes the nature of this value.

Reviewed By: leoleovich

Differential Revision: D61393681
