### PR TITLE
Restore s390

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,16 +23,18 @@ jobs:
   owner: "@meta"
   project: time
   targets:
-    - fedora-all-aarch64
+    - fedora-stable-aarch64
     - fedora-stable-i386
-    - fedora-all-ppc64le
+    - fedora-stable-ppc64le
+    - fedora-stable-s390x
     - fedora-all-x86_64
 - job: copr_build
   trigger: pull_request
   owner: "@meta"
   project: time
   targets:
-    - fedora-all-aarch64
+    - fedora-stable-aarch64
     - fedora-stable-i386
-    - fedora-all-ppc64le
+    - fedora-stable-ppc64le
+    - fedora-stable-s390x
     - fedora-all-x86_64


### PR DESCRIPTION
This was disabled some time ago due to poor state of the s390x build infra. However, it's mandatory in Fedora world to build for this platform meaning we better test diffs on that.

We also only care about all platforms for x86_64. Everything else - we can save time and electricity by building for stable only.