### PR TITLE
Fix buffer overflows

### DIFF
--- a/ptp/protocol/protocol.go
+++ b/ptp/protocol/protocol.go
@@ -268,7 +268,7 @@ func (p *SyncDelayReq) MarshalBinaryTo(b []byte) (int, error) {
 
 // MarshalBinary converts packet to []bytes
 func (p *SyncDelayReq) MarshalBinary() ([]byte, error) {
-	buf := make([]byte, 50)
+	buf := make([]byte, 64)
 	n, err := p.MarshalBinaryTo(buf)
 	return buf[:n], err
 }

--- a/ptp/protocol/protocol_test.go
+++ b/ptp/protocol/protocol_test.go
@@ -321,6 +321,22 @@ func TestParseDelayResp(t *testing.T) {
 	assert.Equal(t, &want, pp)
 }
 
+func TestFoundFuzzResults(t *testing.T) {
+	allBytes := [][]byte{
+		[]byte("00\x0000000000000000000000000000000000000000000\x00\x04\x00\x06000000"),
+		[]byte("00\x00A0000000000000000000000000000000000000000\x00\x04\x00\x06000000\x00\x04\x00\x06000000000"),
+	}
+	for _, b := range allBytes {
+		packet, err := DecodePacket(b)
+		require.NoError(t, err)
+		bb, err := Bytes(packet)
+		require.NoError(t, err)
+		// ignore last 2 bytes as they are only for ipv6 checksums
+		l := len(bb)
+		require.Equal(t, b[:l-2], bb[:l-2], "we expect binary form of packet %v %+v to be equal to original", packet.MessageType(), packet)
+	}
+}
+
 func BenchmarkReadSyncDelay(b *testing.B) {
 	raw := []byte{1, 18, 0, 50, 0, 0, 36, 0, 0, 0, 0, 0, 6, 32, 0, 2, 0, 0, 0, 0, 184, 206, 246, 255, 254, 68, 148, 144, 0, 1, 149, 17, 0, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 7, 0, 2, 16, 146, 0, 0}
 	p := &SyncDelayReq{}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes https://github.com/facebook/time/issues/469

Increase buffer size from 50 to 64 in `(p *SyncDelayReq) MarshalBinary()`

Fuzzer found two inputs that will make go panic
```
[]byte("00\x0000000000000000000000000000000000000000000\x00\x04\x00\x06000000")
[]byte("00\x00A0000000000000000000000000000000000000000\x00\x04\x00\x06000000\x00\x04\x00\x06000000000")
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->

Add a new test that includes these found values.
