### PR TITLE
fix golang-github-facebook-time packit script - to locally build vendor tarball

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,15 +12,17 @@ actions:
   post-upstream-clone:
     - "bash -c \"curl -s https://src.fedoraproject.org/rpms/golang-github-facebook-time/raw/main/f/golang-github-facebook-time.spec | sed -e '/^Patch[0-9]/d' -e 's|^%global commit.*|%global commit          '$(git rev-parse HEAD)'|' -e 's|^%global date.*|%global date            '$(date +%Y%m%d)'|' -e 's|mv fbclock-bin %{gobuilddir}/bin/fbclock-bin|mkdir -p %{gobuilddir}/bin \\&\\& mv fbclock-bin %{gobuilddir}/bin/fbclock-bin|' > golang-github-facebook-time.spec\""
     - "curl -s -o go-vendor-tools.toml https://src.fedoraproject.org/rpms/golang-github-facebook-time/raw/main/f/go-vendor-tools.toml"
-    - "bash -c \"curl -s https://src.fedoraproject.org/rpms/golang-github-facebook-time/raw/main/f/sources | grep vendor | sed 's/SHA512 (\\(.*\\)) = \\(.*\\)/\\1 \\2/' | while read file hash; do curl -L https://src.fedoraproject.org/repo/pkgs/rpms/golang-github-facebook-time/$file/sha512/$hash/$file -o $file && mv $file time-$(git rev-parse HEAD)-vendor.tar.bz2 || true ; done\""
   create-archive:
-    - "bash -c 'git archive --prefix time-$(git rev-parse HEAD)/ --output time-$(git rev-parse HEAD).tar.gz HEAD'"
+    - "spectool -g golang-github-facebook-time.spec"
+    - "go_vendor_archive create golang-github-facebook-time.spec"
     - "bash -c 'echo time-$(git rev-parse HEAD).tar.gz'"
 
 srpm_build_deps:
   - bash
   - curl
   - sed
+  - golang
+  - go-vendor-tools
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
Summary:
Changing the packit script to locally build the tar ball every time to prevent errors
