### PR TITLE
drop PtpClockTime.Time()

### DIFF
--- a/phc/offset.go
+++ b/phc/offset.go
@@ -45,9 +45,9 @@ type SysoffResult struct {
 
 // based on sysoff_estimate from ptp4l sysoff.c
 func sysoffFromExtendedTS(extendedTS [3]PtpClockTime) SysoffResult {
-	t1 := extendedTS[0].Time()
-	tp := extendedTS[1].Time()
-	t2 := extendedTS[2].Time()
+	t1 := time.Unix(extendedTS[0].Sec, int64(extendedTS[0].Nsec))
+	tp := time.Unix(extendedTS[1].Sec, int64(extendedTS[1].Nsec))
+	t2 := time.Unix(extendedTS[2].Sec, int64(extendedTS[2].Nsec))
 	interval := t2.Sub(t1)
 	timestamp := t1.Add(interval / 2)
 	offset := timestamp.Sub(tp)
@@ -60,13 +60,14 @@ func sysoffFromExtendedTS(extendedTS [3]PtpClockTime) SysoffResult {
 }
 
 // SysoffFromPrecise returns SysoffResult from *PTPSysOffsetPrecise . Code based on sysoff_precise from ptp4l sysoff.c
-func SysoffFromPrecise(precise *PTPSysOffsetPrecise) SysoffResult {
-	offset := precise.Realtime.Time().Sub(precise.Device.Time())
+func SysoffFromPrecise(pre *PTPSysOffsetPrecise) SysoffResult {
+	tp := time.Unix(pre.Device.Sec, int64(pre.Device.Nsec))
+	tr := time.Unix(pre.Realtime.Sec, int64(pre.Realtime.Nsec))
 	return SysoffResult{
-		SysTime: precise.Realtime.Time(),
-		PHCTime: precise.Device.Time(),
+		SysTime: tr,
+		PHCTime: tp,
 		Delay:   0, // They are measured at the same time
-		Offset:  offset,
+		Offset:  tr.Sub(tp),
 	}
 }
 

--- a/phc/phc.go
+++ b/phc/phc.go
@@ -90,13 +90,15 @@ func Time(iface string, method TimeMethod) (time.Time, error) {
 			return time.Time{}, err
 		}
 		latest := extended.Ts[extended.Samples-1]
-		return latest[1].Time(), nil
+		tp := latest[1]
+		return time.Unix(tp.Sec, int64(tp.Nsec)), nil
 	case MethodIoctlSysOffsetPrecise:
 		precise, err := dev.ReadSysoffPrecise()
 		if err != nil {
 			return time.Time{}, err
 		}
-		return precise.Device.Time(), nil
+		tp := precise.Device
+		return time.Unix(tp.Sec, int64(tp.Nsec)), nil
 	default:
 		return time.Time{}, fmt.Errorf("unknown method to get PHC time %q", method)
 	}

--- a/phc/pps_source.go
+++ b/phc/pps_source.go
@@ -292,7 +292,8 @@ func (ppsSink *PPSSink) getPPSEventTimestamp() (time.Time, error) {
 		return time.Time{}, fmt.Errorf("extts on unexpected pin index %d, expected %d", event.Index, ppsSink.InputPin)
 	}
 
-	eventTime := event.T.Time()
+	t := event.T
+	eventTime := time.Unix(t.Sec, int64(t.Nsec))
 
 	return eventTime, nil
 }

--- a/phc/unix/linux.go
+++ b/phc/unix/linux.go
@@ -270,25 +270,6 @@ const (
 	PTP_PF_PHYSYNC        //nolint:revive
 )
 
-// https://go-review.googlesource.com/c/sys/+/621498
-
-// TimeToPtpClockTime returns t as PtpClockTime
-func TimeToPtpClockTime(t time.Time) PtpClockTime {
-	sec := t.Unix()
-	nsec := uint32(t.Nanosecond())
-	return PtpClockTime{Sec: sec, Nsec: nsec}
-}
-
-// Time returns PTPClockTime as time.Time
-func (t *PtpClockTime) Time() time.Time {
-	return time.Unix(t.Sec, int64(t.Nsec))
-}
-
-// Unix returns the time stored in t as seconds plus nanoseconds.
-func (t *PtpClockTime) Unix() (sec int64, nsec int64) {
-	return t.Sec, int64(t.Nsec)
-}
-
 // bridging to upstream
 
 type Cmsghdr = unix.Cmsghdr


### PR DESCRIPTION
Summary: Avoid the non-upstreamed PtpClockTime.Time().

On hold until golang/go#70032 is decided upon.

Differential Revision: D64901381


