### PR TITLE
phc2phc use defaultmaxfreq

### DIFF
--- a/cmd/ptpcheck/cmd/phc2phc.go
+++ b/cmd/ptpcheck/cmd/phc2phc.go
@@ -78,9 +78,9 @@ func phc2phcRun(srcDevice string, dstDevice string, interval time.Duration, step
 	if err != nil {
 		log.Warningf("max PHC frequency error: %v", err)
 		maxFreq = phc.DefaultMaxClockFreqPPB
-	} else {
-		pi.SetMaxFreq(maxFreq)
 	}
+	pi.SetMaxFreq(maxFreq)
+
 	log.Debugf("max PHC frequency: %v", maxFreq)
 
 	for ; ; time.Sleep(interval) {


### PR DESCRIPTION
Summary:
WHAT?

Fixes potential issue with pi servo frequency not being set when there is a failure getting it from the device

WHY?
🔨

Considerations:

 - How was this caugh?
   - Found during ts2phc rewrite, this looked funky. ts2phc separates this into function, and upon testing that function this was found.

Reviewed By: abulimov

Differential Revision: D63701624


