### PR TITLE
Disable s390x COPR builds due to QEMU netlink bug

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,7 +32,10 @@ jobs:
     targets:
       - fedora-stable-aarch64
       - fedora-stable-ppc64le
-      - fedora-stable-s390x
+      # s390x disabled: COPR uses QEMU user-mode emulation which has a bug in
+      # netlink RTM_GETLINK rtattr byte-order translation. See PR #506 for details.
+      # Native s390x builds work fine in Koji. QEMU bug report submitted upstream.
+      # - fedora-stable-s390x
       - fedora-all-x86_64
   - job: copr_build
     trigger: pull_request
@@ -41,5 +44,5 @@ jobs:
     targets:
       - fedora-stable-aarch64
       - fedora-stable-ppc64le
-      - fedora-stable-s390x
+      # - fedora-stable-s390x
       - fedora-all-x86_64


### PR DESCRIPTION
COPR lost native s390x builders around March 2026 and switched to QEMU user-mode emulation on x86_64. QEMU doesn't properly byte-swap netlink RTM_GETLINK rtattr structs when emulating big-endian s390x on a little-endian host, causing Go's net.InterfaceByName() to fail with 'parsenetlinkrouteattr: invalid argument'.

We confirmed this is a QEMU bug, not a code issue:
- Native s390x (Koji): all tests pass
- Native x86_64: all tests pass
- QEMU s390x (COPR): only netlink RTM_GETLINK tests fail
- Diagnostic test (PR #506) shows RTM_GETADDR works, RTM_GETLINK doesn't, sysfs/procfs alternatives work fine

A patch has been submitted to QEMU upstream. Removing s390x from COPR targets until the QEMU fix lands. This only affects CI testing, not the official Fedora package. Koji still builds s390x with real hardware and Fedora users are unaffected.

https://gitlab.com/qemu-project/qemu/-/work_items/2485#note_3236597357