### PR TITLE
ptpcheck: rename map command to eth

### DIFF
--- a/phc/unix/README.md
+++ b/phc/unix/README.md
@@ -1,0 +1,5 @@
+A temporary shim for "golang.org/x/sys/unix" until v0.27.0 is cut.
+
+We can't simply update go.mod with pre-release version of the package
+because of the dependency management approach Fedora has for building
+RPMs from Go sources.

--- a/phc/unix/ifreq_linux.go
+++ b/phc/unix/ifreq_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+import (
+	"unsafe"
+)
+
+// An Ifreq is a type-safe wrapper around the raw ifreq struct. An Ifreq
+// contains an interface name and a union of arbitrary data which can be
+// accessed using the Ifreq's methods. To create an Ifreq, use the NewIfreq
+// function.
+type Ifreq struct{ raw ifreq }
+
+// NewIfreq creates an Ifreq with the input network interface name
+func NewIfreq(name string) (*Ifreq, error) {
+	if len(name) >= IFNAMSIZ {
+		return nil, EINVAL
+	}
+
+	var ifr ifreq
+	copy(ifr.Ifrn[:], name)
+
+	return &Ifreq{raw: ifr}, nil
+}
+
+// Name returns the interface name associated with the Ifreq.
+func (ifr *Ifreq) Name() string {
+	return ByteSliceToString(ifr.raw.Ifrn[:])
+}
+
+// An ifreqData is an Ifreq which carries pointer data.
+// To produce an ifreqData, use the Ifreq.withData method.
+type ifreqData struct {
+	name [IFNAMSIZ]byte
+	// A type separate from ifreq is required in order to comply with the
+	// unsafe.Pointer rules since the "pointer-ness" of data would not be
+	// preserved if it were cast into the byte array of a raw ifreq.
+	data unsafe.Pointer
+	// Pad to the same size as ifreq.
+	_ [len(ifreq{}.Ifru) - SizeofPtr]byte
+}
+
+// withData produces an ifreqData with the pointer p set for ioctls which require
+// arbitrary pointer data.
+func (ifr Ifreq) withData(p unsafe.Pointer) ifreqData {
+	return ifreqData{
+		name: ifr.raw.Ifrn,
+		data: p,
+	}
+}

--- a/phc/unix/linux.go
+++ b/phc/unix/linux.go
@@ -1,0 +1,140 @@
+//go:build linux
+
+// @generated
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// https://go-review.googlesource.com/c/sys/+/620376
+
+type HwTstampConfig struct {
+	Flags     int32
+	Tx_type   int32
+	Rx_filter int32
+}
+
+// IoctlGetHwTstamp retrieves the hardware timestamping configuration
+// for the network device specified by ifname.
+func IoctlGetHwTstamp(fd int, ifname string) (*HwTstampConfig, error) {
+	ifr, err := NewIfreq(ifname)
+	if err != nil {
+		return nil, err
+	}
+
+	value := HwTstampConfig{}
+	ifrd := ifr.withData(unsafe.Pointer(&value))
+
+	err = ioctlIfreqData(fd, SIOCGHWTSTAMP, &ifrd)
+	return &value, err
+}
+
+// https://go-review.googlesource.com/c/sys/+/619335
+
+type EthtoolTsInfo struct {
+	Cmd             uint32
+	So_timestamping uint32
+	Phc_index       int32
+	Tx_types        uint32
+	Tx_reserved     [3]uint32
+	Rx_filters      uint32
+	Rx_reserved     [3]uint32
+}
+
+// IoctlGetEthtoolTsInfo fetches ethtool timestamping and PHC
+// association for the network device specified by ifname.
+func IoctlGetEthtoolTsInfo(fd int, ifname string) (*EthtoolTsInfo, error) {
+	ifr, err := NewIfreq(ifname)
+	if err != nil {
+		return nil, err
+	}
+
+	value := EthtoolTsInfo{Cmd: ETHTOOL_GET_TS_INFO}
+	ifrd := ifr.withData(unsafe.Pointer(&value))
+
+	err = ioctlIfreqData(fd, SIOCETHTOOL, &ifrd)
+	return &value, err
+}
+
+// bridging to upstream
+
+type Errno = unix.Errno
+type RawSockaddrInet4 = unix.RawSockaddrInet4
+
+func Socket(domain, typ, proto int) (fd int, err error)    { return unix.Socket(domain, typ, proto) }
+func Close(fd int) (err error)                             { return unix.Close(fd) }
+func Syscall(a, b, c, d uintptr) (uintptr, uintptr, Errno) { return unix.Syscall(a, b, c, d) }
+func ByteSliceToString(b []byte) string                    { return unix.ByteSliceToString(b) }
+
+const (
+	AF_INET             = unix.AF_INET //nolint:staticcheck
+	ETHTOOL_GET_TS_INFO = unix.ETHTOOL_GET_TS_INFO
+	SIOCETHTOOL         = unix.SIOCETHTOOL
+	SIOCGHWTSTAMP       = unix.SIOCGHWTSTAMP
+	SOCK_DGRAM          = unix.SOCK_DGRAM
+	SYS_IOCTL           = unix.SYS_IOCTL
+	EAGAIN              = unix.EAGAIN
+	EINVAL              = unix.EINVAL
+	ENOENT              = unix.ENOENT
+	IFNAMSIZ            = unix.IFNAMSIZ
+	SizeofSockaddrInet4 = unix.SizeofSockaddrInet4
+	SizeofPtr           = unix.SizeofPtr
+)
+
+var (
+	errEAGAIN error = syscall.EAGAIN
+	errEINVAL error = syscall.EINVAL
+	errENOENT error = syscall.ENOENT
+)
+
+// ioctlIfreqData performs an ioctl using an ifreqData structure for input
+// and/or output. See the netdevice(7) man page for details.
+func ioctlIfreqData(fd int, req uint, value *ifreqData) error {
+	// The memory layout of IfreqData (type-safe) and ifreq (not type-safe) are
+	// identical so pass *IfreqData directly.
+	return ioctlPtr(fd, req, unsafe.Pointer(value))
+}
+
+func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+	if e1 != 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case EAGAIN:
+		return errEAGAIN
+	case EINVAL:
+		return errEINVAL
+	case ENOENT:
+		return errENOENT
+	}
+	return e
+}

--- a/phc/unix/linux_386.go
+++ b/phc/unix/linux_386.go
@@ -1,0 +1,24 @@
+//go:build 386 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [16]byte
+}

--- a/phc/unix/linux_amd64.go
+++ b/phc/unix/linux_amd64.go
@@ -1,0 +1,24 @@
+//go:build amd64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_arm.go
+++ b/phc/unix/linux_arm.go
@@ -1,0 +1,24 @@
+//go:build arm && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [16]byte
+}

--- a/phc/unix/linux_arm64.go
+++ b/phc/unix/linux_arm64.go
@@ -1,0 +1,24 @@
+//go:build arm64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_loong64.go
+++ b/phc/unix/linux_loong64.go
@@ -1,0 +1,24 @@
+//go:build loong64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_mips.go
+++ b/phc/unix/linux_mips.go
@@ -1,0 +1,24 @@
+//go:build mips && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [16]byte
+}

--- a/phc/unix/linux_mips64.go
+++ b/phc/unix/linux_mips64.go
@@ -1,0 +1,24 @@
+//go:build mips64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_mips64le.go
+++ b/phc/unix/linux_mips64le.go
@@ -1,0 +1,24 @@
+//go:build mips64le && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_mipsle.go
+++ b/phc/unix/linux_mipsle.go
@@ -1,0 +1,24 @@
+//go:build mipsle && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [16]byte
+}

--- a/phc/unix/linux_ppc.go
+++ b/phc/unix/linux_ppc.go
@@ -1,0 +1,24 @@
+//go:build ppc && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [16]byte
+}

--- a/phc/unix/linux_ppc64.go
+++ b/phc/unix/linux_ppc64.go
@@ -1,0 +1,24 @@
+//go:build ppc64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_ppc64le.go
+++ b/phc/unix/linux_ppc64le.go
@@ -1,0 +1,24 @@
+//go:build ppc64le && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_riscv64.go
+++ b/phc/unix/linux_riscv64.go
@@ -1,0 +1,24 @@
+//go:build riscv64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_s390x.go
+++ b/phc/unix/linux_s390x.go
@@ -1,0 +1,24 @@
+//go:build s390x && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}

--- a/phc/unix/linux_sparc64.go
+++ b/phc/unix/linux_sparc64.go
@@ -1,0 +1,24 @@
+//go:build sparc64 && linux
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unix
+
+type ifreq struct {
+	Ifrn [16]byte
+	Ifru [24]byte
+}


### PR DESCRIPTION
Summary: Replace `ptpcheck map` command with `ptpcheck eth` which is appropriate given the extensions we gave it (and yet to give).

Differential Revision: D64493351
