### PR TITLE
reorder timestamp enablement

### DIFF
--- a/timestamp/timestamp_linux.go
+++ b/timestamp/timestamp_linux.go
@@ -102,12 +102,10 @@ func ioctlHWTimestampCaps(fd int, ifname string) (int32, int32, error) {
 		txFilter = hwtstampTXON
 	}
 
-	if hw.rxFilters&(1<<hwtstampFilterAll) > 0 {
-		rxFilter = hwtstampFilterAll
-	} else if hw.rxFilters&(1<<hwtstampFilterPTPv2Event) > 0 {
-		rxFilter = hwtstampFilterPTPv2Event
-	} else if hw.rxFilters&(1<<hwtstampFilterPTPv2L4Event) > 0 {
+	if hw.rxFilters&(1<<hwtstampFilterPTPv2L4Event) > 0 {
 		rxFilter = hwtstampFilterPTPv2L4Event
+	} else if hw.rxFilters&(1<<hwtstampFilterAll) > 0 {
+		rxFilter = hwtstampFilterAll
 	}
 
 	if txFilter == 0 || rxFilter == 0 {


### PR DESCRIPTION
Summary:
We see the situation where on Broadcom hosts with a lot of traffic we spend up to **20% of entire CPU** in softirq due to spin lock implementation (S456418).
In short - if supported - we need to try to enable PTPv2L4 timestamping first and only if it's not supported timestamp all.
In the same diff removing PTPv2L2 timestamping as we don't do PTP over ethernet.

Reviewed By: vvfedorenko

Differential Revision: D64391681


