### PR TITLE
Add tests to PPS Source Activate function

### DIFF
--- a/phc/phc_test.go
+++ b/phc/phc_test.go
@@ -17,10 +17,38 @@ limitations under the License.
 package phc
 
 import (
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type deviceControllerMock struct {
+	mock.Mock
+}
+
+func (_m *deviceControllerMock) Time() (time.Time, error) {
+	ret := _m.Called()
+	return ret.Get(0).(time.Time), ret.Error(1)
+}
+
+func (_m *deviceControllerMock) setPinFunc(index uint, pf PinFunc, ch uint) error {
+	ret := _m.Called(index, pf, ch)
+	return ret.Error(0)
+}
+
+func (_m *deviceControllerMock) setPTPPerout(req PTPPeroutRequest) error {
+	ret := _m.Called(req)
+	return ret.Error(0)
+}
+
+func (_m *deviceControllerMock) File() *os.File {
+	ret := _m.Called()
+	return ret.Get(0).(*os.File)
+}
 
 func TestIfaceInfoToPHCDevice(t *testing.T) {
 	info := &EthtoolTSinfo{
@@ -51,4 +79,95 @@ func TestMaxAdjFreq(t *testing.T) {
 	caps.MaxAdj = 0
 	got = caps.maxAdj()
 	require.InEpsilon(t, 500000.0, got, 0.00001)
+}
+
+func TestActivatePPSSource(t *testing.T) {
+	// Prepare
+	mockDevice := new(deviceControllerMock)
+
+	// Should set default pin to PPS
+	mockDevice.On("setPinFunc", uint(0), PinFuncPerOut, uint(0)).Return(nil).Once()
+
+	// Should call Time once
+	mockDevice.On("Time").Return(time.Unix(824635825488, 1397965136), nil).Once()
+
+	// Should issue ioctlPTPPeroutRequest2
+	expectedPeroutRequest := PTPPeroutRequest{
+		Index:        uint32(0),
+		Flags:        uint32(0x2),
+		StartOrPhase: PTPClockTime{Sec: 51},
+		Period:       PTPClockTime{Sec: 1},
+		On:           PTPClockTime{NSec: 500000000},
+	}
+	mockDevice.On("setPTPPerout", expectedPeroutRequest).Return(nil).Once()
+
+	// Act
+	err := ActivatePPSSource(mockDevice)
+
+	// Assert calls
+	require.NoError(t, err)
+	mockDevice.AssertExpectations(t)
+}
+
+func TestActivatePPSSourceIgnoreSetPinFailure(t *testing.T) {
+	// Prepare
+	mockDevice := new(deviceControllerMock)
+	mockDevice.On("File").Return(os.NewFile(3, "mock_file"))
+	mockDevice.On("Time").Return(time.Unix(824635825488, 1397965136), nil)
+
+	// If ioctl set pin fails, we continue bravely on...
+	mockDevice.On("setPinFunc", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("error")).Once()
+	mockDevice.On("setPTPPerout", mock.Anything).Return(nil).Once()
+
+	// Act
+	err := ActivatePPSSource(mockDevice)
+
+	// Assert calls
+	mockDevice.AssertExpectations(t)
+	require.NoError(t, err)
+}
+
+func TestActivatePPSSourceSetPTPPeroutFailure(t *testing.T) {
+	// Prepare
+	mockDevice := new(deviceControllerMock)
+	mockDevice.On("File").Return(os.NewFile(3, "mock_file"))
+	mockDevice.On("Time").Return(time.Unix(824635825488, 1397965136), nil)
+
+	mockDevice.On("setPinFunc", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("error")).Once()
+	// If first attempt to set PTPPerout fails
+	mockDevice.On("setPTPPerout", mock.Anything).Return(fmt.Errorf("error")).Once()
+
+	// Should retry setPTPPerout with backward compatible flag
+	expectedPeroutRequest := PTPPeroutRequest{
+		Index:        uint32(0),
+		Flags:        uint32(0x0),
+		StartOrPhase: PTPClockTime{Sec: 51},
+		Period:       PTPClockTime{Sec: 1},
+		On:           PTPClockTime{NSec: 500000000},
+	}
+	mockDevice.On("setPTPPerout", expectedPeroutRequest).Return(nil).Once()
+
+	// Act
+	err := ActivatePPSSource(mockDevice)
+
+	// Assert
+	mockDevice.AssertExpectations(t)
+	require.NoError(t, err)
+}
+
+func TestActivatePPSSourceSetPTPPeroutDoubleFailure(t *testing.T) {
+	// Prepare
+	mockDevice := new(deviceControllerMock)
+	mockDevice.On("File").Return(os.NewFile(3, "mock_file"))
+	mockDevice.On("Time").Return(time.Unix(824635825488, 1397965136), nil)
+	mockDevice.On("setPinFunc", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("error")).Once()
+	mockDevice.On("setPTPPerout", mock.Anything).Return(fmt.Errorf("error")).Once()
+	mockDevice.On("setPTPPerout", mock.Anything).Return(fmt.Errorf("error")).Once()
+
+	// Act
+	err := ActivatePPSSource(mockDevice)
+
+	// Assert
+	mockDevice.AssertExpectations(t)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Summary:
WHAT?

Adds tests to ActivatePPSSource function

WHY?

Ensuring functional correctnes, ensuring edge cases work and making the code more maintainable for the future

Considerations:

That's a lot of code!
 - Yeah, but it is necessary to do the rigging for testing the syscalls

Why do you have machBy with return true?
 - To dereference the pointer of the struct passed as argument, and then assert it with require.Equals, which gives nice comparison logs

Reviewed By: leoleovich

Differential Revision: D62447639
