### PR TITLE
introduce ALTERNATE_RESPONSE_PORT TLV

### DIFF
--- a/fbclock/daemon/logging_test.go
+++ b/fbclock/daemon/logging_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,7 +69,7 @@ func TestLogSample_CSVRecords(t *testing.T) {
 	// make sure we are in sync with header
 	require.Equal(t, len(header), len(got))
 
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 }
 
 func TestCSVLogger_Log(t *testing.T) {
@@ -91,5 +90,5 @@ func TestCSVLogger_Log(t *testing.T) {
 1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2,2.1,2.2,2.3,25.1
 `
 
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 }

--- a/fbclock/daemon/math_test.go
+++ b/fbclock/daemon/math_test.go
@@ -19,7 +19,6 @@ package daemon
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +52,7 @@ func TestConvolve(t *testing.T) {
 		-1.67567686e+08,
 	}
 	require.Equal(t, len(want1), len(got1))
-	assert.InEpsilonSlice(t, want1, got1, 1e+10)
+	require.InEpsilonSlice(t, want1, got1, 1e+10)
 
 	coeffs2 := []float64{1, 3, -3, 1}
 	got2, err := convolve(input, coeffs2)
@@ -67,25 +66,25 @@ func TestConvolve(t *testing.T) {
 		-3.29784203e+08,
 	}
 	require.Equal(t, len(want2), len(got2))
-	assert.InEpsilonSlice(t, want2, got2, 1e+10)
+	require.InEpsilonSlice(t, want2, got2, 1e+10)
 }
 
 func TestMean(t *testing.T) {
 	input := []float64{3, 5, 8, 8}
 	want := 6.0
-	assert.Equal(t, want, mean(input))
+	require.Equal(t, want, mean(input))
 	input = []float64{1, 4, 0, 3, 8}
 	want = 3.2
-	assert.Equal(t, want, mean(input))
+	require.Equal(t, want, mean(input))
 }
 
 func TestVariance(t *testing.T) {
 	input := []float64{8, 8, 8, 8}
 	want := 0.0
-	assert.Equal(t, want, variance(input))
+	require.Equal(t, want, variance(input))
 	input = []float64{1, 4, 0, 3, 8}
 	want = 9.7
-	assert.Equal(t, want, variance(input))
+	require.Equal(t, want, variance(input))
 }
 
 func TestPrepareExpression(t *testing.T) {
@@ -103,7 +102,7 @@ func TestPrepareExpression(t *testing.T) {
 	want := 250.1909601786838
 	got, err := expr.Evaluate(parameters)
 	require.Nil(t, err)
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 }
 
 func TestPrepareExpressionWrongVari(t *testing.T) {

--- a/ptp/linearizability/linearizability_ptp4l.go
+++ b/ptp/linearizability/linearizability_ptp4l.go
@@ -110,8 +110,8 @@ func reqDelay(clockID ptp.ClockIdentity, port uint16) *ptp.SyncDelayReq {
 		Header: ptp.Header{
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageDelayReq, 0),
 			Version:         ptp.Version,
-			SequenceID:      0, // will be populated on sending
-			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			SequenceID:      0,                                                                       // will be populated on sending
+			MessageLength:   uint16(binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{})), //#nosec G115
 			FlagField:       ptp.FlagUnicast,
 			SourcePortIdentity: ptp.PortIdentity{
 				PortNumber:    port,

--- a/ptp/protocol/protocol_test.go
+++ b/ptp/protocol/protocol_test.go
@@ -542,6 +542,20 @@ func FuzzDecodePacket(f *testing.F) {
 						return
 					}
 				}
+			case MessageSync, MessageDelayReq:
+				m := packet.(*SyncDelayReq)
+				// ignore Sync/DelayReq with GrantUnicastTransmissionTLV, TLVPathTrace or TLVAlternateTimeOffsetIndicator TLVs
+				for _, tlv := range m.TLVs {
+					if tlv.Type() == TLVGrantUnicastTransmission {
+						return
+					}
+					if tlv.Type() == TLVAlternateTimeOffsetIndicator {
+						return
+					}
+					if tlv.Type() == TLVPathTrace {
+						return
+					}
+				}
 			}
 			bb, err := Bytes(packet)
 			require.NoError(t, err)

--- a/ptp/protocol/types.go
+++ b/ptp/protocol/types.go
@@ -98,6 +98,7 @@ const (
 	TLVAcknowledgeCancelUnicastTransmission TLVType = 0x0007
 	TLVPathTrace                            TLVType = 0x0008
 	TLVAlternateTimeOffsetIndicator         TLVType = 0x0009
+	TLVAlternateResponsePort                TLVType = 0x2007
 	// Remaining 52 tlvType TLVs not implemented
 )
 
@@ -112,6 +113,7 @@ var TLVTypeToString = map[TLVType]string{
 	TLVAcknowledgeCancelUnicastTransmission: "ACKNOWLEDGE_CANCEL_UNICAST_TRANSMISSION",
 	TLVPathTrace:                            "PATH_TRACE",
 	TLVAlternateTimeOffsetIndicator:         "ALTERNATE_TIME_OFFSET_INDICATOR",
+	TLVAlternateResponsePort:                "ALTERNATE_RESPONSE_PORT",
 }
 
 func (t TLVType) String() string {

--- a/ptp/protocol/types_test.go
+++ b/ptp/protocol/types_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,6 +90,7 @@ func TestTLVTypeString(t *testing.T) {
 	require.Equal(t, "ACKNOWLEDGE_CANCEL_UNICAST_TRANSMISSION", TLVAcknowledgeCancelUnicastTransmission.String())
 	require.Equal(t, "PATH_TRACE", TLVPathTrace.String())
 	require.Equal(t, "ALTERNATE_TIME_OFFSET_INDICATOR", TLVAlternateTimeOffsetIndicator.String())
+	require.Equal(t, "ALTERNATE_RESPONSE_PORT", TLVAlternateResponsePort.String())
 }
 
 func TestTimeSourceString(t *testing.T) {
@@ -178,7 +178,7 @@ func TestTimeIntervalNanoseconds(t *testing.T) {
 			require.Equal(t, tt.wantStr, tt.in.String())
 			// then convert time.Time we just got back to Timestamp
 			gotTI := NewTimeInterval(got)
-			assert.Equal(t, tt.in, gotTI)
+			require.Equal(t, tt.in, gotTI)
 		})
 	}
 }
@@ -208,7 +208,7 @@ func TestPTPSeconds(t *testing.T) {
 			require.Equal(t, tt.wantStr, tt.in.String())
 			// then convert time.Time we just got back to PTPSeconds
 			gotTS := NewPTPSeconds(got)
-			assert.Equal(t, tt.in, gotTS)
+			require.Equal(t, tt.in, gotTS)
 		})
 	}
 }
@@ -244,7 +244,7 @@ func TestTimestamp(t *testing.T) {
 			require.Equal(t, tt.wantStr, tt.in.String())
 			// then convert time.Time we just got back to Timestamp
 			gotTS := NewTimestamp(got)
-			assert.Equal(t, tt.in, gotTS)
+			require.Equal(t, tt.in, gotTS)
 		})
 	}
 }
@@ -341,7 +341,7 @@ func TestLogInterval(t *testing.T) {
 			// then convert time.Duration we just got back to LogInterval
 			gotLI, err := NewLogInterval(gotDuration)
 			require.Nil(t, err)
-			assert.Equal(t, tt.in, gotLI)
+			require.Equal(t, tt.in, gotLI)
 		})
 	}
 }
@@ -353,11 +353,11 @@ func TestClockIdentity(t *testing.T) {
 	got, err := NewClockIdentity(mac)
 	require.Nil(t, err)
 	want := ClockIdentity(0xc42a1fffe6d7ca6)
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 	wantStr := "0c42a1.fffe.6d7ca6"
-	assert.Equal(t, wantStr, got.String())
+	require.Equal(t, wantStr, got.String())
 	back := got.MAC()
-	assert.Equal(t, mac, back)
+	require.Equal(t, mac, back)
 }
 
 func TestPTPText(t *testing.T) {
@@ -415,14 +415,14 @@ func TestPTPText(t *testing.T) {
 			var text PTPText
 			err := text.UnmarshalBinary(tt.in)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.Nil(t, err)
-				assert.Equal(t, tt.want, string(text))
+				require.Equal(t, tt.want, string(text))
 
 				gotBytes, err := text.MarshalBinary()
 				require.Nil(t, err)
-				assert.Equal(t, tt.in, gotBytes)
+				require.Equal(t, tt.in, gotBytes)
 			}
 		})
 	}
@@ -512,7 +512,7 @@ func TestPortAddress(t *testing.T) {
 			var addr PortAddress
 			err := addr.UnmarshalBinary(tt.in)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.Nil(t, err)
 				ip, err := addr.IP()
@@ -522,12 +522,12 @@ func TestPortAddress(t *testing.T) {
 				}
 				require.Nil(t, err)
 
-				assert.Equal(t, *tt.want, addr)
-				assert.True(t, tt.wantIP.Equal(ip), "expect parsed IP %v to be equal to %v", ip, tt.wantIP)
+				require.Equal(t, *tt.want, addr)
+				require.True(t, tt.wantIP.Equal(ip), "expect parsed IP %v to be equal to %v", ip, tt.wantIP)
 
 				gotBytes, err := addr.MarshalBinary()
 				require.Nil(t, err)
-				assert.Equal(t, tt.in, gotBytes)
+				require.Equal(t, tt.in, gotBytes)
 			}
 		})
 	}

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -246,6 +246,7 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 	buf := make([]byte, timestamp.PayloadSizeBytes)
 	oob := make([]byte, timestamp.ControlSizeBytes)
 	dReq := &ptp.SyncDelayReq{}
+	zerotlv := []ptp.TLV{}
 	// Initialize the new random. We will re-seed it every time in findWorker
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	var msgType ptp.MessageType
@@ -253,6 +254,7 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 	var sc *SubscriptionClient
 	var gclisa unix.Sockaddr
 	var expire time.Time
+	var workerOffset int64
 
 	for {
 		bbuf, eclisa, rxTS, err := timestamp.ReadPacketWithRXTimestampBuf(s.eFd, buf, oob)
@@ -279,12 +281,21 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 
 		switch msgType {
 		case ptp.MessageDelayReq:
+			dReq.TLVs = zerotlv
 			if err := ptp.FromBytes(buf[:bbuf], dReq); err != nil {
 				log.Errorf("Failed to read the ptp SyncDelayReq: %v", err)
 				continue
 			}
 			log.Debug("Got delay request")
-			worker = s.findWorker(dReq.Header.SourcePortIdentity, r)
+			// CSPTP AlternateResponsePortTLV POC
+			for _, tlv := range dReq.TLVs {
+				switch v := tlv.(type) {
+				case *ptp.AlternateResponsePortTLV:
+					workerOffset = int64(v.Offset)
+				}
+			}
+
+			worker = s.findWorker(dReq.Header.SourcePortIdentity, r, workerOffset)
 			if dReq.FlagField == ptp.FlagProfileSpecific1|ptp.FlagUnicast {
 				expire = time.Now().Add(subscriptionDuration)
 				// SYNC DELAY_REQUEST and ANNOUNCE
@@ -365,7 +376,7 @@ func (s *Server) handleGeneralMessages(generalConn *net.UDPConn) {
 
 					switch signalingType {
 					case ptp.MessageAnnounce, ptp.MessageSync, ptp.MessageDelayResp:
-						worker = s.findWorker(signaling.SourcePortIdentity, r)
+						worker = s.findWorker(signaling.SourcePortIdentity, r, 0)
 						sc = worker.FindSubscription(signaling.SourcePortIdentity, signalingType)
 						if sc == nil || !sc.Running() {
 							ip := timestamp.SockaddrToIP(gclisa)
@@ -400,7 +411,7 @@ func (s *Server) handleGeneralMessages(generalConn *net.UDPConn) {
 					signalingType = v.MsgTypeAndFlags.MsgType()
 					s.Stats.IncRXSignalingCancel(signalingType)
 					log.Debugf("Got %s cancel request", signalingType)
-					worker = s.findWorker(signaling.SourcePortIdentity, r)
+					worker = s.findWorker(signaling.SourcePortIdentity, r, 0)
 					sc = worker.FindSubscription(signaling.SourcePortIdentity, signalingType)
 					if sc != nil {
 						sc.Stop()
@@ -415,9 +426,9 @@ func (s *Server) handleGeneralMessages(generalConn *net.UDPConn) {
 	}
 }
 
-func (s *Server) findWorker(clientID ptp.PortIdentity, r *rand.Rand) *sendWorker {
+func (s *Server) findWorker(clientID ptp.PortIdentity, r *rand.Rand, offset int64) *sendWorker {
 	// Seeding random with the same value will produce the same number
-	r.Seed(int64(clientID.ClockIdentity) + int64(clientID.PortNumber))
+	r.Seed(int64(clientID.ClockIdentity) + int64(clientID.PortNumber) + offset) //#nosec G115
 	return s.sw[r.Intn(s.Config.SendWorkers)]
 }
 

--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -66,12 +66,12 @@ func TestFindWorker(t *testing.T) {
 	}
 
 	// Consistent across multiple calls
-	require.Equal(t, 0, s.findWorker(clipi1, r).id)
-	require.Equal(t, 0, s.findWorker(clipi1, r).id)
-	require.Equal(t, 0, s.findWorker(clipi1, r).id)
+	require.Equal(t, 0, s.findWorker(clipi1, r, 0).id)
+	require.Equal(t, 0, s.findWorker(clipi1, r, 0).id)
+	require.Equal(t, 0, s.findWorker(clipi1, r, 0).id)
 
-	require.Equal(t, 3, s.findWorker(clipi2, r).id)
-	require.Equal(t, 1, s.findWorker(clipi3, r).id)
+	require.Equal(t, 3, s.findWorker(clipi2, r, 0).id)
+	require.Equal(t, 1, s.findWorker(clipi3, r, 0).id)
 }
 
 func TestStartEventListener(t *testing.T) {

--- a/ptp/ptp4u/server/subscription.go
+++ b/ptp/ptp4u/server/subscription.go
@@ -201,7 +201,7 @@ func (sc *SubscriptionClient) initSync() {
 		Header: ptp.Header{
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0),
 			Version:         ptp.Version,
-			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			MessageLength:   uint16(binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{})), //#nosec G115
 			DomainNumber:    uint8(sc.serverConfig.DomainNumber),
 			FlagField:       ptp.FlagUnicast | ptp.FlagTwoStep,
 			SequenceID:      0,

--- a/ptp/simpleclient/client_test.go
+++ b/ptp/simpleclient/client_test.go
@@ -102,7 +102,7 @@ func announcePkt(seq int) *ptp.Announce {
 }
 
 func syncPkt(seq int) *ptp.SyncDelayReq {
-	l := binary.Size(ptp.SyncDelayReq{})
+	l := binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{})
 	return &ptp.SyncDelayReq{
 		Header: ptp.Header{
 			SdoIDAndMsgType:    ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0),

--- a/ptp/simpleclient/requests.go
+++ b/ptp/simpleclient/requests.go
@@ -95,8 +95,8 @@ func reqDelay(clockID ptp.ClockIdentity) *ptp.SyncDelayReq {
 		Header: ptp.Header{
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageDelayReq, 0),
 			Version:         ptp.Version,
-			SequenceID:      0, // will be populated on sending
-			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			SequenceID:      0,                                                                       // will be populated on sending
+			MessageLength:   uint16(binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{})), //#nosec G115
 			FlagField:       ptp.FlagUnicast,
 			SourcePortIdentity: ptp.PortIdentity{
 				PortNumber:    1,

--- a/ptp/sptp/client/client.go
+++ b/ptp/sptp/client/client.go
@@ -37,8 +37,8 @@ func ReqDelay(clockID ptp.ClockIdentity, portID uint16) *ptp.SyncDelayReq {
 		Header: ptp.Header{
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(ptp.MessageDelayReq, 0),
 			Version:         ptp.Version,
-			SequenceID:      0, // will be populated on sending
-			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			SequenceID:      0,                                                                       // will be populated on sending
+			MessageLength:   uint16(binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{})), //#nosec G115
 			FlagField:       ptp.FlagUnicast | ptp.FlagProfileSpecific1,
 			SourcePortIdentity: ptp.PortIdentity{
 				PortNumber:    portID,
@@ -163,7 +163,7 @@ func NewClient(target netip.Addr, targetPort int, clockID ptp.ClockIdentity, eve
 		sequenceIDMask:  sequenceIDMask,
 		sequenceIDValue: sequenceIDMaskedValue,
 		delayRequest:    ReqDelay(clockID, 1),
-		delayReqBytes:   make([]byte, binary.Size(ptp.Header{})+binary.Size(ptp.SyncDelayReq{})),
+		delayReqBytes:   make([]byte, binary.Size(ptp.Header{})+binary.Size(ptp.SyncDelayReqBody{})+ptp.TrailingBytes),
 		eventConn:       eventConn,
 		eventAddr:       eventAddr,
 		inChan:          make(chan bool, 100),


### PR DESCRIPTION
Summary:
Introduce a new TLV as a POC to support switching port on the GM side. This is an important step towards the asymmetry compensation.
We use a `offset` flag which is uint16 (65536 combinations) which ensures consistency:
```
offset 0 = noop
offset 1 = switch to the next available port
offset 2 = switch to the next next available port
...
offset 65535 = you get the idea
```

For example we have 2 buildings with 2 paths between - short and long (ex 1km vs 3+km)
When forward and return paths are the same (short + short)  or (long + long) everything is good.
Suddenly something changed on the network and path rehashing results in short + long paths (or long + short for completeness).
At this moment we see a large path delay change to from say `(5us + 5us)/ 2 = 5us` to `(5us + 15us) / 2 = 10us`.
This is a problem which only gonna get worse with other DC types where 1km vs 10km paths are possible.
What this change is going to do is:
If we suspect the path change - we can ask GM to start sending packets from different port until we recover the path symmetry. We can't influence the exact port of the GM, but we can basically ask to switch to a next one (in test plan it's visible as `34488`->`38509`). This will be a TLV with `offset = 1`
If this doesn't help we can try jumping to a "next next" port (which in test plan seen as `38509->47977`) - this is `offset = 2`
Because GM doesn't keep this state (hello simple PTP) we now have to submit this counter every time to preserve the "shift". If we set it to 0 (or don't submit the TLV) we will get back to original port `34488`.

Randomly changing count value results in:
```
08:07:02.490110 IP6 client.ptp-event > server.ptp-event: PTPv18
08:07:02.490357 IP6 server.34488 > client.ptp-event: PTPv18
08:07:02.490434 IP6 server.47064 > client.ptp-general: PTPv18

08:07:03.490066 IP6 client.ptp-event > server.ptp-event: PTPv18
08:07:03.490379 IP6 server.38509 > client.ptp-event: PTPv18
08:07:03.490392 IP6 server.63604 > client.ptp-general: PTPv18

08:07:04.490507 IP6 client.ptp-event > server.ptp-event: PTPv18
08:07:04.490755 IP6 server.47977 > client.ptp-event: PTPv18
08:07:04.490836 IP6 server.49796 > client.ptp-general: PTPv18

08:07:05.491305 IP6 client.ptp-event > server.ptp-event: PTPv18
08:07:05.491541 IP6 server.34987 > client.ptp-event: PTPv18
08:07:05.491562 IP6 server.35270 > client.ptp-general: PTPv18
```

One can see new port usages in server -> client communication

Differential Revision: D66656872


