### PR TITLE
Implement ts2phc

### DIFF
--- a/cmd/ptpcheck/cmd/ts2phc.go
+++ b/cmd/ptpcheck/cmd/ts2phc.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/facebook/time/phc"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	srcDeviceTS2PHCFlag string
+	dstDeviceTS2PHCFlag string
+	intervalTS2PHCFlag  time.Duration
+	firstStepTS2PHCFlag time.Duration
+	srcPinTS2PHCFlag    uint
+	dstPinTS2PHCFlag    uint
+)
+
+func init() {
+	RootCmd.AddCommand(ts2phcCmd)
+	ts2phcCmd.Flags().StringVarP(&srcDeviceTS2PHCFlag, "source", "s", "/dev/ptp_tcard", "Source for Time of Day (ToD) data. Only PHC devices are supported at the moment")
+	ts2phcCmd.Flags().StringVarP(&dstDeviceTS2PHCFlag, "destination", "d", "eth0", "PHC to be synchronized. The clock may be identified by its character device (like /dev/ptp0) or its associated network interface (like eth0).")
+	ts2phcCmd.Flags().DurationVarP(&intervalTS2PHCFlag, "interval", "i", time.Second, "Interval between syncs in nanosseconds")
+	ts2phcCmd.Flags().DurationVarP(&firstStepTS2PHCFlag, "first_step", "f", 20*time.Microsecond, "The maximum offset, specified in seconds, that the servo will correct by changing the clock frequency instead of stepping the clock. This is only applied on the first update. When set to 0.0, the servo will not step the clock on start. The default is 0.00002 (20 microseconds).")
+	ts2phcCmd.Flags().UintVarP(&srcPinTS2PHCFlag, "out-pin", "n", phc.DefaultTs2PhcIndex, "output pin number of the PPS signal on source device. Defaults to Pin 3")
+	ts2phcCmd.Flags().UintVarP(&dstPinTS2PHCFlag, "in-pin", "o", phc.DefaultTs2PhcSinkIndex, "input pin number of the PPS signal on destination device. Defaults to Pin 3")
+}
+
+func ts2phcRun(srcDevicePath string, dstDeviceName string, interval time.Duration, stepth time.Duration, srcPinIndex uint) error {
+	ppsSource, err := getPPSSourceFromPath(srcDevicePath, srcPinIndex)
+	if err != nil {
+		return fmt.Errorf("error opening source phc device: %w", err)
+	}
+	dstDevice, err := phcDeviceFromName(dstDeviceName)
+	if err != nil {
+		return fmt.Errorf("error opening target phc device: %w", err)
+	}
+	ppsSink, err := phc.PPSSinkFromDevice(dstDevice, dstPinTS2PHCFlag)
+	if err != nil {
+		return fmt.Errorf("error setting target device as PPS sink: %w", err)
+	}
+	pi, err := phc.NewPiServo(interval, stepth, dstDevice)
+	if err != nil {
+		return fmt.Errorf("error getting servo: %w", err)
+	}
+	ticker := time.NewTicker(interval)
+
+	for range ticker.C {
+		eventTime, err := phc.PollLatestPPSEvent(ppsSink)
+		if err != nil {
+			log.Errorf("Error polling PPS Sink: %v", err)
+			continue
+		} else if eventTime.IsZero() {
+			continue
+		}
+		log.Debugf("PPS event at %+v", eventTime.UnixNano())
+		if err := phc.PPSClockSync(pi, ppsSource, eventTime, dstDevice); err != nil {
+			log.Errorf("Error syncing PHC: %v", err)
+		}
+	}
+	return nil
+}
+
+func getPPSSourceFromPath(srcDevicePath string, pinIndex uint) (*phc.PPSSource, error) {
+	srcDeviceFile, err := os.Open(srcDevicePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening source device: %w", err)
+	}
+	ppsSource, err := phc.ActivatePPSSource(phc.FromFile(srcDeviceFile), pinIndex)
+	if err != nil {
+		return nil, fmt.Errorf("error activating PPS Source for PHC: %w", err)
+	}
+
+	return ppsSource, nil
+}
+
+// phcDeviceFromName returns a PHC device from a device name, which can be either an interface name or a PHC device path
+func phcDeviceFromName(dstDeviceName string) (*phc.Device, error) {
+	devicePath, err := phc.IfaceToPHCDevice(dstDeviceName)
+	if err != nil {
+		log.Infof("Provided device name is not an interface, assuming it is a PHC device path")
+		devicePath = dstDeviceName
+	}
+	// need RW permissions to issue CLOCK_ADJTIME on the device
+	dstFile, err := os.OpenFile(devicePath, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error opening destination device: %w", err)
+	}
+	dstDevice := phc.FromFile(dstFile)
+	return dstDevice, nil
+}
+
+var ts2phcCmd = &cobra.Command{
+	Use:   "ts2phc",
+	Short: "Sync PHC with external timestamps",
+	Run: func(_ *cobra.Command, _ []string) {
+		ConfigureVerbosity()
+		if err := ts2phcRun(srcDeviceTS2PHCFlag, dstDeviceTS2PHCFlag, intervalTS2PHCFlag, firstStepTS2PHCFlag, srcPinTS2PHCFlag); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/phc/device.go
+++ b/phc/device.go
@@ -53,6 +53,9 @@ var iocPinSetfunc2 = ioctl.IOW(ptpClkMagic, 16, unsafe.Sizeof(rawPinDesc{}))
 // ioctlPTPPeroutRequest2 is an IOCTL req corresponding to PTP_PEROUT_REQUEST2 in linux/ptp_clock.h
 var ioctlPTPPeroutRequest2 = ioctl.IOW(ptpClkMagic, 12, unsafe.Sizeof(PTPPeroutRequest{}))
 
+// ioctlExtTTSRequest2 is an IOCTL req corresponding to PTP_EXTTS_REQUEST2 in linux/ptp_clock.h
+var ioctlExtTTSRequest2 = ioctl.IOW(ptpClkMagic, 11, unsafe.Sizeof(PTPExtTTSRequest{}))
+
 // Ifreq is the request we send with SIOCETHTOOL IOCTL
 // as per Linux kernel's include/uapi/linux/if.h
 type Ifreq struct {
@@ -134,6 +137,30 @@ type PTPPeroutRequest struct {
 	Index        uint32       // Which channel to configure
 	Flags        uint32       // Configuration flags
 	On           PTPClockTime // "On" time of the signal. Must be lower than the period. Valid only if (flags & PTP_PEROUT_DUTY_CYCLE) is set.
+}
+
+// Bits of the ptp_extts_request.flags field:
+const (
+	PTPEnableFeature uint32 = 1 << 0 // Enable feature
+	PTPRisingEdge    uint32 = 1 << 1 // Rising edge
+	PTPFallingEdge   uint32 = 1 << 2 // Falling edge
+	PTPStrictFlags   uint32 = 1 << 3 // Strict flags
+	PTPExtOffset     uint32 = 1 << 4 // External offset
+)
+
+// PTPExtTTSRequest as defined in linux/ptp_clock.h
+type PTPExtTTSRequest struct {
+	index uint32
+	flags uint32
+	rsv   [2]uint32
+}
+
+// PTPExtTTS as defined in linux/ptp_clock.h
+type PTPExtTTS struct {
+	T     PTPClockTime /* Time when event occurred. */
+	Index uint32       /* Which channel produced the event. Corresponds to the 'index' field of the PTP_EXTTS_REQUEST and PTP_PEROUT_REQUEST ioctls.*/
+	Flags uint32       /* Event flags */
+	Rsv   [2]uint32    /* Reserved for future use. */
 }
 
 // PTPClockTime as defined in linux/ptp_clock.h

--- a/phc/helper_386.go
+++ b/phc/helper_386.go
@@ -24,6 +24,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func timeToTimespec(time time.Time) (ts unix.Timespec) {
-	return unix.Timespec{Sec: int32(time.Unix()), Nsec: int32(time.Nanosecond())}
+func timeToTimespec(t time.Time) unix.Timespec {
+	return unix.Timespec{Sec: int32(t.Unix()), Nsec: int32(t.Nanosecond())}
+}
+
+func ptpClockTimeToTime(t PTPClockTime) time.Time {
+	return time.Unix(int64(t.Sec), int64(t.NSec))
 }

--- a/phc/helper_64bit.go
+++ b/phc/helper_64bit.go
@@ -24,6 +24,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func timeToTimespec(time time.Time) (ts unix.Timespec) {
-	return unix.Timespec{Sec: time.Unix(), Nsec: int64(time.Nanosecond())}
+func timeToTimespec(t time.Time) unix.Timespec {
+	return unix.Timespec{Sec: t.Unix(), Nsec: int64(t.Nanosecond())}
+}
+
+func ptpClockTimeToTime(t PTPClockTime) time.Time {
+	return time.Unix(t.Sec, int64(t.NSec))
 }

--- a/phc/phc.go
+++ b/phc/phc.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -274,6 +275,10 @@ func (dev *Device) setPTPPerout(req PTPPeroutRequest) error {
 	return dev.ioctl(ioctlPTPPeroutRequest2, unsafe.Pointer(&req))
 }
 
+func (dev *Device) extTTSRequest(req PTPExtTTSRequest) error {
+	return dev.ioctl(ioctlExtTTSRequest2, unsafe.Pointer(&req))
+}
+
 // FreqPPB reads PHC device frequency in PPB (parts per billion)
 func (dev *Device) FreqPPB() (freqPPB float64, err error) { return freqPPBFromDevice(dev) }
 
@@ -282,3 +287,7 @@ func (dev *Device) AdjFreq(freqPPB float64) error { return clockAdjFreq(dev, fre
 
 // Step steps the PHC clock by given duration
 func (dev *Device) Step(step time.Duration) error { return clockStep(dev, step) }
+
+func (dev *Device) Read(buffer []byte) (int, error) {
+	return syscall.Read(int(dev.Fd()), buffer)
+}

--- a/phc/pps_source_mocks.go
+++ b/phc/pps_source_mocks.go
@@ -142,6 +142,20 @@ func (mr *MockDeviceControllerMockRecorder) AdjFreq(freq interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdjFreq", reflect.TypeOf((*MockDeviceController)(nil).AdjFreq), freq)
 }
 
+// Fd mocks base method.
+func (m *MockDeviceController) Fd() uintptr {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Fd")
+	ret0, _ := ret[0].(uintptr)
+	return ret0
+}
+
+// Fd indicates an expected call of Fd.
+func (mr *MockDeviceControllerMockRecorder) Fd() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fd", reflect.TypeOf((*MockDeviceController)(nil).Fd))
+}
+
 // File mocks base method.
 func (m *MockDeviceController) File() *os.File {
 	m.ctrl.T.Helper()
@@ -154,6 +168,21 @@ func (m *MockDeviceController) File() *os.File {
 func (mr *MockDeviceControllerMockRecorder) File() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "File", reflect.TypeOf((*MockDeviceController)(nil).File))
+}
+
+// Read mocks base method.
+func (m *MockDeviceController) Read(buf []byte) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Read", buf)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockDeviceControllerMockRecorder) Read(buf interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockDeviceController)(nil).Read), buf)
 }
 
 // Step mocks base method.
@@ -185,6 +214,20 @@ func (mr *MockDeviceControllerMockRecorder) Time() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Time", reflect.TypeOf((*MockDeviceController)(nil).Time))
 }
 
+// extTTSRequest mocks base method.
+func (m *MockDeviceController) extTTSRequest(req PTPExtTTSRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "extTTSRequest", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// extTTSRequest indicates an expected call of extTTSRequest.
+func (mr *MockDeviceControllerMockRecorder) extTTSRequest(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "extTTSRequest", reflect.TypeOf((*MockDeviceController)(nil).extTTSRequest), req)
+}
+
 // setPTPPerout mocks base method.
 func (m *MockDeviceController) setPTPPerout(req PTPPeroutRequest) error {
 	m.ctrl.T.Helper()
@@ -211,4 +254,95 @@ func (m *MockDeviceController) setPinFunc(index uint, pf PinFunc, ch uint) error
 func (mr *MockDeviceControllerMockRecorder) setPinFunc(index, pf, ch interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setPinFunc", reflect.TypeOf((*MockDeviceController)(nil).setPinFunc), index, pf, ch)
+}
+
+// MockPPSPoller is a mock of PPSPoller interface.
+type MockPPSPoller struct {
+	ctrl     *gomock.Controller
+	recorder *MockPPSPollerMockRecorder
+}
+
+// MockPPSPollerMockRecorder is the mock recorder for MockPPSPoller.
+type MockPPSPollerMockRecorder struct {
+	mock *MockPPSPoller
+}
+
+// NewMockPPSPoller creates a new mock instance.
+func NewMockPPSPoller(ctrl *gomock.Controller) *MockPPSPoller {
+	mock := &MockPPSPoller{ctrl: ctrl}
+	mock.recorder = &MockPPSPollerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPPSPoller) EXPECT() *MockPPSPollerMockRecorder {
+	return m.recorder
+}
+
+// pollPPSSink mocks base method.
+func (m *MockPPSPoller) pollPPSSink() (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "pollPPSSink")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// pollPPSSink indicates an expected call of pollPPSSink.
+func (mr *MockPPSPollerMockRecorder) pollPPSSink() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "pollPPSSink", reflect.TypeOf((*MockPPSPoller)(nil).pollPPSSink))
+}
+
+// MockFrequencyGetter is a mock of FrequencyGetter interface.
+type MockFrequencyGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockFrequencyGetterMockRecorder
+}
+
+// MockFrequencyGetterMockRecorder is the mock recorder for MockFrequencyGetter.
+type MockFrequencyGetterMockRecorder struct {
+	mock *MockFrequencyGetter
+}
+
+// NewMockFrequencyGetter creates a new mock instance.
+func NewMockFrequencyGetter(ctrl *gomock.Controller) *MockFrequencyGetter {
+	mock := &MockFrequencyGetter{ctrl: ctrl}
+	mock.recorder = &MockFrequencyGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockFrequencyGetter) EXPECT() *MockFrequencyGetterMockRecorder {
+	return m.recorder
+}
+
+// FreqPPB mocks base method.
+func (m *MockFrequencyGetter) FreqPPB() (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FreqPPB")
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FreqPPB indicates an expected call of FreqPPB.
+func (mr *MockFrequencyGetterMockRecorder) FreqPPB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FreqPPB", reflect.TypeOf((*MockFrequencyGetter)(nil).FreqPPB))
+}
+
+// MaxFreqAdjPPB mocks base method.
+func (m *MockFrequencyGetter) MaxFreqAdjPPB() (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxFreqAdjPPB")
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MaxFreqAdjPPB indicates an expected call of MaxFreqAdjPPB.
+func (mr *MockFrequencyGetterMockRecorder) MaxFreqAdjPPB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxFreqAdjPPB", reflect.TypeOf((*MockFrequencyGetter)(nil).MaxFreqAdjPPB))
 }

--- a/servo/pi.go
+++ b/servo/pi.go
@@ -128,6 +128,11 @@ func (s *PiServo) SetMaxFreq(freq float64) {
 	s.maxFreq = freq
 }
 
+// GetMaxFreq gets current configured max frequency
+func (s *PiServo) GetMaxFreq() float64 {
+	return s.maxFreq
+}
+
 // IsSpike function to check if offset is considered as spike
 func (s *PiServo) IsSpike(offset int64) bool {
 	if s.filter == nil || s.count < 2 {


### PR DESCRIPTION
Summary:
WHAT?

Implements minimal version of ts2phc command

WHY?

Remove dependency on linuxptp

CONSIDERATIONS:

 - Why not test getPPSSourceFromPath and getPHCDeviceFromName?

   - Trivial implementations, mostly os related, testing seems counterproductive

  - Why not test PPSSinkFromDevice and pollPPSSink ?
    - Can be done in the future, would not add much at the moment.

Differential Revision: D63384165
