### PR TITLE
bump go version to 1.26

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.26
       - run: sudo apt-get install libpcap-dev
       - uses: golangci/golangci-lint-action@v3
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.26
       - run: sudo apt-get install libpcap-dev libcap2-bin
       - run: go build -v ./...
       # fuzzing, need to specify each package separately

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/facebook/time
 
-go 1.23.0
+go 1.26.0
 
-toolchain go1.23.7
+toolchain go1.26.0
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible


### PR DESCRIPTION
Summary:
Unbreak GH lint check, which fails on D100332220 because it uses `strings.SplitSeq` (Go 1.24+) but the github mirror was pinned to 1.23.

Bump to 1.26 to match what we use internally.

Differential Revision: D101806507


