### PR TITLE
phc: use the pre-1.22 for-loop syntax

### DIFF
--- a/phc/phc.go
+++ b/phc/phc.go
@@ -224,7 +224,7 @@ func (dev *Device) ReadPins() ([]PinDesc, error) {
 	}
 	npins := int(caps.NPins)
 	desc := make([]PinDesc, npins)
-	for i := range npins {
+	for i := 0; i < npins; i++ {
 		if err := dev.readPinDesc(i, &desc[i]); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Summary: Retain backwards compatibility with Go 1.21 by rewriting the for-loop using the classic syntax.

Differential Revision: D61906434
