### PR TITLE
add CAP_NET_RAW to github worker running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.22
-      - run: sudo apt-get install libpcap-dev
+      - run: sudo apt-get install libpcap-dev libcap2-bin
       - run: go build -v ./...
       # fuzzing, need to specify each package separately
       - run: go test -v -fuzz='.*' -fuzztime=10s ./ptp/protocol/
       - run: go test -v -fuzz='.*' -fuzztime=10s ./ntp/protocol/
       - run: go test -v -fuzz='.*' -fuzztime=10s ./ntp/chrony/
       - name: Run coverage
-        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: sudo capsh --inh=cap_net_raw --print -- -c "go test -v -race -coverprofile=coverage.txt -covermode=atomic ./..."
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Summary: TestPing fails because of lack of CAP_NET_RAW to open RAW socket. Add this capability to test runner

Differential Revision: D67863697


