### PR TITLE
undo forced port 319

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -291,12 +291,14 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 				if sc = worker.FindSubscription(dReq.Header.SourcePortIdentity, ptp.MessageDelayReq); sc == nil {
 					gclisa = timestamp.NewSockaddrWithPort(eclisa, ptp.PortGeneral)
 					// Create a new subscription
-					sc = NewSubscriptionClient(worker.queue, worker.signalingQueue, timestamp.NewSockaddrWithPort(eclisa, ptp.PortEvent), gclisa, ptp.MessageDelayReq, s.Config, subscriptionDuration, expire)
+					sc = NewSubscriptionClient(worker.queue, worker.signalingQueue, eclisa, gclisa, ptp.MessageDelayReq, s.Config, subscriptionDuration, expire)
 					worker.RegisterSubscription(dReq.Header.SourcePortIdentity, ptp.MessageDelayReq, sc)
 					go sc.Start(s.ctx)
 				} else {
 					// bump the subscription
 					sc.SetExpire(expire)
+					// sptp is stateless, port can change
+					sc.eclisa = eclisa
 				}
 				sc.UpdateSyncDelayReq(rxTS, dReq.SequenceID)
 				sc.UpdateAnnounceDelayReq(dReq.CorrectionField, dReq.SequenceID)


### PR DESCRIPTION
Summary:
After https://github.com/facebook/time/commit/1fb59ca9bc6b8e08a679efc6a86c2c0dbc46d3ac SPTP sends packets from port 319 and we no longer need this hack in ptp4u.

And with this change ptp4u is able to respond to `ptpings`!

Reviewed By: deathowl

Differential Revision: D61858305


