### PR TITLE
fix sync packet length

### DIFF
--- a/cmd/ziffy/node/packets.go
+++ b/cmd/ziffy/node/packets.go
@@ -66,7 +66,7 @@ func formSyncPacket(msgType ptp.MessageType, hop int, routeIndex int) *ptp.SyncD
 		Header: ptp.Header{
 			SdoIDAndMsgType: ptp.NewSdoIDAndMsgType(msgType, 0),
 			Version:         ptp.Version,
-			MessageLength:   uint16(binary.Size(ptp.SyncDelayReq{})),
+			MessageLength:   uint16(binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{})), //#nosec G115
 			FlagField:       ptp.FlagUnicast,
 			SequenceID:      uint16(hop),
 			SourcePortIdentity: ptp.PortIdentity{

--- a/ptp/sptp/client/client_test.go
+++ b/ptp/sptp/client/client_test.go
@@ -49,7 +49,7 @@ func announcePkt(seq int) *ptp.Announce {
 }
 
 func syncPkt(seq int) *ptp.SyncDelayReq {
-	l := binary.Size(ptp.SyncDelayReq{})
+	l := binary.Size(ptp.Header{}) + binary.Size(ptp.SyncDelayReqBody{}) //#nosec G115
 	return &ptp.SyncDelayReq{
 		Header: ptp.Header{
 			SdoIDAndMsgType:    ptp.NewSdoIDAndMsgType(ptp.MessageSync, 0),


### PR DESCRIPTION
Summary: Alternate Port TLV made sync packets non-fixed size.

Reviewed By: leoleovich

Differential Revision: D68329227


