### PR TITLE
Optimizes hashing for findWorker

### DIFF
--- a/ptp/ptp4u/server/server_test.go
+++ b/ptp/ptp4u/server/server_test.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"math/rand"
 	"net"
 	"os"
 	"testing"
@@ -32,7 +31,6 @@ import (
 )
 
 func TestFindWorker(t *testing.T) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	c := &Config{
 		clockIdentity: ptp.ClockIdentity(1234),
 		StaticConfig: StaticConfig{
@@ -66,12 +64,12 @@ func TestFindWorker(t *testing.T) {
 	}
 
 	// Consistent across multiple calls
-	require.Equal(t, 0, s.findWorker(clipi1, r, 0).id)
-	require.Equal(t, 0, s.findWorker(clipi1, r, 0).id)
-	require.Equal(t, 0, s.findWorker(clipi1, r, 0).id)
+	require.Equal(t, 3, s.findWorker(clipi1, 0).id)
+	require.Equal(t, 3, s.findWorker(clipi1, 0).id)
+	require.Equal(t, 3, s.findWorker(clipi1, 0).id)
 
-	require.Equal(t, 3, s.findWorker(clipi2, r, 0).id)
-	require.Equal(t, 1, s.findWorker(clipi3, r, 0).id)
+	require.Equal(t, 7, s.findWorker(clipi2, 0).id)
+	require.Equal(t, 6, s.findWorker(clipi3, 0).id)
 }
 
 func TestStartEventListener(t *testing.T) {


### PR DESCRIPTION
Summary:
WHAT?
Changes math/rand based approach for hashing with xxhash algorithm

WHY?
Current approach is not scaling very well, especially in the context of additional parallel executions. Xxhash is faster, 0 allocation and is more uniform, as seen by comparing the standard deviation of the generated hash.

Considerations:
- Why not write our own hash?
  - Other code at Meta already relies on xxhash, so reuse seemed appropriate
- Why not just module?
  - Very uneven distribution

Reviewed By: deathowl

Differential Revision: D73934719


