### PR TITLE
ptpcheck: phc: add clock setting function

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -58,6 +58,7 @@ const (
 
 // Adjtime issues CLOCK_ADJTIME syscall to either adjust the parameters of given clock,
 // or read them if buf is empty.  man(2) clock_adjtime
+// TODO: replace this with a call to https://pkg.go.dev/golang.org/x/sys/unix#ClockAdjtime
 func Adjtime(clockid int32, buf *unix.Timex) (state int, err error) {
 	r0, _, errno := unix.Syscall(unix.SYS_CLOCK_ADJTIME, uintptr(clockid), uintptr(unsafe.Pointer(buf)), 0)
 	state = int(r0)
@@ -65,6 +66,16 @@ func Adjtime(clockid int32, buf *unix.Timex) (state int, err error) {
 		err = errno
 	}
 	return state, err
+}
+
+// Settime issues clock_settime(3) syscall to set the time of the specified clock.
+// TODO: issue a PR for golang.org/x/sys/unix to add this function there
+func Settime(clockid int32, time *unix.Timespec) (err error) {
+	_, _, errno := unix.Syscall(unix.SYS_CLOCK_SETTIME, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0)
+	if errno != 0 {
+		err = errno
+	}
+	return err
 }
 
 // FrequencyPPB reads device frequency in PPB

--- a/phc/adjtime.go
+++ b/phc/adjtime.go
@@ -61,3 +61,11 @@ func clockStep(dev *Device, step time.Duration) error {
 	}
 	return err
 }
+
+func clockSetTime(dev *Device, t time.Time) error {
+	ts, err := unix.TimeToTimespec(t)
+	if err != nil {
+		return err
+	}
+	return clock.Settime(dev.ClockID(), &ts)
+}

--- a/phc/phc.go
+++ b/phc/phc.go
@@ -288,6 +288,9 @@ func (dev *Device) AdjFreq(freqPPB float64) error { return clockAdjFreq(dev, fre
 // Step steps the PHC clock by given duration
 func (dev *Device) Step(step time.Duration) error { return clockStep(dev, step) }
 
+// SetTime sets the time of the PHC clock
+func (dev *Device) SetTime(t time.Time) error { return clockSetTime(dev, t) }
+
 func (dev *Device) Read(buffer []byte) (int, error) {
 	return syscall.Read(int(dev.Fd()), buffer)
 }


### PR DESCRIPTION
Summary:
Enable the `ptpcheck phc` command to set the PTP clock to a given value.

The new flag, `-s`, takes a Unix timestamp as an argument, and writes it to the PTP device. The resolution is thus limited to whole seconds, so the clock then requires a more precise tuning – achievable, for example, with the sptp program.

Differential Revision: D64134612


