### PR TITLE
make fbclock-bin compile in mock root

### DIFF
--- a/cmd/fbclock-bin/Makefile
+++ b/cmd/fbclock-bin/Makefile
@@ -2,7 +2,7 @@ CC=gcc
 CFLAGS=-Wall -g -lrt -msse4.2 -std=gnu11
 
 fbclock-bin:
-	$(CC) $(CFLAGS) -o fbclock-bin -I ../../../ fbclock-bin.c ../../fbclock/fbclock.c
+	$(CC) $(CFLAGS) -o fbclock-bin fbclock-bin.c ../../fbclock/fbclock.c
 
 .PHONY: clean
 

--- a/cmd/fbclock-bin/fbclock-bin.c
+++ b/cmd/fbclock-bin/fbclock-bin.c
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "time/fbclock/fbclock.h"
+#include "../../fbclock/fbclock.h"
 
 #include <stdio.h> // for printf and perror
 #include <stdlib.h> // for EXIT_* constants


### PR DESCRIPTION
Summary:
It fails because project root in mock build is not `time`, it's `time-<commit>`:
```
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.ELzalV
+ umask 022
+ cd /builddir/build/BUILD/golang-github-facebook-time-0_20250320git7aa5a0f-build
/builddir/build/BUILD/golang-github-facebook-time-0_20250320git7aa5a0f-build/time-7aa5a0f301b66872715509922356dc6a95090ef0
gcc -Wall -g -lrt -msse4.2 -std=gnu11 -o fbclock-bin -I ../../../ fbclock-bin.c ../../fbclock/fbclock.c
fbclock-bin.c:17:10: fatal error: time/fbclock/fbclock.h: No such file or directory
   17 | #include "time/fbclock/fbclock.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
```

Differential Revision: D71617115


