### PR TITLE
Fix TestServer by correcting sendto flags and increasing buffers

### DIFF
--- a/ntp/responder/server/server.go
+++ b/ntp/responder/server/server.go
@@ -237,7 +237,7 @@ func (t *task) serve(response *ntp.Packet, extraoffset time.Duration) {
 	}
 
 	log.Debugf("Writing response: %+v", response)
-	if err := unix.Sendto(t.connFd, responseBytes, unix.O_NONBLOCK, t.addr); err != nil {
+	if err := unix.Sendto(t.connFd, responseBytes, unix.MSG_DONTWAIT, t.addr); err != nil {
 		log.Debugf("Failed to respond to the request: %v", err)
 		return
 	}


### PR DESCRIPTION
## Summary

The test used to be skipping (see https://github.com/facebook/time/pull/372), now something changed and we sometimes see it skip, sometimes fail (10m timeout). I asked Claude to find and fix issues that may cause the hang:

1. Fix `unix.Sendto` flags: Change from `O_NONBLOCK` (0x800, a file descriptor flag) to `MSG_DONTWAIT` (0x40, the correct sendmsg flag for non-blocking). Using the wrong constant caused undefined behavior.

2. Add `SetDeadline(10s)` to prevent test hanging forever if some response doesn't arrive.

3. Increase socket buffer sizes to 1MB. The test sends 1000 UDP packets rapidly and the default buffers were too small, causing packet drops after ~200 requests. With 1MB buffers, all 1000 requests succeed reliably.

## Test Plan

Before:

```
$ go test github.com/facebook/time/ntp/responder/server -count 1 -timeout 1s
time="2026-01-28T12:22:01+01:00" level=info msg="Adding 1.2.3.4 to lol-does-not-exist"
time="2026-01-28T12:22:01+01:00" level=info msg="Deleting 1.2.3.4 to lol-does-not-exist"
panic: test timed out after 1s
        running tests:
                TestServer (1s)

goroutine 47 [running]:
testing.(*M).startAlarm.func1()
        /usr/lib/golang/src/testing/testing.go:2682 +0x345
created by time.goFunc
        /usr/lib/golang/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0000a2fc0, {0x688277?, 0xc000121b30?}, 0x69e5a8)
        /usr/lib/golang/src/testing/testing.go:2005 +0x485
testing.runTests.func1(0xc0000a2fc0)
        /usr/lib/golang/src/testing/testing.go:2477 +0x37
testing.tRunner(0xc0000a2fc0, 0xc000121c70)
        /usr/lib/golang/src/testing/testing.go:1934 +0xea
testing.runTests(0xc0000c6240, {0x8a5460, 0x12, 0x12}, {0x7?, 0xc0000b2c00?, 0x8ac7e0?})
        /usr/lib/golang/src/testing/testing.go:2475 +0x4b4
testing.(*M).Run(0xc0000c4d20)
        /usr/lib/golang/src/testing/testing.go:2337 +0x63a
main.main()
        _testmain.go:83 +0x9b

goroutine 40 [IO wait]:
internal/poll.runtime_pollWait(0x7f0690059e00, 0x72)
        /usr/lib/golang/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc000111000?, 0xc00020b260?, 0x0)
        /usr/lib/golang/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/golang/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000111000, {0xc00020b260, 0x30, 0x30})
        /usr/lib/golang/src/internal/poll/fd_unix.go:165 +0x279
net.(*netFD).Read(0xc000111000, {0xc00020b260?, 0x30?, 0xc000071808?})
        /usr/lib/golang/src/net/fd_posix.go:68 +0x25
net.(*conn).Read(0xc0000c2120, {0xc00020b260?, 0xc000123cf8?, 0x47dde9?})
        /usr/lib/golang/src/net/net.go:196 +0x45
io.ReadAtLeast({0x7f069005a220, 0xc0000c2120}, {0xc00020b260, 0x30, 0x30}, 0x30)
        /usr/lib/golang/src/io/io.go:335 +0x8e
io.ReadFull(...)
        /usr/lib/golang/src/io/io.go:354
encoding/binary.Read({0x7f069005a220, 0xc0000c2120}, {0x6e75b0, 0x8cd1a0}, {0x646ea0, 0xc000123e48})
        /usr/lib/golang/src/encoding/binary/binary.go:286 +0x350
github.com/facebook/time/ntp/responder/server.TestServer(0xc00014d500)
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:210 +0x7a5
testing.tRunner(0xc00014d500, 0x69e5a8)
        /usr/lib/golang/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
        /usr/lib/golang/src/testing/testing.go:1997 +0x465

goroutine 37 [syscall]:
syscall.Syscall(0x2f, 0x5, 0xc000081c50, 0x0)
        /usr/lib/golang/src/syscall/syscall_linux.go:74 +0x25
golang.org/x/sys/unix.recvmsg(0x8adac0?, 0xc0000b6c40?, 0xc000081c70?)
        /home/pzmarzly/go/pkg/mod/golang.org/x/sys@v0.31.0/unix/zsyscall_linux_amd64.go:554 +0x33
golang.org/x/sys/unix.recvmsgRaw(0xc000081d10?, {0xc000081d08?, 0x36?, 0x5?}, {0xc000081de8?, 0x2d?, 0x0?}, 0x2?, 0x0?)
        /home/pzmarzly/go/pkg/mod/golang.org/x/sys@v0.31.0/unix/syscall_linux.go:1575 +0x72
golang.org/x/sys/unix.Recvmsg(0x5, {0xc0000ecb00?, 0xc000081d70?, 0x47a0e5?}, {0xc000081de8, 0x80, 0x80}, 0x0)
        /home/pzmarzly/go/pkg/mod/golang.org/x/sys@v0.31.0/unix/syscall_unix.go:370 +0xa7
github.com/facebook/time/timestamp.ReadPacketWithRXTimestampBuf(0x5?, {0xc0000ecb00?, 0x4198d4?, 0x41957b?}, {0xc000081de8, 0x80, 0x80})
        /home/pzmarzly/repos/time/timestamp/timestamp.go:151 +0x3a
github.com/facebook/time/ntp/responder/server.(*Server).startListener(0xc0000f20c0, 0xc0000c20f0)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:181 +0x295
created by github.com/facebook/time/ntp/responder/server.TestListener in goroutine 36
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:131 +0x12e

goroutine 39 [chan receive]:
github.com/facebook/time/ntp/responder/server.(*Server).startWorker(0xc0000f2180)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:217 +0x151
created by github.com/facebook/time/ntp/responder/server.TestWorker in goroutine 38
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:158 +0x21b

goroutine 41 [chan receive]:
github.com/facebook/time/ntp/responder/server.(*Server).startWorker(0xc0000f2240)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:217 +0x151
created by github.com/facebook/time/ntp/responder/server.TestServer in goroutine 40
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:179 +0x146

goroutine 42 [chan receive]:
github.com/facebook/time/ntp/responder/server.(*Server).startWorker(0xc0000f2240)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:217 +0x151
created by github.com/facebook/time/ntp/responder/server.TestServer in goroutine 40
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:179 +0x146

goroutine 43 [chan receive]:
github.com/facebook/time/ntp/responder/server.(*Server).startWorker(0xc0000f2240)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:217 +0x151
created by github.com/facebook/time/ntp/responder/server.TestServer in goroutine 40
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:179 +0x146

goroutine 44 [chan receive]:
github.com/facebook/time/ntp/responder/server.(*Server).startWorker(0xc0000f2240)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:217 +0x151
created by github.com/facebook/time/ntp/responder/server.TestServer in goroutine 40
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:179 +0x146

goroutine 45 [chan receive]:
github.com/facebook/time/ntp/responder/server.(*Server).startWorker(0xc0000f2240)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:217 +0x151
created by github.com/facebook/time/ntp/responder/server.TestServer in goroutine 40
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:179 +0x146

goroutine 46 [syscall]:
syscall.Syscall(0x2f, 0x5, 0xc000083c50, 0x0)
        /usr/lib/golang/src/syscall/syscall_linux.go:74 +0x25
golang.org/x/sys/unix.recvmsg(0xc000071008?, 0xc000164f50?, 0xc000083c70?)
        /home/pzmarzly/go/pkg/mod/golang.org/x/sys@v0.31.0/unix/zsyscall_linux_amd64.go:554 +0x33
golang.org/x/sys/unix.recvmsgRaw(0x481af2?, {0xc000083d08?, 0x4113b3?, 0xc000083ce0?}, {0xc000083de8?, 0xc000083f58?, 0xc00014d880?}, 0x411420?, 0xc00014d880?)
        /home/pzmarzly/go/pkg/mod/golang.org/x/sys@v0.31.0/unix/syscall_linux.go:1575 +0x72
golang.org/x/sys/unix.Recvmsg(0x5, {0xc0000ecc80?, 0xc000083d70?, 0x47a0e5?}, {0xc000083de8, 0x80, 0x80}, 0x0)
        /home/pzmarzly/go/pkg/mod/golang.org/x/sys@v0.31.0/unix/syscall_unix.go:370 +0xa7
github.com/facebook/time/timestamp.ReadPacketWithRXTimestampBuf(0xc000163830?, {0xc0000ecc80?, 0x30?, 0x80?}, {0xc000083de8, 0x80, 0x80})
        /home/pzmarzly/repos/time/timestamp/timestamp.go:151 +0x3a
github.com/facebook/time/ntp/responder/server.(*Server).startListener(0xc0000f2240, 0xc0000c2110)
        /home/pzmarzly/repos/time/ntp/responder/server/server.go:181 +0x295
created by github.com/facebook/time/ntp/responder/server.TestServer in goroutine 40
        /home/pzmarzly/repos/time/ntp/responder/server/server_test.go:184 +0x273
FAIL    github.com/facebook/time/ntp/responder/server   1.008s
FAIL
```

After:
```
for i in {1..20}; do go test github.com/facebook/time/ntp/responder/server -count 1 -timeout 1s; done
ok      github.com/facebook/time/ntp/responder/server   0.338s
ok      github.com/facebook/time/ntp/responder/server   0.344s
ok      github.com/facebook/time/ntp/responder/server   0.205s
ok      github.com/facebook/time/ntp/responder/server   0.341s
ok      github.com/facebook/time/ntp/responder/server   0.344s
ok      github.com/facebook/time/ntp/responder/server   0.208s
ok      github.com/facebook/time/ntp/responder/server   0.335s
ok      github.com/facebook/time/ntp/responder/server   0.339s
ok      github.com/facebook/time/ntp/responder/server   0.339s
ok      github.com/facebook/time/ntp/responder/server   0.339s
ok      github.com/facebook/time/ntp/responder/server   0.339s
ok      github.com/facebook/time/ntp/responder/server   0.206s
ok      github.com/facebook/time/ntp/responder/server   0.340s
ok      github.com/facebook/time/ntp/responder/server   0.342s
ok      github.com/facebook/time/ntp/responder/server   0.206s
ok      github.com/facebook/time/ntp/responder/server   0.340s
ok      github.com/facebook/time/ntp/responder/server   0.338s
ok      github.com/facebook/time/ntp/responder/server   0.207s
ok      github.com/facebook/time/ntp/responder/server   0.344s
ok      github.com/facebook/time/ntp/responder/server   0.339s
```
