### PR TITLE
ptp4u: ensure `workerOffset` is always initialized to zero for each new packet

### DIFF
--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -290,6 +290,7 @@ func (s *Server) handleEventMessages(eventConn *net.UDPConn) {
 		switch msgType {
 		case ptp.MessageDelayReq:
 			dReq.TLVs = zerotlv
+			workerOffset = 0
 			if err := ptp.FromBytes(buf[:bbuf], dReq); err != nil {
 				log.Errorf("Failed to read the ptp SyncDelayReq: %v", err)
 				continue


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes https://github.com/facebook/time/issues/471

A bit defence in depth to ensure `workerOffset` is always initialized to zero for each new packet processed. The sptp client sets the value to zero by default, but It'd be a good practice to just reset the value if the client doesn't provide it for whatever reason.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->

I didn't write any unit tests to check for this.