### PR TITLE
support IPADDR_ID

### DIFF
--- a/cmd/ntpcheck/checker/chrony_test.go
+++ b/cmd/ntpcheck/checker/chrony_test.go
@@ -68,7 +68,7 @@ var (
 
 	replySD0 = &chrony.ReplySourceData{
 		SourceData: chrony.SourceData{
-			IPAddr:         net.ParseIP("192.168.0.2"),
+			IPAddr:         &chrony.IPAddr{IP: chrony.IPToBytes(net.ParseIP("192.168.0.2")), Family: chrony.IPAddrInet4},
 			Flags:          chrony.NTPFlagsTests,
 			Poll:           10,
 			Stratum:        2,
@@ -81,7 +81,7 @@ var (
 
 	replySD1 = &chrony.ReplySourceData{
 		SourceData: chrony.SourceData{
-			IPAddr:         net.ParseIP("192.168.0.4"),
+			IPAddr:         &chrony.IPAddr{IP: chrony.IPToBytes(net.ParseIP("192.168.0.4")), Family: chrony.IPAddrInet4},
 			Flags:          chrony.NTPFlagsTests,
 			Poll:           11,
 			Stratum:        2,

--- a/cmd/testchrony/main.go
+++ b/cmd/testchrony/main.go
@@ -150,12 +150,17 @@ func runCommand(address string, cmd string) error {
 				return fmt.Errorf("failed to get 'sourcedata' response for source #%d: %w", i, err)
 			}
 			sourceData := packet.(*chrony.ReplySourceData)
+			// Skip sources with unresolved addresses (IPADDR_ID family)
+			if sourceData.IPAddr.Family == chrony.IPAddrID {
+				fmt.Printf("Source %d: %s (unresolved)\n", i, sourceData.IPAddr.String())
+				continue
+			}
 			req := chrony.NewNTPDataPacket(sourceData.IPAddr)
 			selectData, err := client.Communicate(req)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Source %d (%s): %+v\n", i, sourceData.IPAddr, selectData)
+			fmt.Printf("Source %d (%s): %+v\n", i, sourceData.IPAddr.String(), selectData)
 		}
 	case "sourcename":
 		req := chrony.NewSourcesPacket()
@@ -172,12 +177,17 @@ func runCommand(address string, cmd string) error {
 				return fmt.Errorf("failed to get 'sourcedata' response for source #%d: %w", i, err)
 			}
 			sourceData := packet.(*chrony.ReplySourceData)
+			// Skip sources with unresolved addresses (IPADDR_ID family)
+			if sourceData.IPAddr.Family == chrony.IPAddrID {
+				fmt.Printf("Source %d: %s (unresolved)\n", i, sourceData.IPAddr.String())
+				continue
+			}
 			req := chrony.NewNTPSourceNamePacket(sourceData.IPAddr)
 			selectData, err := client.Communicate(req)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Source %d (%s): %+v\n", i, sourceData.IPAddr, selectData)
+			fmt.Printf("Source %d (%s): %+v\n", i, sourceData.IPAddr.String(), selectData)
 		}
 	case "selectdata":
 		req := chrony.NewSourcesPacket()

--- a/ntp/chrony/client_test.go
+++ b/ntp/chrony/client_test.go
@@ -115,7 +115,7 @@ func TestCommunicateOK(t *testing.T) {
 	}
 	packetBody := replyTrackingContent{
 		RefID:              1,
-		IPAddr:             *newIPAddr(net.IP([]byte{192, 168, 0, 10})),
+		IPAddr:             IPAddr{IP: IPToBytes(net.ParseIP("192.168.0.10")), Family: IPAddrInet4},
 		Stratum:            3,
 		LeapStatus:         0,
 		RefTime:            timeSpec{},

--- a/ntp/chrony/packet.go
+++ b/ntp/chrony/packet.go
@@ -279,7 +279,7 @@ type RequestSourceData struct {
 // As of now, it's only allowed by Chrony over unix socket connection.
 type RequestNTPData struct {
 	RequestHead
-	IPAddr ipAddr
+	IPAddr IPAddr
 	EOR    int32
 	// we pass at max ipv6 addr - 16 bytes
 	data [maxDataLen - 16]uint8
@@ -288,7 +288,7 @@ type RequestNTPData struct {
 // RequestNTPSourceName - packet to request source name for peer IP.
 type RequestNTPSourceName struct {
 	RequestHead
-	IPAddr ipAddr
+	IPAddr IPAddr
 	EOR    int32
 	// we pass at max ipv6 addr - 16 bytes
 	data [maxDataLen - 16]uint8
@@ -377,7 +377,7 @@ type ReplySources struct {
 }
 
 type replySourceDataContent struct {
-	IPAddr         ipAddr
+	IPAddr         IPAddr
 	Poll           int16
 	Stratum        uint16
 	State          SourceStateType
@@ -392,7 +392,7 @@ type replySourceDataContent struct {
 
 // SourceData contains parsed version of 'source data' reply
 type SourceData struct {
-	IPAddr         net.IP
+	IPAddr         *IPAddr
 	Poll           int16
 	Stratum        uint16
 	State          SourceStateType
@@ -407,7 +407,7 @@ type SourceData struct {
 
 func newSourceData(r *replySourceDataContent) *SourceData {
 	return &SourceData{
-		IPAddr:         r.IPAddr.ToNetIP(),
+		IPAddr:         &r.IPAddr,
 		Poll:           r.Poll,
 		Stratum:        r.Stratum,
 		State:          r.State,
@@ -429,7 +429,7 @@ type ReplySourceData struct {
 
 type replyTrackingContent struct {
 	RefID              uint32
-	IPAddr             ipAddr // our current sync source
+	IPAddr             IPAddr // our current sync source
 	Stratum            uint16
 	LeapStatus         uint16
 	RefTime            timeSpec
@@ -489,7 +489,7 @@ type ReplyTracking struct {
 
 type replySourceStatsContent struct {
 	RefID              uint32
-	IPAddr             ipAddr
+	IPAddr             IPAddr
 	NSamples           uint32
 	NRuns              uint32
 	SpanSeconds        uint32
@@ -536,8 +536,8 @@ type ReplySourceStats struct {
 }
 
 type replyNTPDataContent struct {
-	RemoteAddr      ipAddr
-	LocalAddr       ipAddr
+	RemoteAddr      IPAddr
+	LocalAddr       IPAddr
 	RemotePort      uint16
 	Leap            uint8
 	Version         uint8
@@ -627,8 +627,8 @@ type ReplyNTPData struct {
 }
 
 type replyNTPData2Content struct {
-	RemoteAddr      ipAddr
-	LocalAddr       ipAddr
+	RemoteAddr      IPAddr
+	LocalAddr       IPAddr
 	RemotePort      uint16
 	Leap            uint8
 	Version         uint8
@@ -836,7 +836,7 @@ type ReplyServerStats4 struct {
 
 type replySelectData struct {
 	RefID          uint32
-	IPAddr         ipAddr
+	IPAddr         IPAddr
 	StateChar      uint8
 	Authentication uint8
 	Leap           uint8
@@ -939,27 +939,27 @@ func NewSourceDataPacket(sourceID int32) *RequestSourceData {
 }
 
 // NewNTPDataPacket creates new packet to request 'ntp data' information for given peer IP
-func NewNTPDataPacket(ip net.IP) *RequestNTPData {
+func NewNTPDataPacket(ip *IPAddr) *RequestNTPData {
 	return &RequestNTPData{
 		RequestHead: RequestHead{
 			Version: protoVersionNumber,
 			PKTType: pktTypeCmdRequest,
 			Command: reqNTPData,
 		},
-		IPAddr: *newIPAddr(ip),
+		IPAddr: *ip,
 		data:   [maxDataLen - 16]uint8{},
 	}
 }
 
 // NewNTPSourceNamePacket creates new packet to request 'source name' information for given peer IP
-func NewNTPSourceNamePacket(ip net.IP) *RequestNTPSourceName {
+func NewNTPSourceNamePacket(ip *IPAddr) *RequestNTPSourceName {
 	return &RequestNTPSourceName{
 		RequestHead: RequestHead{
 			Version: protoVersionNumber,
 			PKTType: pktTypeCmdRequest,
 			Command: reqNTPSourceName,
 		},
-		IPAddr: *newIPAddr(ip),
+		IPAddr: *ip,
 		data:   [maxDataLen - 16]uint8{},
 	}
 }


### PR DESCRIPTION
Summary:
Addressing https://github.com/facebook/time/issues/493 which flagged a valid point that we don't respect all possible chrony IP family types defined in https://gitlab.com/chrony/chrony/-/blob/master/addressing.h#L36-39

To address this we need to change the SourceData struct to pass support address family

Reviewed By: t3lurid3

Differential Revision: D90385063


