### PR TITLE
time: import golang.org/cl/621375

### DIFF
--- a/phc/unix/linux.go
+++ b/phc/unix/linux.go
@@ -118,6 +118,149 @@ func ClockSettime(clockid int32, time *Timespec) (err error) {
 	return
 }
 
+// https://go-review.googlesource.com/c/sys/+/621375
+
+type (
+	PtpClockCaps struct {
+		Max_adj            int32 //nolint:revive
+		N_alarm            int32 //nolint:revive
+		N_ext_ts           int32 //nolint:revive
+		N_per_out          int32 //nolint:revive
+		Pps                int32
+		N_pins             int32 //nolint:revive
+		Cross_timestamping int32 //nolint:revive
+		Adjust_phase       int32 //nolint:revive
+		Max_phase_adj      int32 //nolint:revive
+		Rsv                [11]int32
+	}
+	PtpClockTime struct {
+		Sec      int64
+		Nsec     uint32
+		Reserved uint32
+	}
+	PtpExttsEvent struct {
+		T     PtpClockTime
+		Index uint32
+		Flags uint32
+		Rsv   [2]uint32
+	}
+	PtpExttsRequest struct {
+		Index uint32
+		Flags uint32
+		Rsv   [2]uint32
+	}
+	PtpPeroutRequest struct {
+		StartOrPhase PtpClockTime
+		Period       PtpClockTime
+		Index        uint32
+		Flags        uint32
+		On           PtpClockTime
+	}
+	PtpPinDesc struct {
+		Name  [64]byte
+		Index uint32
+		Func  uint32
+		Chan  uint32
+		Rsv   [5]uint32
+	}
+	PtpSysOffset struct {
+		Samples uint32
+		Rsv     [3]uint32
+		Ts      [51]PtpClockTime
+	}
+	PtpSysOffsetExtended struct {
+		Samples uint32
+		Rsv     [3]uint32
+		Ts      [25][3]PtpClockTime
+	}
+	PtpSysOffsetPrecise struct {
+		Device   PtpClockTime
+		Realtime PtpClockTime
+		Monoraw  PtpClockTime
+		Rsv      [4]uint32
+	}
+)
+
+const (
+	PTP_CLK_MAGIC             = '='        //nolint:revive
+	PTP_ENABLE_FEATURE        = 0x1        //nolint:revive
+	PTP_EXTTS_EDGES           = 0x6        //nolint:revive
+	PTP_EXTTS_EVENT_VALID     = 0x1        //nolint:revive
+	PTP_EXTTS_V1_VALID_FLAGS  = 0x7        //nolint:revive
+	PTP_EXTTS_VALID_FLAGS     = 0x1f       //nolint:revive
+	PTP_EXT_OFFSET            = 0x10       //nolint:revive
+	PTP_FALLING_EDGE          = 0x4        //nolint:revive
+	PTP_MAX_SAMPLES           = 0x19       //nolint:revive
+	PTP_PEROUT_DUTY_CYCLE     = 0x2        //nolint:revive
+	PTP_PEROUT_ONE_SHOT       = 0x1        //nolint:revive
+	PTP_PEROUT_PHASE          = 0x4        //nolint:revive
+	PTP_PEROUT_V1_VALID_FLAGS = 0x0        //nolint:revive
+	PTP_PEROUT_VALID_FLAGS    = 0x7        //nolint:revive
+	PTP_PIN_GETFUNC           = 0xc0603d06 //nolint:revive
+	PTP_PIN_GETFUNC2          = 0xc0603d0f //nolint:revive
+	PTP_RISING_EDGE           = 0x2        //nolint:revive
+	PTP_STRICT_FLAGS          = 0x8        //nolint:revive
+	PTP_SYS_OFFSET_EXTENDED   = 0xc4c03d09 //nolint:revive
+	PTP_SYS_OFFSET_EXTENDED2  = 0xc4c03d12 //nolint:revive
+	PTP_SYS_OFFSET_PRECISE    = 0xc0403d08 //nolint:revive
+	PTP_SYS_OFFSET_PRECISE2   = 0xc0403d11 //nolint:revive
+)
+
+// FdToClockID derives the clock ID from the file descriptor number
+// - see clock_gettime(3), FD_TO_CLOCKID macros. The resulting ID is
+// suitable for system calls like ClockGettime.
+func FdToClockID(fd int) int32 { return int32(((^fd) << 3) | 3) }
+
+// IoctlPtpClockGetcaps returns the description of a given PTP device.
+func IoctlPtpClockGetcaps(fd int) (*PtpClockCaps, error) {
+	var value PtpClockCaps
+	err := ioctlPtr(fd, PTP_CLOCK_GETCAPS2, unsafe.Pointer(&value))
+	return &value, err
+}
+
+// IoctlPtpSysOffsetPrecise returns a description of the clock
+// offset compared to the system clock.
+func IoctlPtpSysOffsetPrecise(fd int) (*PtpSysOffsetPrecise, error) {
+	var value PtpSysOffsetPrecise
+	err := ioctlPtr(fd, PTP_SYS_OFFSET_PRECISE2, unsafe.Pointer(&value))
+	return &value, err
+}
+
+// IoctlPtpSysOffsetExtended returns an extended description of the
+// clock offset compared to the system clock. The samples parameter
+// specifies the desired number of measurements.
+func IoctlPtpSysOffsetExtended(fd int, samples uint) (*PtpSysOffsetExtended, error) {
+	value := PtpSysOffsetExtended{Samples: uint32(samples)}
+	err := ioctlPtr(fd, PTP_SYS_OFFSET_EXTENDED2, unsafe.Pointer(&value))
+	return &value, err
+}
+
+// IoctlPtpPinGetfunc returns the configuration of the specified
+// I/O pin on given PTP device.
+func IoctlPtpPinGetfunc(fd int, index uint) (*PtpPinDesc, error) {
+	value := PtpPinDesc{Index: uint32(index)}
+	err := ioctlPtr(fd, PTP_PIN_GETFUNC2, unsafe.Pointer(&value))
+	return &value, err
+}
+
+// IoctlPtpPinSetfunc updates configuration of the specified PTP
+// I/O pin.
+func IoctlPtpPinSetfunc(fd int, pd *PtpPinDesc) error {
+	return ioctlPtr(fd, PTP_PIN_SETFUNC2, unsafe.Pointer(pd))
+}
+
+// IoctlPtpPeroutRequest configures the periodic output mode of the
+// PTP I/O pins.
+func IoctlPtpPeroutRequest(fd int, r *PtpPeroutRequest) error {
+	return ioctlPtr(fd, PTP_PEROUT_REQUEST2, unsafe.Pointer(r))
+}
+
+// IoctlPtpExttsRequest configures the external timestamping mode
+// of the PTP I/O pins.
+func IoctlPtpExttsRequest(fd int, r *PtpExttsRequest) error {
+	return ioctlPtr(fd, PTP_EXTTS_REQUEST2, unsafe.Pointer(r))
+}
+
 // bridging to upstream
 
 type Cmsghdr = unix.Cmsghdr
@@ -147,36 +290,36 @@ func TimeToTimespec(t time.Time) (Timespec, error)         { return unix.TimeToT
 func Uname(s *Utsname) error                               { return unix.Uname(s) }
 
 const (
-	AF_INET = unix.AF_INET                         //nolint:revive
-	EAGAIN = unix.EAGAIN                           //nolint:revive
-	EINVAL = unix.EINVAL                           //nolint:revive
-	ENOENT = unix.ENOENT                           //nolint:revive
-	ENOTSUP = unix.ENOTSUP                         //nolint:revive
-	ETHTOOL_GET_TS_INFO = unix.ETHTOOL_GET_TS_INFO //nolint:revive
-	IFNAMSIZ = unix.IFNAMSIZ                       //nolint:revive
-	MSG_ERRQUEUE = unix.MSG_ERRQUEUE               //nolint:revive
-	POLLERR = unix.POLLERR                         //nolint:revive
-	SIOCETHTOOL = unix.SIOCETHTOOL                 //nolint:revive
-	SIOCGHWTSTAMP = unix.SIOCGHWTSTAMP             //nolint:revive
-	SIOCSHWTSTAMP = unix.SIOCSHWTSTAMP             //nolint:revive
-	SizeofPtr = unix.SizeofPtr
-	SizeofSockaddrInet4 = unix.SizeofSockaddrInet4
-	SOCK_DGRAM = unix.SOCK_DGRAM                                       //nolint:revive
-	SOF_TIMESTAMPING_OPT_TSONLY = unix.SOF_TIMESTAMPING_OPT_TSONLY     //nolint:revive
+	AF_INET                       = unix.AF_INET             //nolint:revive
+	EAGAIN                        = unix.EAGAIN              //nolint:revive
+	EINVAL                        = unix.EINVAL              //nolint:revive
+	ENOENT                        = unix.ENOENT              //nolint:revive
+	ENOTSUP                       = unix.ENOTSUP             //nolint:revive
+	ETHTOOL_GET_TS_INFO           = unix.ETHTOOL_GET_TS_INFO //nolint:revive
+	IFNAMSIZ                      = unix.IFNAMSIZ            //nolint:revive
+	MSG_ERRQUEUE                  = unix.MSG_ERRQUEUE        //nolint:revive
+	POLLERR                       = unix.POLLERR             //nolint:revive
+	SIOCETHTOOL                   = unix.SIOCETHTOOL         //nolint:revive
+	SIOCGHWTSTAMP                 = unix.SIOCGHWTSTAMP       //nolint:revive
+	SIOCSHWTSTAMP                 = unix.SIOCSHWTSTAMP       //nolint:revive
+	SizeofPtr                     = unix.SizeofPtr
+	SizeofSockaddrInet4           = unix.SizeofSockaddrInet4
+	SOCK_DGRAM                    = unix.SOCK_DGRAM                    //nolint:revive
+	SOF_TIMESTAMPING_OPT_TSONLY   = unix.SOF_TIMESTAMPING_OPT_TSONLY   //nolint:revive
 	SOF_TIMESTAMPING_RAW_HARDWARE = unix.SOF_TIMESTAMPING_RAW_HARDWARE //nolint:revive
-	SOF_TIMESTAMPING_RX_HARDWARE = unix.SOF_TIMESTAMPING_RX_HARDWARE   //nolint:revive
-	SOF_TIMESTAMPING_RX_SOFTWARE = unix.SOF_TIMESTAMPING_RX_SOFTWARE   //nolint:revive
-	SOF_TIMESTAMPING_SOFTWARE = unix.SOF_TIMESTAMPING_SOFTWARE         //nolint:revive
-	SOF_TIMESTAMPING_TX_HARDWARE = unix.SOF_TIMESTAMPING_TX_HARDWARE   //nolint:revive
-	SOF_TIMESTAMPING_TX_SOFTWARE = unix.SOF_TIMESTAMPING_TX_SOFTWARE   //nolint:revive
-	SOL_SOCKET = unix.SOL_SOCKET                                       //nolint:revive
-	SO_SELECT_ERR_QUEUE = unix.SO_SELECT_ERR_QUEUE                     //nolint:revive
-	SO_TIMESTAMPING_NEW = unix.SO_TIMESTAMPING_NEW                     //nolint:revive
-	SO_TIMESTAMPING = unix.SO_TIMESTAMPING                             //nolint:revive
-	SYS_CLOCK_SETTIME = unix.SYS_CLOCK_SETTIME                         //nolint:revive
-	SYS_IOCTL = unix.SYS_IOCTL                                         //nolint:revive
-	SYS_RECVMSG = unix.SYS_RECVMSG                                     //nolint:revive
-	TIME_OK = unix.TIME_OK                                             //nolint:revive
+	SOF_TIMESTAMPING_RX_HARDWARE  = unix.SOF_TIMESTAMPING_RX_HARDWARE  //nolint:revive
+	SOF_TIMESTAMPING_RX_SOFTWARE  = unix.SOF_TIMESTAMPING_RX_SOFTWARE  //nolint:revive
+	SOF_TIMESTAMPING_SOFTWARE     = unix.SOF_TIMESTAMPING_SOFTWARE     //nolint:revive
+	SOF_TIMESTAMPING_TX_HARDWARE  = unix.SOF_TIMESTAMPING_TX_HARDWARE  //nolint:revive
+	SOF_TIMESTAMPING_TX_SOFTWARE  = unix.SOF_TIMESTAMPING_TX_SOFTWARE  //nolint:revive
+	SOL_SOCKET                    = unix.SOL_SOCKET                    //nolint:revive
+	SO_SELECT_ERR_QUEUE           = unix.SO_SELECT_ERR_QUEUE           //nolint:revive
+	SO_TIMESTAMPING_NEW           = unix.SO_TIMESTAMPING_NEW           //nolint:revive
+	SO_TIMESTAMPING               = unix.SO_TIMESTAMPING               //nolint:revive
+	SYS_CLOCK_SETTIME             = unix.SYS_CLOCK_SETTIME             //nolint:revive
+	SYS_IOCTL                     = unix.SYS_IOCTL                     //nolint:revive
+	SYS_RECVMSG                   = unix.SYS_RECVMSG                   //nolint:revive
+	TIME_OK                       = unix.TIME_OK                       //nolint:revive
 )
 
 var (

--- a/phc/unix/linux_386.go
+++ b/phc/unix/linux_386.go
@@ -1,5 +1,6 @@
 //go:build 386 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [16]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_amd64.go
+++ b/phc/unix/linux_amd64.go
@@ -1,5 +1,6 @@
 //go:build amd64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_arm.go
+++ b/phc/unix/linux_arm.go
@@ -1,5 +1,6 @@
 //go:build arm && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [16]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_arm64.go
+++ b/phc/unix/linux_arm64.go
@@ -1,5 +1,6 @@
 //go:build arm64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_loong64.go
+++ b/phc/unix/linux_loong64.go
@@ -1,5 +1,6 @@
 //go:build loong64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_mips.go
+++ b/phc/unix/linux_mips.go
@@ -1,5 +1,6 @@
 //go:build mips && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [16]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_mips64.go
+++ b/phc/unix/linux_mips64.go
@@ -1,5 +1,6 @@
 //go:build mips64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_mips64le.go
+++ b/phc/unix/linux_mips64le.go
@@ -1,5 +1,6 @@
 //go:build mips64le && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_mipsle.go
+++ b/phc/unix/linux_mipsle.go
@@ -1,5 +1,6 @@
 //go:build mipsle && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [16]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_ppc.go
+++ b/phc/unix/linux_ppc.go
@@ -1,5 +1,6 @@
 //go:build ppc && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [16]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_ppc64.go
+++ b/phc/unix/linux_ppc64.go
@@ -1,5 +1,6 @@
 //go:build ppc64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_ppc64le.go
+++ b/phc/unix/linux_ppc64le.go
@@ -1,5 +1,6 @@
 //go:build ppc64le && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)

--- a/phc/unix/linux_riscv64.go
+++ b/phc/unix/linux_riscv64.go
@@ -1,5 +1,6 @@
 //go:build riscv64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_s390x.go
+++ b/phc/unix/linux_s390x.go
@@ -1,5 +1,6 @@
 //go:build s390x && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x80503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x80503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x40043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x40043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x40103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x40103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x3d13     //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x40043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x40383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x40383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x40603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x40603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x43403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x43403d0e //nolint:revive
+)

--- a/phc/unix/linux_sparc64.go
+++ b/phc/unix/linux_sparc64.go
@@ -1,5 +1,6 @@
 //go:build sparc64 && linux
 
+// @generated
 /*
 Copyright (c) Facebook, Inc. and its affiliates.
 
@@ -22,3 +23,20 @@ type ifreq struct {
 	Ifrn [16]byte
 	Ifru [24]byte
 }
+
+const (
+	PTP_CLOCK_GETCAPS   = 0x40503d01 //nolint:revive
+	PTP_CLOCK_GETCAPS2  = 0x40503d0a //nolint:revive
+	PTP_ENABLE_PPS      = 0x80043d04 //nolint:revive
+	PTP_ENABLE_PPS2     = 0x80043d0d //nolint:revive
+	PTP_EXTTS_REQUEST   = 0x80103d02 //nolint:revive
+	PTP_EXTTS_REQUEST2  = 0x80103d0b //nolint:revive
+	PTP_MASK_CLEAR_ALL  = 0x20003d13 //nolint:revive
+	PTP_MASK_EN_SINGLE  = 0x80043d14 //nolint:revive
+	PTP_PEROUT_REQUEST  = 0x80383d03 //nolint:revive
+	PTP_PEROUT_REQUEST2 = 0x80383d0c //nolint:revive
+	PTP_PIN_SETFUNC     = 0x80603d07 //nolint:revive
+	PTP_PIN_SETFUNC2    = 0x80603d10 //nolint:revive
+	PTP_SYS_OFFSET      = 0x83403d05 //nolint:revive
+	PTP_SYS_OFFSET2     = 0x83403d0e //nolint:revive
+)


### PR DESCRIPTION
Summary:
https://go-review.googlesource.com/c/sys/+/621375: unix: add PTP IOCTLs on Linux

Import into the local shim so we can start adopting the code before the version is cut.

Differential Revision: D64695439


