### PR TITLE
simplify `ptpheck map`

### DIFF
--- a/ntp/responder/server/server_linux.go
+++ b/ntp/responder/server/server_linux.go
@@ -97,7 +97,7 @@ func deleteIfaceIP(iface *net.Interface, addr *net.IP) error {
 
 // PHCOffset periodically checks for PHC-SYS offset and updates it in the config
 func phcOffset(iface string) (time.Duration, error) {
-	device, err := phc.DeviceFromIface(iface)
+	device, err := phc.IfaceToPHCDevice(iface)
 	if err != nil {
 		return 0, err
 	}

--- a/phc/device.go
+++ b/phc/device.go
@@ -18,7 +18,6 @@ package phc
 
 import (
 	"fmt"
-	"net"
 	"unsafe"
 
 	"github.com/vtolstov/go-ioctl"
@@ -215,34 +214,7 @@ func IfaceInfo(iface string) (*EthtoolTSinfo, error) {
 		uintptr(unsafe.Pointer(ifreq)),
 	)
 	if errno != 0 {
-		return nil, fmt.Errorf("failed get phc ID: %w", errno)
+		return nil, fmt.Errorf("failed get phc ID for %s: %w", iface, errno)
 	}
 	return data, nil
-}
-
-// IfaceData has both net.Interface and EthtoolTSinfo
-type IfaceData struct {
-	Iface  net.Interface
-	TSInfo EthtoolTSinfo
-}
-
-// IfacesInfo is like net.Interfaces() but with added EthtoolTSinfo
-func IfacesInfo() ([]IfaceData, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-	res := []IfaceData{}
-	for _, iface := range ifaces {
-		data, err := IfaceInfo(iface.Name)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res,
-			IfaceData{
-				Iface:  iface,
-				TSInfo: *data,
-			})
-	}
-	return res, nil
 }

--- a/phc/device.go
+++ b/phc/device.go
@@ -246,24 +246,3 @@ func IfacesInfo() ([]IfaceData, error) {
 	}
 	return res, nil
 }
-
-// DeviceFromIface returns a path to a PHC device from a network interface
-func DeviceFromIface(iface string) (string, error) {
-	ifaces, err := IfacesInfo()
-	if err != nil {
-		return "", err
-	}
-	if len(ifaces) == 0 {
-		return "", fmt.Errorf("no network devices found")
-	}
-
-	for _, d := range ifaces {
-		if d.Iface.Name == iface {
-			if d.TSInfo.PHCIndex < 0 {
-				return "", fmt.Errorf("no PHC support for %s", iface)
-			}
-			return fmt.Sprintf("/dev/ptp%d", d.TSInfo.PHCIndex), nil
-		}
-	}
-	return "", fmt.Errorf("%s interface is not found", iface)
-}

--- a/phc/device_test.go
+++ b/phc/device_test.go
@@ -17,24 +17,11 @@ limitations under the License.
 package phc
 
 import (
-	"fmt"
 	"testing"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestDeviceFromIfaceNotSupported(t *testing.T) {
-	dev, err := DeviceFromIface("lo")
-	require.Equal(t, fmt.Errorf("no PHC support for lo"), err)
-	require.Equal(t, "", dev)
-}
-
-func TestDeviceFromIfaceNotFound(t *testing.T) {
-	dev, err := DeviceFromIface("lol-does-not-exist")
-	require.Equal(t, fmt.Errorf("lol-does-not-exist interface is not found"), err)
-	require.Equal(t, "", dev)
-}
 
 func TestIoctlValues(t *testing.T) {
 	require.Equal(t, iocPinGetfunc, uintptr(3227532550))

--- a/phc/phc.go
+++ b/phc/phc.go
@@ -94,20 +94,16 @@ const (
 	PinFuncPhySync                // PTP_PF_PHYSYNC
 )
 
-func ifaceInfoToPHCDevice(info *EthtoolTSinfo) (string, error) {
-	if info.PHCIndex < 0 {
-		return "", fmt.Errorf("interface doesn't support PHC")
-	}
-	return fmt.Sprintf("/dev/ptp%d", info.PHCIndex), nil
-}
-
 // IfaceToPHCDevice returns path to PHC device associated with given network card iface
 func IfaceToPHCDevice(iface string) (string, error) {
 	info, err := IfaceInfo(iface)
 	if err != nil {
 		return "", fmt.Errorf("getting interface %s info: %w", iface, err)
 	}
-	return ifaceInfoToPHCDevice(info)
+	if info.PHCIndex < 0 {
+		return "", fmt.Errorf("%s: no PHC support", iface)
+	}
+	return fmt.Sprintf("/dev/ptp%d", info.PHCIndex), nil
 }
 
 // Time returns time we got from network card

--- a/phc/phc_test.go
+++ b/phc/phc_test.go
@@ -22,24 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIfaceInfoToPHCDevice(t *testing.T) {
-	info := &EthtoolTSinfo{
-		PHCIndex: 0,
-	}
-	got, err := ifaceInfoToPHCDevice(info)
-	require.NoError(t, err)
-	require.Equal(t, "/dev/ptp0", got)
-
-	info.PHCIndex = 23
-	got, err = ifaceInfoToPHCDevice(info)
-	require.NoError(t, err)
-	require.Equal(t, "/dev/ptp23", got)
-
-	info.PHCIndex = -1
-	_, err = ifaceInfoToPHCDevice(info)
-	require.Error(t, err)
-}
-
 func TestMaxAdjFreq(t *testing.T) {
 	caps := &PTPClockCaps{
 		MaxAdj: 1000000000,
@@ -51,4 +33,16 @@ func TestMaxAdjFreq(t *testing.T) {
 	caps.MaxAdj = 0
 	got = caps.maxAdj()
 	require.InEpsilon(t, 500000.0, got, 0.00001)
+}
+
+func TestIfaceToPHCDeviceNotSupported(t *testing.T) {
+	dev, err := IfaceToPHCDevice("lo")
+	require.Error(t, err)
+	require.Equal(t, "", dev)
+}
+
+func TestIfaceToPHCDeviceNotFound(t *testing.T) {
+	dev, err := IfaceToPHCDevice("lol-does-not-exist")
+	require.Error(t, err)
+	require.Equal(t, "", dev)
 }


### PR DESCRIPTION
Summary:
Simplify implementation of the `ptpcheck map` command.

Deprecate `phc.IfacesInfo` which is a mere combination of `net.Interfaces` and `phc.IfaceInfo`, was only used in `ptpcheck map` which is simpler AND more optimal without it.

Differential Revision: D64395255


