### PR TITLE
remove formatter where we don't need it

### DIFF
--- a/calnex/cmd/clear.go
+++ b/calnex/cmd/clear.go
@@ -45,7 +45,7 @@ func clearDevice() error {
 		return err
 	}
 
-	log.Infof("Device data cleared. The device will now reboot.")
+	log.Info("Device data cleared. The device will now reboot.")
 
 	return nil
 }

--- a/calnex/cmd/reboot.go
+++ b/calnex/cmd/reboot.go
@@ -45,7 +45,7 @@ func reboot() error {
 		return err
 	}
 
-	log.Infof("Calnex device will now reboot.")
+	log.Info("Calnex device will now reboot.")
 
 	return nil
 }

--- a/cmd/fbclock-daemon/main.go
+++ b/cmd/fbclock-daemon/main.go
@@ -76,7 +76,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 	if csvPath != "" && !csvLog {
-		log.Fatalf("'csvpath' flag requires 'csvlog' flag")
+		log.Fatal("'csvpath' flag requires 'csvlog' flag")
 	}
 	if cfgPath != "" {
 		log.Warningf("using config from %s, flag values are ignored", cfgPath)

--- a/cmd/ntpcheck/checker/chrony.go
+++ b/cmd/ntpcheck/checker/chrony.go
@@ -86,7 +86,7 @@ func (n *ChronyCheck) Run() (*NTPCheckResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get 'tracking' response: %w", err)
 	}
-	log.Debugf("Got 'tracking' response:")
+	log.Debug("Got 'tracking' response:")
 	log.Debugf("Status: %v", packet.GetStatus())
 	tracking, ok := packet.(*chrony.ReplyTracking)
 	if !ok {

--- a/cmd/ntpcheck/checker/ntpd.go
+++ b/cmd/ntpcheck/checker/ntpd.go
@@ -89,7 +89,7 @@ func (n *NTPCheck) Run() (*NTPCheckResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get 'read status' packet from NTP server: %w", err)
 	}
-	log.Debugf("Got 'read status' response:")
+	log.Debug("Got 'read status' response:")
 	log.Debugf("Version: %v", packet.GetVersion())
 	log.Debugf("Mode: %v", packet.GetMode())
 	log.Debugf("Response: %v", packet.IsResponse())
@@ -113,7 +113,7 @@ func (n *NTPCheck) Run() (*NTPCheckResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get 'read variables' packet from NTP server for associationID=0: %w", err)
 	}
-	log.Debugf("Got 'read variables' response:")
+	log.Debug("Got 'read variables' response:")
 	log.Debugf("Version: %v", infoPacket.GetVersion())
 	log.Debugf("Mode: %v", infoPacket.GetMode())
 	log.Debugf("Response: %v", infoPacket.IsResponse())
@@ -166,7 +166,7 @@ func (n *NTPCheck) ServerStats() (*ServerStats, error) {
 		return nil, fmt.Errorf("failed to get 'server variables' packet from NTP server: %w", err)
 	}
 
-	log.Debugf("Got system 'read variables' response:")
+	log.Debug("Got system 'read variables' response:")
 	log.Debugf("Version: %v", serverVars.GetVersion())
 	log.Debugf("Mode: %v", serverVars.GetMode())
 	log.Debugf("Response: %v", serverVars.IsResponse())

--- a/cmd/ntpcheck/cmd/utils.go
+++ b/cmd/ntpcheck/cmd/utils.go
@@ -103,7 +103,7 @@ func receiveNTPPacketWithRetries(connFd int, buf, oob []byte, tries int) (*ntp.P
 	for try := 0; try < tries; try++ {
 		n, _, clientReceiveTime, err = timestamp.ReadPacketWithRXTimestampBuf(connFd, buf, oob)
 		if errors.Is(err, unix.EINTR) || errors.Is(err, unix.EAGAIN) {
-			log.Debugf("got timeout reading response packet, retrying")
+			log.Debug("got timeout reading response packet, retrying")
 			continue
 		}
 		if err == nil {
@@ -217,7 +217,7 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int, ntp
 				log.Errorf("Client TX timestamp %v not equal to Origin TX timestamp %v", clientTransmitTime, originTime)
 				return err
 			}
-			log.Debugf("skipped one packet from the receive queue")
+			log.Debug("skipped one packet from the receive queue")
 			skipped++
 			serverReceiveTime = ntp.Unix(response.RxTimeSec, response.RxTimeFrac)
 			serverTransmitTime = ntp.Unix(response.TxTimeSec, response.TxTimeFrac)
@@ -233,7 +233,7 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int, ntp
 
 		if i == requests-1 {
 			fmt.Printf("\nServer: %s, Stratum: %d, Requests %d\n", addr, response.Stratum, requests)
-			fmt.Printf("Last Request:\n")
+			fmt.Print("Last Request:")
 			fmt.Printf("Offset: %fs (%sus) | Delay: %fs (%sus)\n",
 				float64(offset)/float64(time.Second.Nanoseconds()),
 				stripZeroes(math.Round(float64(offset)/float64(time.Microsecond.Nanoseconds()))),

--- a/cmd/ntpresponder/main.go
+++ b/cmd/ntpresponder/main.go
@@ -87,7 +87,7 @@ func main() {
 	}
 
 	if s.Config.ShouldAnnounce {
-		log.Warningf("Will announce VIPs")
+		log.Warning("Will announce VIPs")
 	}
 
 	// Monitoring

--- a/cmd/ptpcheck/cmd/trace.go
+++ b/cmd/ptpcheck/cmd/trace.go
@@ -86,7 +86,7 @@ func runTrace(cfg *client.Config) error {
 	if err != nil && !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return err
 	}
-	log.Infof("done")
+	log.Info("done")
 	return nil
 }
 

--- a/cmd/ptpcheck/cmd/ts2phc.go
+++ b/cmd/ptpcheck/cmd/ts2phc.go
@@ -110,7 +110,7 @@ func getPPSSourceFromPath(srcDevicePath string, pinIndex uint) (*phc.PPSSource, 
 func phcDeviceFromName(dstDeviceName string) (*phc.Device, error) {
 	devicePath, err := phc.IfaceToPHCDevice(dstDeviceName)
 	if err != nil {
-		log.Infof("Provided device name is not an interface, assuming it is a PHC device path")
+		log.Info("Provided device name is not an interface, assuming it is a PHC device path")
 		devicePath = dstDeviceName
 	}
 	// need RW permissions to issue CLOCK_ADJTIME on the device

--- a/cmd/ziffy/main.go
+++ b/cmd/ziffy/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 
 	if c.IcmpTimeout < 100*time.Millisecond {
-		log.Warnf("setting timeout < 100ms for ICMP replies may lead to inaccurate results")
+		log.Warn("setting timeout < 100ms for ICMP replies may lead to inaccurate results")
 	}
 
 	switch messageType {
@@ -124,7 +124,7 @@ func main() {
 
 	switch c.Mode {
 	case "receiver":
-		log.Infof("RECEIVER")
+		log.Info("RECEIVER")
 
 		r := node.Receiver{
 			Config: c,
@@ -133,10 +133,10 @@ func main() {
 			log.Errorf("receiver start failed: %v", err)
 		}
 	case "sender":
-		log.Infof("SENDER")
+		log.Info("SENDER")
 
 		if c.DestinationAddress == "" {
-			log.Fatalf("A target host is required in 'sender' mode; use -addr {hostname} to specify target")
+			log.Fatal("A target host is required in 'sender' mode; use -addr {hostname} to specify target")
 		}
 
 		s := node.Sender{
@@ -153,6 +153,6 @@ func main() {
 			node.CsvPrint(c, info, s.Config.CsvFile, ptp.NewCorrection(float64(nsCFThreshold)))
 		}
 	default:
-		log.Errorf("--mode must be sender or receiver")
+		log.Error("--mode must be sender or receiver")
 	}
 }

--- a/cmd/ziffy/node/print.go
+++ b/cmd/ziffy/node/print.go
@@ -107,7 +107,7 @@ func debugPrint(routes []*PathInfo) {
 		}
 	}
 
-	log.Debugf("TESTED:")
+	log.Debug("TESTED:")
 	aux := make([]string, 0, len(tested))
 	for key := range tested {
 		aux = append(aux, getLookUpName(key))

--- a/cmd/ziffy/node/receiver.go
+++ b/cmd/ziffy/node/receiver.go
@@ -107,7 +107,7 @@ func (r *Receiver) handlePacket(rawPacket gopacket.Packet) {
 		return
 	}
 	if ptpSync.Header.ControlField != ZiffyHexa {
-		log.Tracef("no ziffy packet")
+		log.Trace("no ziffy packet")
 		return
 	}
 

--- a/cmd/ziffy/node/sender.go
+++ b/cmd/ziffy/node/sender.go
@@ -297,17 +297,17 @@ func (s *Sender) monitorIcmp(conn net.PacketConn) {
 func (s *Sender) handleIcmpPacket(rawPacket []byte, l int, rAddr net.Addr) {
 	icmpType := rawPacket[0]
 	if ipv6.ICMPType(icmpType) != ipv6.ICMPTypeTimeExceeded {
-		log.Tracef("not ipv6 timeexceeded packet")
+		log.Trace("not ipv6 timeexceeded packet")
 		return
 	}
 	ptpOffset := Ipv6HeaderSize + UDPHeaderSize + ICMPHeaderSize
 	if ptpOffset > l {
-		log.Tracef("packet too short")
+		log.Trace("packet too short")
 		return
 	}
 	ptpPacket, err := ptp.DecodePacket(rawPacket[ptpOffset:l])
 	if err != nil {
-		log.Tracef("PTP not contained in ICMP")
+		log.Trace("PTP not contained in ICMP")
 		return
 	}
 

--- a/fbclock/daemon/daemon.go
+++ b/fbclock/daemon/daemon.go
@@ -359,7 +359,7 @@ func (s *Daemon) doWork(shm *fbclock.Shm, data *DataPoint) error {
 		timeSinceIngress := phcTime.UnixNano() - it
 		log.Debugf("Time since ingress: %dns", timeSinceIngress)
 	} else {
-		log.Warningf("No data for time since ingress")
+		log.Warning("No data for time since ingress")
 	}
 	// read tzdata for leap seconds
 	leaps, err := leapSeconds()

--- a/ntp/responder/server/server.go
+++ b/ntp/responder/server/server.go
@@ -102,7 +102,7 @@ func (s *Server) Start(ctx context.Context, cancelFunc context.CancelFunc) {
 
 	// Run PHC-SYS offset periodically
 	if s.Config.TimestampType == timestamp.HWRX {
-		log.Infof("Starting periodic measurement between phc and sysclock")
+		log.Info("Starting periodic measurement between phc and sysclock")
 		go func() {
 			for ; ; time.Sleep(time.Second) {
 				offset, err := phcOffset(s.Config.Iface)

--- a/ptp/c4u/c4u.go
+++ b/ptp/c4u/c4u.go
@@ -39,9 +39,9 @@ func SdNotify() error {
 	if !supported && err != nil {
 		return err
 	} else if !supported {
-		log.Warningf("sd_notify not supported")
+		log.Warning("sd_notify not supported")
 	} else {
-		log.Infof("successfully sent sd_notify event")
+		log.Info("successfully sent sd_notify event")
 	}
 	return nil
 }

--- a/ptp/linearizability/linearizability_ptp4l.go
+++ b/ptp/linearizability/linearizability_ptp4l.go
@@ -393,7 +393,7 @@ func (lt *PTP4lTester) handleMsg(msg *inPacket) error {
 					if v.DurationField == 0 {
 						return fmt.Errorf("%w for %v", ErrGrantDenied, tlvType)
 					}
-					log.Debugf("got unicast grant for Delay Response")
+					log.Debug("got unicast grant for Delay Response")
 					if err := lt.sendDelay(); err != nil {
 						return err
 					}
@@ -463,7 +463,7 @@ func (lt *PTP4lTester) runListener(ctx context.Context) {
 
 	lt.listenerRunning = true
 	<-ctx.Done()
-	log.Debugf("cancelled port receiver")
+	log.Debug("cancelled port receiver")
 }
 
 // runSingleTest performs one Tester run and will exit on completion.
@@ -487,7 +487,7 @@ func (lt *PTP4lTester) runSingleTest(ctx context.Context, subDuration time.Durat
 		for {
 			select {
 			case <-ctx.Done():
-				log.Debugf("cancelled main loop")
+				log.Debug("cancelled main loop")
 				return ctx.Err()
 			case msg := <-lt.inChan:
 				if err := lt.handleMsg(msg); err != nil {

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -117,7 +117,7 @@ func (s *Server) Start() error {
 			}
 
 			if shouldDrain {
-				log.Warningf("shifting traffic")
+				log.Warning("shifting traffic")
 				s.Drain()
 				s.Stats.SetDrain(1)
 			} else {
@@ -283,7 +283,7 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 				log.Errorf("Failed to read the ptp SyncDelayReq: %v", err)
 				continue
 			}
-			log.Debugf("Got delay request")
+			log.Debug("Got delay request")
 			worker = s.findWorker(dReq.Header.SourcePortIdentity, r)
 			if dReq.FlagField == ptp.FlagProfileSpecific1|ptp.FlagUnicast {
 				expire = time.Now().Add(subscriptionDuration)
@@ -450,7 +450,7 @@ func (s *Server) Undrain() {
 
 // handleSighup watches for SIGHUP and reloads the dynamic config
 func (s *Server) handleSighup() {
-	log.Infof("Engaging the SIGHUP monitoring")
+	log.Info("Engaging the SIGHUP monitoring")
 	sigchan := make(chan os.Signal, 10)
 	signal.Notify(sigchan, unix.SIGHUP)
 	for range sigchan {
@@ -470,7 +470,7 @@ func (s *Server) handleSighup() {
 
 // handleSigterm watches for SIGTERM and SIGINT and removes the pid file
 func (s *Server) handleSigterm() {
-	log.Infof("Engaging the SIGTERM/SIGINT monitoring")
+	log.Info("Engaging the SIGTERM/SIGINT monitoring")
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, unix.SIGTERM, unix.SIGINT)
 	<-sigchan

--- a/ptp/ptp4u/server/worker.go
+++ b/ptp/ptp4u/server/worker.go
@@ -159,7 +159,7 @@ func (s *sendWorker) Start() {
 					log.Errorf("Failed to generate the sync packet: %v", err)
 					continue
 				}
-				log.Debugf("Sending sync")
+				log.Debug("Sending sync")
 
 				err = unix.Sendto(eFd, buf[:n], 0, c.eclisa)
 				if err != nil {
@@ -233,7 +233,7 @@ func (s *sendWorker) Start() {
 					log.Errorf("Failed to generate the sync packet: %v", err)
 					continue
 				}
-				log.Debugf("Sending sync")
+				log.Debug("Sending sync")
 
 				err = unix.Sendto(eFd, buf[:n], 0, c.eclisa)
 				if err != nil {

--- a/ptp/simpleclient/client.go
+++ b/ptp/simpleclient/client.go
@@ -255,7 +255,7 @@ func (c *Client) setup(ctx context.Context, eg *errgroup.Group) error {
 		}()
 		select {
 		case <-ctx.Done():
-			log.Debugf("cancelled general port receiver")
+			log.Debug("cancelled general port receiver")
 			return ctx.Err()
 		case err = <-doneChan:
 			return err
@@ -281,7 +281,7 @@ func (c *Client) setup(ctx context.Context, eg *errgroup.Group) error {
 		}()
 		select {
 		case <-ctx.Done():
-			log.Debugf("cancelled event port receiver")
+			log.Debug("cancelled event port receiver")
 			return ctx.Err()
 		case err = <-doneChan:
 			return err
@@ -322,7 +322,7 @@ func (c *Client) handleGrantUnicast(tlv *ptp.GrantUnicastTransmissionTLV) error 
 		if tlv.DurationField == 0 {
 			return fmt.Errorf("server denied us grant for %s", msgType)
 		}
-		log.Infof("unicast handshake complete")
+		log.Info("unicast handshake complete")
 	default:
 		return fmt.Errorf("got unexpected grant for %s", msgType)
 	}
@@ -483,7 +483,7 @@ func (c *Client) runInternal(skipSetup bool) error {
 		for {
 			select {
 			case <-ctx.Done():
-				log.Debugf("cancelled main loop")
+				log.Debug("cancelled main loop")
 				return ctx.Err()
 			case msg := <-c.inChan:
 				if err := c.handleMsg(msg); err != nil {

--- a/ptp/sptp/client/sptp.go
+++ b/ptp/sptp/client/sptp.go
@@ -152,7 +152,7 @@ func (p *SPTP) init() error {
 	timestamp.TimeoutTXTS = p.cfg.TimeoutTXTS
 
 	if p.cfg.FreeRunning {
-		log.Warningf("operating in FreeRunning mode, will NOT adjust clock")
+		log.Warning("operating in FreeRunning mode, will NOT adjust clock")
 		p.clock = &FreeRunningClock{}
 	} else {
 		if p.cfg.Timestamping == timestamp.HW {
@@ -250,7 +250,7 @@ func (p *SPTP) RunListener(ctx context.Context) error {
 		}()
 		select {
 		case <-ctx.Done():
-			log.Debugf("cancelled general port receiver")
+			log.Debug("cancelled general port receiver")
 			return ctx.Err()
 		case err := <-doneChan:
 			return err
@@ -296,7 +296,7 @@ func (p *SPTP) RunListener(ctx context.Context) error {
 			}()
 			select {
 			case <-ctx.Done():
-				log.Debugf("cancelled event port receiver")
+				log.Debug("cancelled event port receiver")
 				return ctx.Err()
 			case err := <-doneChan:
 				return err
@@ -395,7 +395,7 @@ func (p *SPTP) processResults(results map[netip.Addr]*RunResult) {
 	}
 	best := bmca(results, localPrioMap, p.cfg)
 	if best == nil {
-		log.Warningf("no Best Master selected")
+		log.Warning("no Best Master selected")
 		p.bestGM = netip.Addr{}
 		freqAdj := p.setMeanFreq()
 		log.Infof("offset Unknown s%d freq %+7.0f path delay Unknown", servo.StateHoldover, -freqAdj)
@@ -442,7 +442,7 @@ func (p *SPTP) processResults(results map[netip.Addr]*RunResult) {
 			log.Errorf("failed to adjust freq to %v: %v", -freqAdj, err)
 		}
 		if err := p.clock.SetSync(); err != nil {
-			log.Errorf("failed to set clock sync state")
+			log.Error("failed to set clock sync state")
 		}
 		// make sure we don't step after we get into the locked state
 		p.pi.UnsetFirstUpdate()
@@ -488,7 +488,7 @@ func (p *SPTP) runInternal(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Debugf("cancelled main loop")
+			log.Debug("cancelled main loop")
 			freqAdj := p.pi.MeanFreq()
 			log.Infof("Existing, setting freq to: %v", -freqAdj)
 			if err := p.clock.AdjFreqPPB(-1 * freqAdj); err != nil {
@@ -505,7 +505,7 @@ func (p *SPTP) runInternal(ctx context.Context) error {
 // Run makes things run, continuously
 func (p *SPTP) Run(ctx context.Context) error {
 	go func() {
-		log.Debugf("starting listener")
+		log.Debug("starting listener")
 		if err := p.RunListener(ctx); err != nil {
 			log.Fatal(err)
 		}

--- a/servo/pi.go
+++ b/servo/pi.go
@@ -192,7 +192,7 @@ func (s *PiServo) Sample(offset int64, localTs uint64) (float64, State) {
 			freqEstInterval = 1000.0
 		}
 		if localDiff < freqEstInterval {
-			log.Warningf("servo Sample is called too often, not enough time passed since first sample")
+			log.Warning("servo Sample is called too often, not enough time passed since first sample")
 			break
 		}
 


### PR DESCRIPTION
Summary: Avoid invoking formatter where there are no placeholders

Reviewed By: deathowl

Differential Revision: D66573138


