### PR TITLE
bump go version to 1.24 (#511)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.24
       - run: sudo apt-get install libpcap-dev
       - uses: golangci/golangci-lint-action@v3
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.24
       - run: sudo apt-get install libpcap-dev libcap2-bin
       - run: go build -v ./...
       # fuzzing, need to specify each package separately

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/facebook/time
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.24.0
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible


### PR DESCRIPTION
Summary:

Unbreak GH lint check, which fails on D100332220 because it uses `strings.SplitSeq` (Go 1.24+) but the github mirror was pinned to 1.23.

Going to 1.24 (not 1.26 to match internal) because the github toolchain ecosystem isn't there yet — golangci-lint v1.64.8 was built with Go 1.24 and Fedora packit ships Go 1.25.9, so a 1.26 bump breaks both. 1.24 is the minimum to allow `strings.SplitSeq` while keeping downstream consumers happy.

Differential Revision: D101807455


