### PR TITLE
align chrony and ptp smearing timelines

### DIFF
--- a/fbclock/daemon/daemon.go
+++ b/fbclock/daemon/daemon.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	utcOffsetOriginalS int32  = 10    // UTC-TAI offset was 10s before leap seconds started (1972)
-	leapDurationS      uint64 = 65000 // 18.06 hours
+	leapDurationS      uint64 = 62500 // 17.36 hours https://chrony-project.org/doc/4.6/chrony.conf.html
 	monPrefix          string = "linearizability."
 )
 

--- a/fbclock/daemon/daemon_test.go
+++ b/fbclock/daemon/daemon_test.go
@@ -421,7 +421,7 @@ func TestDaemonCalculateSHMData(t *testing.T) {
 		ErrorBoundNS:         123.0,
 		HoldoverMultiplierNS: 64.5,
 		SmearingStartS:       1483228836,
-		SmearingEndS:         1483293836,
+		SmearingEndS:         1483291336,
 		UTCOffsetPreS:        36,
 		UTCOffsetPostS:       37,
 	}
@@ -464,7 +464,7 @@ func TestDaemonCalculateSHMData(t *testing.T) {
 		ErrorBoundNS:         157,
 		HoldoverMultiplierNS: 9362.84482758621,
 		SmearingStartS:       1483228836,
-		SmearingEndS:         1483293836,
+		SmearingEndS:         1483291336,
 		UTCOffsetPreS:        36,
 		UTCOffsetPostS:       37,
 	}
@@ -673,7 +673,7 @@ func TestLeapSecondSmearing(t *testing.T) {
 	got := leapSecondSmearing(leaps)
 	want := &clockSmearing{
 		smearingStartS: 1483228836, // Sun, 01 Jan 2017 00:00:36 TAI (or Sat, 31 Dec 2016 12:00:00 UTC)
-		smearingEndS:   1483293836, // Sun, 01 Jan 2017 18:03:56 TAI (or Sun, 01 Jan 2017 18:03:19 UTC)
+		smearingEndS:   1483291336, // Sun, 01 Jan 2017 17:22:53 TAI (or Sun, 01 Jan 2017 17:22:16 UTC)
 		utcOffsetPreS:  35,
 		utcOffsetPostS: 36,
 	}


### PR DESCRIPTION
Summary: Bring 2 smearing strategies to start/finish at the same time

Reviewed By: deathowl

Differential Revision: D66967712


