### PR TITLE
remove usage of pkg/errors

### DIFF
--- a/cmd/ntpcheck/checker/checkresult.go
+++ b/cmd/ntpcheck/checker/checkresult.go
@@ -17,10 +17,10 @@ limitations under the License.
 package checker
 
 import (
+	"errors"
 	"slices"
 
 	"github.com/facebook/time/ntp/control"
-	"github.com/pkg/errors"
 )
 
 // NTPCheckResult represents result of NTPCheck run populated with information about the server and its peers.

--- a/cmd/ntpcheck/checker/peer.go
+++ b/cmd/ntpcheck/checker/peer.go
@@ -17,13 +17,13 @@ limitations under the License.
 package checker
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/facebook/time/ntp/chrony"
 	"github.com/facebook/time/ntp/control"
-	"github.com/pkg/errors"
 )
 
 // Peer contains parsed information from Peer Variables and peer status word, as described in http://doc.ntp.org/current-stable/ntpq.html

--- a/cmd/ntpcheck/checker/peerstats.go
+++ b/cmd/ntpcheck/checker/peerstats.go
@@ -21,14 +21,12 @@ import (
 	"math"
 	"net"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // NewNTPPeerStats constructs NTPStats from NTPCheckResult
 func NewNTPPeerStats(r *NTPCheckResult, noDNS bool) (map[string]any, error) {
 	if r.SysVars == nil {
-		return nil, errors.New("no system variables to output stats")
+		return nil, fmt.Errorf("no system variables to output stats")
 	}
 
 	result := make(map[string]any, len(r.Peers))

--- a/cmd/ntpcheck/checker/stats.go
+++ b/cmd/ntpcheck/checker/stats.go
@@ -17,10 +17,10 @@ limitations under the License.
 package checker
 
 import (
+	"fmt"
 	"math"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -52,7 +52,7 @@ func peersAverages(peers []*Peer) (*averages, error) {
 	// calculate averages
 	total := len(peers)
 	if total == 0 {
-		return nil, errors.New("no peers detected to output stats")
+		return nil, fmt.Errorf("no peers detected to output stats")
 	}
 	totalDelay := 0.0
 	totalJitter := 0.0
@@ -86,7 +86,7 @@ func peersAverages(peers []*Peer) (*averages, error) {
 // NewNTPStats constructs NTPStats from NTPCheckResult
 func NewNTPStats(r *NTPCheckResult) (*NTPStats, error) {
 	if r.SysVars == nil {
-		return nil, errors.New("no system variables to output stats")
+		return nil, fmt.Errorf("no system variables to output stats")
 	}
 	var delay, jitter, offset float64
 	var poll uint
@@ -97,11 +97,11 @@ func NewNTPStats(r *NTPCheckResult) (*NTPStats, error) {
 		log.Warningf("Can't get system peer: %v", err)
 		goodPeers, err := r.FindGoodPeers()
 		if err != nil {
-			return nil, errors.Wrap(err, "nothing to calculate stats from")
+			return nil, fmt.Errorf("nothing to calculate stats from: %w", err)
 		}
 		peerAvgs, err := peersAverages(goodPeers)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to calculate stats from peers")
+			return nil, fmt.Errorf("failed to calculate stats from peers: %w", err)
 		}
 
 		delay = peerAvgs.delay

--- a/cmd/ntpcheck/checker/system.go
+++ b/cmd/ntpcheck/checker/system.go
@@ -17,11 +17,11 @@ limitations under the License.
 package checker
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/facebook/time/ntp/chrony"
 	"github.com/facebook/time/ntp/control"
-	"github.com/pkg/errors"
 )
 
 // SystemVariables holds System Variables extracted from k=v pairs, as described in http://doc.ntp.org/current-stable/ntpq.html

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/hashicorp/go-version v1.5.0
 	github.com/jsimonetti/rtnetlink v1.2.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -208,7 +208,6 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/ntp/responder/server/server_darwin.go
+++ b/ntp/responder/server/server_darwin.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"os/exec"
 	"time"
-
-	errors "github.com/pkg/errors"
 )
 
 func addIfaceIP(iface *net.Interface, addr *net.IP) error {
@@ -47,7 +45,7 @@ func addIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	cmd := exec.Command("ifconfig", iface.Name, proto, "alias", fmt.Sprintf("%s/%d", addr.String(), mask))
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "can't add address")
+		return fmt.Errorf("can't add address: %w", err)
 	}
 	return nil
 }
@@ -71,7 +69,7 @@ func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	cmd := exec.Command("ifconfig", iface.Name, proto, "-alias", addr.String())
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "can't remove address")
+		return fmt.Errorf("can't remove address: %w", err)
 	}
 
 	return nil

--- a/ntp/responder/server/server_freebsd.go
+++ b/ntp/responder/server/server_freebsd.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"os/exec"
 	"time"
-
-	errors "github.com/pkg/errors"
 )
 
 func addIfaceIP(iface *net.Interface, addr *net.IP) error {
@@ -48,7 +46,7 @@ func addIfaceIP(iface *net.Interface, addr *net.IP) error {
 	cmd := exec.Command("ifconfig", iface.Name, proto, "alias", fmt.Sprintf("%s/%d", addr.String(), mask))
 	fmt.Println(cmd.Args)
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "can't add address")
+		return fmt.Errorf("can't add address: %w", err)
 	}
 	return nil
 }
@@ -72,7 +70,7 @@ func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	cmd := exec.Command("ifconfig", iface.Name, proto, "-alias", addr.String())
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "can't remove address")
+		return fmt.Errorf("can't remove address: %w", err)
 	}
 
 	return nil

--- a/ntp/responder/server/server_linux.go
+++ b/ntp/responder/server/server_linux.go
@@ -17,12 +17,12 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/facebook/time/phc"
 	"github.com/jsimonetti/rtnetlink/rtnl"
-	errors "github.com/pkg/errors"
 )
 
 // bitsInBytes is a number of bits in byte
@@ -46,7 +46,7 @@ func addIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	conn, err := rtnl.Dial(nil)
 	if err != nil {
-		return errors.Wrap(err, "can't establish netlink connection")
+		return fmt.Errorf("can't establish netlink connection: %w", err)
 	}
 	defer conn.Close()
 
@@ -59,7 +59,7 @@ func addIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	err = conn.AddrAdd(iface, &net.IPNet{IP: *addr, Mask: mask})
 	if err != nil {
-		return errors.Wrap(err, "can't add address")
+		return fmt.Errorf("can't add address: %w", err)
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	conn, err := rtnl.Dial(nil)
 	if err != nil {
-		return errors.Wrap(err, "can't establish netlink connection")
+		return fmt.Errorf("can't establish netlink connection: %w", err)
 	}
 	defer conn.Close()
 
@@ -89,7 +89,7 @@ func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 	err = conn.AddrDel(iface, &net.IPNet{IP: *addr, Mask: mask})
 	if err != nil {
-		return errors.Wrap(err, "can't remove address")
+		return fmt.Errorf("can't remove address: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Summary: No need to use the outdated, archived lib since stdlib started to support error wrapping natively.

Differential Revision: D62128049
