### PR TITLE
exclude flaky Ping test from race check

### DIFF
--- a/calnex/verify/checks/checks_test.go
+++ b/calnex/verify/checks/checks_test.go
@@ -116,29 +116,6 @@ func TestHTTPError(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
-func TestPing(t *testing.T) {
-	r := PingRemediation{}
-	c := Ping{Remediation: r}
-	require.Equal(t, "Ping", c.Name())
-
-	err := c.Run("::1", false)
-	require.NoError(t, err)
-}
-
-func TestPingError(t *testing.T) {
-	r := PingRemediation{}
-	c := Ping{Remediation: r}
-	require.Equal(t, "Ping", c.Name())
-
-	err := c.Run("1.2.3.4", false)
-	require.Error(t, err)
-
-	want, _ := r.Remediate()
-	got, err := c.Remediate()
-	require.NoError(t, err)
-	require.Equal(t, want, got)
-}
-
 func TestPSU(t *testing.T) {
 	r := PSURemediation{}
 	c := PSU{Remediation: r}

--- a/calnex/verify/checks/ping_test.go
+++ b/calnex/verify/checks/ping_test.go
@@ -1,0 +1,49 @@
+//go:build !race
+// +build !race
+
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPing(t *testing.T) {
+	r := PingRemediation{}
+	c := Ping{Remediation: r}
+	require.Equal(t, "Ping", c.Name())
+
+	err := c.Run("::1", false)
+	require.NoError(t, err)
+}
+
+func TestPingError(t *testing.T) {
+	r := PingRemediation{}
+	c := Ping{Remediation: r}
+	require.Equal(t, "Ping", c.Name())
+
+	err := c.Run("1.2.3.4", false)
+	require.Error(t, err)
+
+	want, _ := r.Remediate()
+	got, err := c.Remediate()
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
Summary: Ping tests are flaky on GitHub, let's move them to a different test file and exclude them from racy tests

Differential Revision: D67942189


