### PR TITLE
sptp: use custom ring buffer and quickselect in window.go

### DIFF
--- a/ptp/sptp/client/window.go
+++ b/ptp/sptp/client/window.go
@@ -70,36 +70,36 @@ func (w *slidingWindow) allSamples() []float64 {
 	return w.sorted[0:w.currentSize]
 }
 
-func medianOfThree(arr []float64, low, high int) {
+func medianOfThree(data []float64, low, high int) {
 	mid := low + (high-low)/2
-	if (arr[low] > arr[mid]) != (arr[low] > arr[high]) {
-		arr[low], arr[high] = arr[high], arr[low]
-	} else if (arr[mid] > arr[low]) != (arr[mid] > arr[high]) {
-		arr[mid], arr[high] = arr[high], arr[mid]
+	if (data[low] > data[mid]) != (data[low] > data[high]) {
+		data[low], data[high] = data[high], data[low]
+	} else if (data[low] > data[mid]) != (data[high] > data[mid]) {
+		data[mid], data[high] = data[high], data[mid]
 	}
 }
 
-func partition(arr []float64, low, high int) int {
+func partition(data []float64, low, high int) int {
 	if high-low > 3 {
-		medianOfThree(arr, low, high)
+		medianOfThree(data, low, high)
 	}
-	pivot := arr[high]
+	pivot := data[high]
 	i := low
 	for j := low; j < high; j++ {
-		if arr[j] < pivot {
-			arr[i], arr[j] = arr[j], arr[i]
+		if data[j] < pivot {
+			data[i], data[j] = data[j], data[i]
 			i++
 		}
 	}
-	arr[i], arr[high] = arr[high], arr[i]
+	data[i], data[high] = data[high], data[i]
 	return i
 }
 
-func quickselect(arr []float64, low, high, k int) float64 {
+func quickselect(data []float64, low, high, k int) float64 {
 	for low <= high {
-		pi := partition(arr, low, high)
+		pi := partition(data, low, high)
 		if pi == k {
-			return arr[pi]
+			return data[pi]
 		} else if pi < k {
 			low = pi + 1
 		} else {


### PR DESCRIPTION
## Summary


It looks like "container/ring" was removed due to allocations in https://github.com/facebook/time/commit/7940a9b508a563e8f3f65f937b1431a022d42b58

While the current O(n) add() is fine with small window sizes, we can easily add a head tracking and make it behave like a ring buffer with O(1) add() operations.

Additionally using the quickselect algorithm instead of a (modified) quicksort, we can save some compute time while searching for the median since we don't care about the order of the latter part of the array.


## Test Plan

Here's a quick vibe coded benchmark. While micro benchmarks aren't the best way to benchmark anything, at least it's pretty easy to see how the ring buffer makes the add operations perform much faster even with relatively small window sizes.

EDIT: The benchmark now includes the median of three pivot selection. It really doesn't change the results with these random values, but it should prevent the worst cases from sorted arrays, etc.

window_benchmark_test.go
```go
package client

import (
	"fmt"
	"math"
	"math/rand"
	"sort"
	"testing"
)

// =====================================================================================
// Implementation 1: Original Shifting Slice
// =====================================================================================

type slidingWindowOriginal struct {
	size        int
	currentSize int
	sum         float64
	samples     []float64
	sorted      []float64
}

func newSlidingWindowOriginal(size int) *slidingWindowOriginal {
	if size < 1 {
		size = 1
	}
	w := &slidingWindowOriginal{
		size:    size,
		samples: make([]float64, size),
		sorted:  make([]float64, size),
	}
	for i := 0; i < w.size; i++ {
		w.samples[i] = math.NaN()
		w.sorted[i] = math.NaN()
	}
	return w
}

func (w *slidingWindowOriginal) add(sample float64) {
	if !w.Full() {
		w.currentSize++
	} else {
		w.sum -= w.samples[w.size-1]
	}
	// This is the inefficient part - O(n) operation
	for i := w.currentSize - 1; i > 0; i-- {
		w.samples[i] = w.samples[i-1]
	}
	w.samples[0] = sample
	w.sum += sample
}

func (w *slidingWindowOriginal) allSamples() []float64 {
	for j, v := range w.samples {
		if !math.IsNaN(v) {
			w.sorted[j] = v
		}
	}
	return w.sorted[0:w.currentSize]
}

func (w *slidingWindowOriginal) median() float64 {
	c := w.allSamples()
	sort.Float64s(c) // O(n log n)
	l := len(c)
	if l == 0 {
		return math.NaN()
	} else if l%2 == 0 {
		return mean(c[l/2-1 : l/2+1])
	}
	return c[l/2]
}

func (w *slidingWindowOriginal) Full() bool {
	return w.currentSize == w.size
}

// =====================================================================================
// Implementation 2: Ring Buffer
// =====================================================================================

type slidingWindowRing struct {
	size        int
	currentSize int
	head        int
	sum         float64
	samples     []float64
	sorted      []float64
}

func newSlidingWindowRing(size int) *slidingWindowRing {
	if size < 1 {
		size = 1
	}
	w := &slidingWindowRing{
		size:    size,
		head:    size - 1,
		samples: make([]float64, size),
		sorted:  make([]float64, size),
	}
	for i := 0; i < w.size; i++ {
		w.samples[i] = math.NaN()
		w.sorted[i] = math.NaN()
	}
	return w
}

func (w *slidingWindowRing) add(sample float64) {
	w.head = (w.head + 1) % w.size
	if !math.IsNaN(w.samples[w.head]) {
		w.sum -= w.samples[w.head]
	} else {
		w.currentSize++
	}
	w.samples[w.head] = sample
	w.sum += sample
}

func (w *slidingWindowRing) allSamples() []float64 {
	for j, v := range w.samples {
		if !math.IsNaN(v) {
			w.sorted[j] = v
		}
	}
	return w.sorted[0:w.currentSize]
}

func (w *slidingWindowRing) median() float64 {
	c := w.allSamples()
	sort.Float64s(c) // O(n log n)
	l := len(c)
	if l == 0 {
		return math.NaN()
	} else if l%2 == 0 {
		return mean(c[l/2-1 : l/2+1])
	}
	return c[l/2]
}

func (w *slidingWindowRing) Full() bool {
	return w.currentSize == w.size
}

// =====================================================================================
// Implementation 3: Ring Buffer with Quickselect Median
// =====================================================================================

type slidingWindowQuickselect struct {
	slidingWindowRing // Embed the ring buffer implementation
}

func newSlidingWindowQuickselect(size int) *slidingWindowQuickselect {
	return &slidingWindowQuickselect{*newSlidingWindowRing(size)}
}

func medianOfThree(arr []float64, low, high int) {
	mid := low + (high-low)/2
	if (arr[low] > arr[mid]) != (arr[low] > arr[high]) {
		arr[low], arr[high] = arr[high], arr[low]
	} else if (arr[mid] > arr[low]) != (arr[mid] > arr[high]) {
		arr[mid], arr[high] = arr[high], arr[mid]
	}
}

// partition is a helper for quickselect
func partition(arr []float64, low, high int) int {
	if high-low > 3 {
		medianOfThree(arr, low, high)
	}
	pivot := arr[high]
	i := low
	for j := low; j < high; j++ {
		if arr[j] < pivot {
			arr[i], arr[j] = arr[j], arr[i]
			i++
		}
	}
	arr[i], arr[high] = arr[high], arr[i]
	return i
}

// quickselect finds the k-th smallest element in an array (O(n) average time).
func quickselect(arr []float64, low, high, k int) float64 {
	for low <= high {
		pi := partition(arr, low, high)
		if pi == k {
			return arr[pi]
		} else if pi < k {
			low = pi + 1
		} else {
			high = pi - 1
		}
	}
	return math.NaN() // Should not happen with valid inputs
}

func (w *slidingWindowQuickselect) median() float64 {
	c := w.allSamples() // O(n) to copy
	l := len(c)
	if l == 0 {
		return math.NaN()
	}
	if l%2 == 1 {
		return quickselect(c, 0, l-1, l/2)
	}
	mid1 := quickselect(c, 0, l-1, l/2-1)
	mid2 := c[l/2]
	for i := l/2 + 1; i < l; i++ {
		if c[i] < mid2 {
			mid2 = c[i]
		}
	}
	return (mid1 + mid2) / 2.0
}

// =====================================================================================
// SHARED UTILS
// =====================================================================================
func mean(data []float64) float64 {
	sum := 0.0
	for _, v := range data {
		sum += v
	}
	return sum / float64(len(data))
}

// =====================================================================================
// BENCHMARK SETUP
// =====================================================================================

var (
	addBenchmarkSizes    = []int{10, 100, 1000, 10000}
	medianBenchmarkSizes = []int{10, 11, 100, 101, 1000, 1001, 10000, 10001}
	randomData           = make([]float64, 1000000)
)

func init() {
	for i := range randomData {
		randomData[i] = rand.Float64() * 1000
	}
}

// =====================================================================================
// BENCHMARKS
// =====================================================================================

func BenchmarkAdd(b *testing.B) {
	b.Run("Original", func(b *testing.B) {
		for _, size := range addBenchmarkSizes {
			b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
				w := newSlidingWindowOriginal(size)
				b.ReportAllocs()
				b.ResetTimer()
				for i := 0; i < b.N; i++ {
					w.add(randomData[i%len(randomData)])
				}
			})
		}
	})
	b.Run("RingBuffer", func(b *testing.B) {
		for _, size := range addBenchmarkSizes {
			b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
				w := newSlidingWindowRing(size)
				b.ReportAllocs()
				b.ResetTimer()
				for i := 0; i < b.N; i++ {
					w.add(randomData[i%len(randomData)])
				}
			})
		}
	})
	// Add benchmark for Quickselect is the same as RingBuffer, so we don't need a separate one.
}

func BenchmarkMedian(b *testing.B) {
	b.Run("Original", func(b *testing.B) {
		for _, size := range medianBenchmarkSizes {
			b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
				w := newSlidingWindowOriginal(size)
				for i := 0; i < size; i++ {
					w.add(randomData[i])
				}
				b.ReportAllocs()
				b.ResetTimer()
				for i := 0; i < b.N; i++ {
					w.median()
				}
			})
		}
	})
	b.Run("RingBuffer", func(b *testing.B) {
		for _, size := range medianBenchmarkSizes {
			b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
				w := newSlidingWindowRing(size)
				for i := 0; i < size; i++ {
					w.add(randomData[i])
				}
				b.ReportAllocs()
				b.ResetTimer()
				for i := 0; i < b.N; i++ {
					w.median()
				}
			})
		}
	})
	b.Run("Quickselect", func(b *testing.B) {
		for _, size := range medianBenchmarkSizes {
			b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
				w := newSlidingWindowQuickselect(size)
				for i := 0; i < size; i++ {
					w.add(randomData[i])
				}
				b.ReportAllocs()
				b.ResetTimer()
				for i := 0; i < b.N; i++ {
					w.median()
				}
			})
		}
	})
}
```

```
goos: darwin
goarch: arm64
cpu: Apple M1
BenchmarkAdd/Original/size=10-8         169256193                6.928 ns/op           0 B/op          0 allocs/op
BenchmarkAdd/Original/size=100-8                24860890                48.27 ns/op            0 B/op          0 allocs/op
BenchmarkAdd/Original/size=1000-8                2504211               479.3 ns/op             0 B/op          0 allocs/op
BenchmarkAdd/Original/size=10000-8                506365              4684 ns/op               0 B/op          0 allocs/op
BenchmarkAdd/RingBuffer/size=10-8               173754271                6.906 ns/op           0 B/op          0 allocs/op
BenchmarkAdd/RingBuffer/size=100-8              173885017                6.906 ns/op           0 B/op          0 allocs/op
BenchmarkAdd/RingBuffer/size=1000-8             173831155                6.908 ns/op           0 B/op          0 allocs/op
BenchmarkAdd/RingBuffer/size=10000-8            173178780                6.933 ns/op           0 B/op          0 allocs/op
BenchmarkMedian/Original/size=10-8              23243857                51.96 ns/op            0 B/op          0 allocs/op
BenchmarkMedian/Original/size=11-8              20970252                56.97 ns/op            0 B/op          0 allocs/op
BenchmarkMedian/Original/size=100-8              1349672               890.5 ns/op             0 B/op          0 allocs/op
BenchmarkMedian/Original/size=101-8              1236194               970.8 ns/op             0 B/op          0 allocs/op
BenchmarkMedian/Original/size=1000-8               73087             15588 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Original/size=1001-8               86073             13505 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Original/size=10000-8               2163            547249 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Original/size=10001-8               2144            552073 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=10-8            27953674                43.67 ns/op            0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=11-8            24920910                48.58 ns/op            0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=100-8            1290236               933.2 ns/op             0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=101-8            1271910               937.6 ns/op             0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=1000-8             57458             18092 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=1001-8             76575             15157 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=10000-8             2158            547444 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/RingBuffer/size=10001-8             2162            552329 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=10-8           32701854                36.42 ns/op            0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=11-8           38888804                30.27 ns/op            0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=100-8           4690263               253.5 ns/op             0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=101-8           6684326               182.3 ns/op             0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=1000-8           436898              2756 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=1001-8           488048              2468 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=10000-8           18874             60507 ns/op               0 B/op          0 allocs/op
BenchmarkMedian/Quickselect/size=10001-8           22555             52039 ns/op               0 B/op          0 allocs/op
PASS
ok      command-line-arguments  51.737s
```
