### PR TITLE
Add unit tests across all time packages (#521)

### DIFF
--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestSetFreq(t *testing.T) {
+	tx := &unix.Timex{}
+	setFreq(tx, 1000.0)
+	require.Equal(t, int64(65536), tx.Freq)
+
+	setFreq(tx, -500.0)
+	require.Equal(t, int64(-32768), tx.Freq)
+
+	setFreq(tx, 0)
+	require.Equal(t, int64(0), tx.Freq)
+}
+
+func TestSetTime(t *testing.T) {
+	tx := &unix.Timex{}
+	setTime(tx, 5*time.Second, 123*time.Nanosecond)
+	require.Equal(t, int64(5*time.Second), tx.Time.Sec)
+	require.Equal(t, int64(123*time.Nanosecond), tx.Time.Usec)
+}
+
+func TestSetTimeNegative(t *testing.T) {
+	tx := &unix.Timex{}
+	setTime(tx, -1*time.Second, -500*time.Nanosecond)
+	require.Equal(t, int64(-1*time.Second), tx.Time.Sec)
+	require.Equal(t, int64(-500*time.Nanosecond), tx.Time.Usec)
+}
+
+func TestFrequencyPPB(t *testing.T) {
+	// CLOCK_REALTIME = 0, should be readable on any Linux system
+	freqPPB, state, err := FrequencyPPB(0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, state, 0)
+	// frequency should be reasonable (within +-500ppm)
+	require.Less(t, freqPPB, 500000.0)
+	require.Greater(t, freqPPB, -500000.0)
+}
+
+func TestMaxFreqPPB(t *testing.T) {
+	// CLOCK_REALTIME = 0
+	maxFreq, state, err := MaxFreqPPB(0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, state, 0)
+	require.Greater(t, maxFreq, 0.0)
+}
+
+func TestFrequencyPPBInvalidClock(t *testing.T) {
+	// Invalid clock ID should return an error
+	_, _, err := FrequencyPPB(-1)
+	require.Error(t, err)
+}
+
+func TestMaxFreqPPBInvalidClock(t *testing.T) {
+	_, _, err := MaxFreqPPB(-1)
+	require.Error(t, err)
+}

--- a/cmd/ntpcheck/cmd/utils_test.go
+++ b/cmd/ntpcheck/cmd/utils_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefIDIPv4(t *testing.T) {
+	// refID prints to stdout; just check it doesn't error on valid IPv4
+	err := refID("192.168.1.1")
+	require.NoError(t, err)
+}
+
+func TestRefIDIPv6(t *testing.T) {
+	err := refID("2001:db8::1")
+	require.NoError(t, err)
+}
+
+func TestRefIDEmpty(t *testing.T) {
+	err := refID("")
+	require.Error(t, err)
+}
+
+func TestRefIDInvalid(t *testing.T) {
+	err := refID("not-an-ip")
+	require.Error(t, err)
+}
+
+func TestStripZeroes(t *testing.T) {
+	testCases := []struct {
+		input float64
+		want  string
+	}{
+		{input: 1.50, want: "1.5"},
+		{input: 2.00, want: "2"},
+		{input: 3.14, want: "3.14"},
+		{input: 0.10, want: "0.1"},
+		{input: 0.00, want: "0"},
+		{input: 100.00, want: "100"},
+		{input: 42.01, want: "42.01"},
+		{input: -1.50, want: "-1.5"},
+		{input: -0.10, want: "-0.1"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want, func(t *testing.T) {
+			got := stripZeroes(tc.input)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConfigureVerbosity(t *testing.T) {
+	verbose = false
+	ConfigureVerbosity()
+	require.Equal(t, log.InfoLevel, log.GetLevel())
+
+	verbose = true
+	ConfigureVerbosity()
+	require.Equal(t, log.DebugLevel, log.GetLevel())
+}

--- a/cmd/ptpcheck/cmd/helpers_test.go
+++ b/cmd/ptpcheck/cmd/helpers_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckAgainstThresholdEdgeCases(t *testing.T) {
+	s, _ := checkAgainstThreshold("test", int64(5), int64(10), int64(20), "")
+	require.Equal(t, OK, s)
+
+	s, _ = checkAgainstThreshold("test", int64(15), int64(10), int64(20), "")
+	require.Equal(t, WARN, s)
+
+	s, _ = checkAgainstThreshold("test", int64(25), int64(10), int64(20), "")
+	require.Equal(t, FAIL, s)
+}
+
+func TestCheckAgainstThresholdPositive(t *testing.T) {
+	s, _ := checkAgainstThresholdPositive("test", int64(5), int64(10), int64(20), "")
+	require.Equal(t, OK, s)
+
+	s, _ = checkAgainstThresholdPositive("test", int64(0), int64(10), int64(20), "")
+	require.Equal(t, FAIL, s)
+
+	s, _ = checkAgainstThresholdPositive("test", int64(-1), int64(10), int64(20), "")
+	require.Equal(t, FAIL, s)
+}
+
+func TestCheckAgainstThresholdNonZero(t *testing.T) {
+	s, _ := checkAgainstThresholdNonZero("test", int64(5), int64(10), int64(20), "")
+	require.Equal(t, OK, s)
+
+	s, _ = checkAgainstThresholdNonZero("test", int64(0), int64(10), int64(20), "")
+	require.Equal(t, FAIL, s)
+}
+
+func TestCalculateJitterBounds(t *testing.T) {
+	result := CalculateJitter(0)
+	require.Equal(t, time.Duration(0), result)
+
+	result = CalculateJitter(-1 * time.Second)
+	require.Equal(t, time.Duration(0), result)
+
+	result = CalculateJitter(100 * time.Millisecond)
+	require.GreaterOrEqual(t, result, time.Duration(0))
+	require.Less(t, result, 100*time.Millisecond)
+}
+
+func TestSelectNonLinkLocalAddrEdgeCases(t *testing.T) {
+	// no addresses
+	_, err := selectNonLinkLocalAddr(nil)
+	require.Error(t, err)
+
+	// only IPv4 (should be skipped)
+	addrs := []net.Addr{
+		&net.IPNet{IP: net.ParseIP("192.168.1.1"), Mask: net.CIDRMask(24, 32)},
+	}
+	_, err = selectNonLinkLocalAddr(addrs)
+	require.Error(t, err)
+
+	// link-local IPv6 (should be skipped)
+	addrs = []net.Addr{
+		&net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)},
+	}
+	_, err = selectNonLinkLocalAddr(addrs)
+	require.Error(t, err)
+
+	// global unicast IPv6
+	addrs = []net.Addr{
+		&net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(64, 128)},
+	}
+	ip, err := selectNonLinkLocalAddr(addrs)
+	require.NoError(t, err)
+	require.Equal(t, "2001:db8::1", ip.String())
+}
+
+func TestFmtThreshold(t *testing.T) {
+	result := fmtThreshold(100)
+	require.Contains(t, result, "100")
+}
+
+func TestTxTypeString(t *testing.T) {
+	require.Equal(t, "off", TxType(0).String())
+	require.Equal(t, "on", TxType(1).String())
+	require.Equal(t, "stepsync", TxType(2).String())
+	require.Equal(t, "?", TxType(99).String())
+}
+
+func TestRxFilterString(t *testing.T) {
+	require.Equal(t, "none", RxFilter(0).String())
+	require.Equal(t, "all", RxFilter(1).String())
+	require.Equal(t, "some", RxFilter(2).String())
+	require.Equal(t, "?", RxFilter(99).String())
+}

--- a/fbclock/daemon/datafetcher_http_test.go
+++ b/fbclock/daemon/datafetcher_http_test.go
@@ -95,3 +95,116 @@ func TestFetchStatsServoNotLocked(t *testing.T) {
 	expected := DataPoint{IngressTimeNS: 0, MasterOffsetNS: -43.43, PathDelayNS: 43.43, FreqAdjustmentPPB: 0, ClockAccuracyNS: 250, ServoState: 0}
 	require.Equal(t, sstats, &expected)
 }
+
+func TestFetchStatsNoSelectedGM(t *testing.T) {
+	sampleResp := `
+[
+	{"gm_address": "127.0.0.1", "selected": false, "port_identity": "gm1", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -42.42, "mean_path_delay": 42.42, "gm_present": 1, "error": ""},
+	{"gm_address": "127.0.0.2", "selected": false, "port_identity": "gm2", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -10.0, "mean_path_delay": 20.0, "gm_present": 1, "error": ""}
+]
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, sampleResp)
+	}))
+	defer ts.Close()
+	surl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	cfg := &Config{PTPClientAddress: fmt.Sprintf("%s:%s", surl.Hostname(), surl.Port())}
+	fetcher := &HTTPFetcher{}
+	_, err = fetcher.FetchStats(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no selected grandmaster")
+}
+
+func TestFetchStatsGMNotPresent(t *testing.T) {
+	sampleResp := `
+[
+	{"gm_address": "::1", "selected": true, "port_identity": "gm1", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -50.5, "mean_path_delay": 100.0, "gm_present": 0, "servo_state": 2}
+]
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, sampleResp)
+	}))
+	defer ts.Close()
+	surl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	cfg := &Config{PTPClientAddress: fmt.Sprintf("%s:%s", surl.Hostname(), surl.Port())}
+	fetcher := &HTTPFetcher{}
+	dp, err := fetcher.FetchStats(cfg)
+	require.NoError(t, err)
+	// gm_present=0 means ClockAccuracyNS should be 0
+	require.Equal(t, float64(0), dp.ClockAccuracyNS)
+	require.Equal(t, -50.5, dp.MasterOffsetNS)
+	require.Equal(t, 100.0, dp.PathDelayNS)
+}
+
+func TestFetchStatsWithIngressTime(t *testing.T) {
+	sampleResp := `
+[
+	{"gm_address": "::1", "selected": true, "port_identity": "gm1", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -23.5, "mean_path_delay": 150.0, "gm_present": 1, "ingress_time": 1674148530671467104, "servo_state": 2}
+]
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, sampleResp)
+	}))
+	defer ts.Close()
+	surl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	cfg := &Config{PTPClientAddress: fmt.Sprintf("%s:%s", surl.Hostname(), surl.Port())}
+	fetcher := &HTTPFetcher{}
+	dp, err := fetcher.FetchStats(cfg)
+	require.NoError(t, err)
+	require.Equal(t, int64(1674148530671467104), dp.IngressTimeNS)
+	require.Equal(t, -23.5, dp.MasterOffsetNS)
+	require.Equal(t, 150.0, dp.PathDelayNS)
+	require.Equal(t, 2, dp.ServoState)
+}
+
+func TestFetchGMsMultipleWithFiltering(t *testing.T) {
+	sampleResp := `
+[
+	{"gm_address": "10.0.0.1", "selected": true, "port_identity": "best", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -1.0, "mean_path_delay": 5.0, "gm_present": 1, "error": ""},
+	{"gm_address": "10.0.0.2", "selected": false, "port_identity": "gm2", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -2.0, "mean_path_delay": 10.0, "gm_present": 1, "error": ""},
+	{"gm_address": "10.0.0.3", "selected": false, "port_identity": "gm3", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -3.0, "mean_path_delay": 15.0, "gm_present": 1, "error": "timeout"},
+	{"gm_address": "10.0.0.4", "selected": false, "port_identity": "gm4", "clock_quality": {"clock_class": 6, "clock_accuracy": 33, "offset_scaled_log_variance": 42}, "offset": -4.0, "mean_path_delay": 20.0, "gm_present": 1, "error": ""}
+]
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, sampleResp)
+	}))
+	defer ts.Close()
+	surl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	cfg := &Config{PTPClientAddress: fmt.Sprintf("%s:%s", surl.Hostname(), surl.Port())}
+	fetcher := &HTTPFetcher{}
+	hosts, err := fetcher.FetchGMs(cfg)
+	require.NoError(t, err)
+	// 10.0.0.1 skipped (selected), 10.0.0.3 skipped (has error)
+	require.Equal(t, []string{"10.0.0.2", "10.0.0.4"}, hosts)
+}
+
+func TestFetchStatsHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	surl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	cfg := &Config{PTPClientAddress: fmt.Sprintf("%s:%s", surl.Hostname(), surl.Port())}
+	fetcher := &HTTPFetcher{}
+	_, err = fetcher.FetchStats(cfg)
+	require.Error(t, err)
+}
+
+func TestFetchGMsHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	surl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	cfg := &Config{PTPClientAddress: fmt.Sprintf("%s:%s", surl.Hostname(), surl.Port())}
+	fetcher := &HTTPFetcher{}
+	_, err = fetcher.FetchGMs(cfg)
+	require.Error(t, err)
+}

--- a/fbclock/daemon/helpers_test.go
+++ b/fbclock/daemon/helpers_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/facebook/time/fbclock"
+	"github.com/facebook/time/leapsectz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinRingSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ringSize int
+		interval time.Duration
+		want     int
+	}{
+		{
+			name:     "ring size already covers 1 minute",
+			ringSize: 60,
+			interval: time.Second,
+			want:     60,
+		},
+		{
+			name:     "ring size larger than needed",
+			ringSize: 120,
+			interval: time.Second,
+			want:     120,
+		},
+		{
+			name:     "ring size too small for 1 minute coverage",
+			ringSize: 10,
+			interval: time.Second,
+			want:     60,
+		},
+		{
+			name:     "fast interval needs more samples",
+			ringSize: 30,
+			interval: 100 * time.Millisecond,
+			want:     600,
+		},
+		{
+			name:     "slow interval needs fewer samples",
+			ringSize: 5,
+			interval: 30 * time.Second,
+			want:     5,
+		},
+		{
+			name:     "exact boundary",
+			ringSize: 30,
+			interval: 2 * time.Second,
+			want:     30,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := minRingSize(tc.ringSize, tc.interval)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPrepareMathParameters(t *testing.T) {
+	dataPoints := []*DataPoint{
+		{MasterOffsetNS: 10.0, PathDelayNS: 100.0, FreqAdjustmentPPB: 1000.0, ClockAccuracyNS: 25.0},
+		{MasterOffsetNS: 20.0, PathDelayNS: 200.0, FreqAdjustmentPPB: 1500.0, ClockAccuracyNS: 50.0},
+		{MasterOffsetNS: 30.0, PathDelayNS: 300.0, FreqAdjustmentPPB: 1200.0, ClockAccuracyNS: 75.0},
+	}
+
+	got := prepareMathParameters(dataPoints)
+	require.Equal(t, []float64{10.0, 20.0, 30.0}, got["offset"])
+	require.Equal(t, []float64{100.0, 200.0, 300.0}, got["delay"])
+	require.Equal(t, []float64{1000.0, 1500.0, 1200.0}, got["freq"])
+	require.Equal(t, []float64{25.0, 50.0, 75.0}, got["clockaccuracy"])
+	require.Equal(t, []float64{500.0, -300.0}, got["freqchange"])
+	require.Equal(t, []float64{500.0, 300.0}, got["freqchangeabs"])
+}
+
+func TestPrepareMathParametersSinglePoint(t *testing.T) {
+	dataPoints := []*DataPoint{
+		{MasterOffsetNS: 42.0, PathDelayNS: 123.0, FreqAdjustmentPPB: 999.0, ClockAccuracyNS: 10.0},
+	}
+
+	got := prepareMathParameters(dataPoints)
+	require.Equal(t, []float64{42.0}, got["offset"])
+	require.Equal(t, []float64{123.0}, got["delay"])
+	require.Equal(t, []float64{999.0}, got["freq"])
+	require.Equal(t, []float64{10.0}, got["clockaccuracy"])
+	require.Empty(t, got["freqchange"])
+	require.Empty(t, got["freqchangeabs"])
+}
+
+func TestMapOfInterface(t *testing.T) {
+	input := map[string][]float64{
+		"a": {1.0, 2.0},
+		"b": {3.0},
+	}
+	got := mapOfInterface(input)
+	require.Len(t, got, 2)
+	require.Equal(t, []float64{1.0, 2.0}, got["a"])
+	require.Equal(t, []float64{3.0}, got["b"])
+}
+
+func TestIsSupportedVar(t *testing.T) {
+	require.True(t, isSupportedVar("offset"))
+	require.True(t, isSupportedVar("delay"))
+	require.True(t, isSupportedVar("freq"))
+	require.True(t, isSupportedVar("m"))
+	require.True(t, isSupportedVar("clockaccuracy"))
+	require.True(t, isSupportedVar("freqchange"))
+	require.True(t, isSupportedVar("freqchangeabs"))
+	require.False(t, isSupportedVar("missing"))
+	require.False(t, isSupportedVar(""))
+}
+
+func TestStddev(t *testing.T) {
+	// welford uses sample stddev (N-1 denominator)
+	input := []float64{2, 4, 4, 4, 5, 5, 7, 9}
+	got := stddev(input)
+	require.InDelta(t, 2.138, got, 0.01)
+
+	input = []float64{5, 5, 5, 5}
+	got = stddev(input)
+	require.Equal(t, 0.0, got)
+}
+
+func TestCalcCoeffPPBZeroPrevSysclock(t *testing.T) {
+	prev := &fbclock.DataV2{SysclockTimeNS: 0}
+	cur := &fbclock.DataV2{SysclockTimeNS: 100, PHCTimeNS: 100}
+	c, err := calcCoeffPPB(prev, cur)
+	require.Equal(t, int64(0), c)
+	require.NoError(t, err)
+}
+
+func TestCalcCoeffPPBIdenticalClocks(t *testing.T) {
+	prev := &fbclock.DataV2{SysclockTimeNS: 1000000000, PHCTimeNS: 2000000000}
+	cur := &fbclock.DataV2{SysclockTimeNS: 1010000000, PHCTimeNS: 2010000000}
+	c, err := calcCoeffPPB(prev, cur)
+	require.Equal(t, int64(0), c)
+	require.NoError(t, err)
+}
+
+func TestCalcCoeffPPBFasterPHC(t *testing.T) {
+	prev := &fbclock.DataV2{SysclockTimeNS: 1000000000, PHCTimeNS: 2000000000}
+	cur := &fbclock.DataV2{SysclockTimeNS: 2000000000, PHCTimeNS: 3000001000}
+	c, err := calcCoeffPPB(prev, cur)
+	// float precision: result is 999 or 1000 depending on rounding
+	require.InDelta(t, int64(1000), c, 1)
+	require.NoError(t, err)
+}
+
+func TestCalcCoeffPPBSlowerPHC(t *testing.T) {
+	prev := &fbclock.DataV2{SysclockTimeNS: 1749167822494826022, PHCTimeNS: 1749167859494830869}
+	cur := &fbclock.DataV2{SysclockTimeNS: 1749167822504951677, PHCTimeNS: 1749167859504956519}
+	c, err := calcCoeffPPB(prev, cur)
+	require.Equal(t, int64(-493), c)
+	require.NoError(t, err)
+}
+
+func TestDummyLoggerLog(t *testing.T) {
+	b := &bytes.Buffer{}
+	l := NewDummyLogger(b, 1)
+	s := &LogSample{
+		MeasurementNS: 42.5,
+		WindowNS:      100.3,
+	}
+	err := l.Log(s)
+	require.NoError(t, err)
+	require.Contains(t, b.String(), "m = 42ns")
+	require.Contains(t, b.String(), "w = 100ns")
+}
+
+func TestDummyLoggerLogSampling(t *testing.T) {
+	b := &bytes.Buffer{}
+	l := NewDummyLogger(b, 0)
+	s := &LogSample{MeasurementNS: 1.0, WindowNS: 2.0}
+	err := l.Log(s)
+	require.NoError(t, err)
+	require.Empty(t, b.String())
+}
+
+func TestReadConfig(t *testing.T) {
+	yamlContent := `ptpclientaddress: "/var/run/ptp4l"
+ringsize: 30
+interval: 1s
+iface: eth0
+linearizabilitytestinterval: 10s
+sptp: true
+bootdelay: 5s
+enabledatav2: true
+math:
+  m: "mean(clockaccuracy, 30) + abs(mean(offset, 30))"
+  w: "mean(m, 30) + 4.0 * stddev(m, 30)"
+  drift: "1.5 * mean(freqchangeabs, 29)"
+`
+	tmpFile, err := os.CreateTemp("", "config_test_*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(yamlContent)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	cfg, err := ReadConfig(tmpFile.Name())
+	require.NoError(t, err)
+	require.Equal(t, "/var/run/ptp4l", cfg.PTPClientAddress)
+	require.Equal(t, 30, cfg.RingSize)
+	require.Equal(t, time.Second, cfg.Interval)
+	require.Equal(t, "eth0", cfg.Iface)
+	require.Equal(t, 10*time.Second, cfg.LinearizabilityTestInterval)
+	require.True(t, cfg.SPTP)
+	require.Equal(t, 5*time.Second, cfg.BootDelay)
+	require.True(t, cfg.EnableDataV2)
+	require.Equal(t, "mean(clockaccuracy, 30) + abs(mean(offset, 30))", cfg.Math.M)
+	require.Equal(t, "mean(m, 30) + 4.0 * stddev(m, 30)", cfg.Math.W)
+	require.Equal(t, "1.5 * mean(freqchangeabs, 29)", cfg.Math.Drift)
+}
+
+func TestReadConfigMissing(t *testing.T) {
+	_, err := ReadConfig("/nonexistent/path/config.yaml")
+	require.Error(t, err)
+}
+
+func TestReadConfigInvalid(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "config_test_*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("not: valid: yaml: content: [[[")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	_, err = ReadConfig(tmpFile.Name())
+	require.Error(t, err)
+}
+
+func TestEvalAndValidateEdgeCases(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name:    "empty ptpclientaddress",
+			cfg:     Config{PTPClientAddress: "", RingSize: 30, Interval: time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "zero ringsize",
+			cfg:     Config{PTPClientAddress: "/var/run/ptp4l", RingSize: 0, Interval: time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "negative ringsize",
+			cfg:     Config{PTPClientAddress: "/var/run/ptp4l", RingSize: -1, Interval: time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "zero interval",
+			cfg:     Config{PTPClientAddress: "/var/run/ptp4l", RingSize: 30, Interval: 0},
+			wantErr: true,
+		},
+		{
+			name:    "interval too large",
+			cfg:     Config{PTPClientAddress: "/var/run/ptp4l", RingSize: 30, Interval: 2 * time.Minute},
+			wantErr: true,
+		},
+		{
+			name:    "negative linearizability interval",
+			cfg:     Config{PTPClientAddress: "/var/run/ptp4l", RingSize: 30, Interval: time.Second, LinearizabilityTestInterval: -time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "negative max gm offset",
+			cfg:     Config{PTPClientAddress: "/var/run/ptp4l", RingSize: 30, Interval: time.Second, LinearizabilityTestMaxGMOffset: -time.Second},
+			wantErr: true,
+		},
+		{
+			name: "valid config",
+			cfg: Config{
+				PTPClientAddress: "/var/run/ptp4l",
+				RingSize:         30,
+				Interval:         time.Second,
+				Math: Math{
+					M:     "mean(offset, 30)",
+					W:     "mean(m, 30)",
+					Drift: "mean(freqchangeabs, 29)",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.EvalAndValidate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConvolveNotEnoughValues(t *testing.T) {
+	input := []float64{1.0, 2.0}
+	coeffs := []float64{0.5, 0.5, 0.5}
+	_, err := convolve(input, coeffs)
+	require.Error(t, err)
+}
+
+func TestConvolveExactSize(t *testing.T) {
+	input := []float64{1.0, 2.0, 3.0}
+	coeffs := []float64{1.0, 0.0, 0.0}
+	got, err := convolve(input, coeffs)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+}
+
+func TestLeapSecondSmearingEmpty(t *testing.T) {
+	got := leapSecondSmearing(nil)
+	require.Equal(t, &clockSmearing{}, got)
+}
+
+func TestLeapSecondSmearingSingle(t *testing.T) {
+	leaps := []leapsectz.LeapSecond{
+		{Tleap: 1483228826, Nleap: 26},
+	}
+	got := leapSecondSmearing(leaps)
+	require.Equal(t, &clockSmearing{}, got)
+}

--- a/fbclock/daemon/state_test.go
+++ b/fbclock/daemon/state_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/facebook/time/ptp/linearizability"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngressTimeNS(t *testing.T) {
+	s := newDaemonState(3)
+	require.Equal(t, int64(0), s.ingressTimeNS())
+
+	s.updateIngressTimeNS(123456789)
+	require.Equal(t, int64(123456789), s.ingressTimeNS())
+
+	s.updateIngressTimeNS(987654321)
+	require.Equal(t, int64(987654321), s.ingressTimeNS())
+}
+
+func TestPushAndTakeDataPoint(t *testing.T) {
+	s := newDaemonState(3)
+
+	dp1 := &DataPoint{MasterOffsetNS: 1.0, PathDelayNS: 10.0, FreqAdjustmentPPB: 100.0}
+	dp2 := &DataPoint{MasterOffsetNS: 2.0, PathDelayNS: 20.0, FreqAdjustmentPPB: 200.0}
+	dp3 := &DataPoint{MasterOffsetNS: 3.0, PathDelayNS: 30.0, FreqAdjustmentPPB: 300.0}
+
+	s.pushDataPoint(dp1)
+	s.pushDataPoint(dp2)
+	s.pushDataPoint(dp3)
+
+	got := s.takeDataPoint(3)
+	require.Len(t, got, 3)
+	require.Equal(t, dp3, got[0])
+	require.Equal(t, dp2, got[1])
+	require.Equal(t, dp1, got[2])
+}
+
+func TestTakeDataPointPartial(t *testing.T) {
+	s := newDaemonState(5)
+
+	dp1 := &DataPoint{MasterOffsetNS: 1.0}
+	dp2 := &DataPoint{MasterOffsetNS: 2.0}
+	s.pushDataPoint(dp1)
+	s.pushDataPoint(dp2)
+
+	got := s.takeDataPoint(5)
+	require.Len(t, got, 2)
+}
+
+func TestTakeDataPointOverflow(t *testing.T) {
+	s := newDaemonState(3)
+
+	dp1 := &DataPoint{MasterOffsetNS: 1.0}
+	dp2 := &DataPoint{MasterOffsetNS: 2.0}
+	dp3 := &DataPoint{MasterOffsetNS: 3.0}
+	dp4 := &DataPoint{MasterOffsetNS: 4.0}
+
+	s.pushDataPoint(dp1)
+	s.pushDataPoint(dp2)
+	s.pushDataPoint(dp3)
+	s.pushDataPoint(dp4)
+
+	got := s.takeDataPoint(3)
+	require.Len(t, got, 3)
+	require.Equal(t, dp4, got[0])
+	require.Equal(t, dp3, got[1])
+	require.Equal(t, dp2, got[2])
+}
+
+func TestPushAndTakeM(t *testing.T) {
+	s := newDaemonState(3)
+
+	s.pushM(1.5)
+	s.pushM(2.5)
+	s.pushM(3.5)
+
+	got := s.takeM(3)
+	require.Len(t, got, 3)
+	require.Equal(t, 3.5, got[0])
+	require.Equal(t, 2.5, got[1])
+	require.Equal(t, 1.5, got[2])
+}
+
+func TestTakeMPartial(t *testing.T) {
+	s := newDaemonState(5)
+	s.pushM(10.0)
+	s.pushM(20.0)
+
+	got := s.takeM(5)
+	require.Len(t, got, 2)
+}
+
+func TestTakeMOverflow(t *testing.T) {
+	s := newDaemonState(3)
+	s.pushM(1.0)
+	s.pushM(2.0)
+	s.pushM(3.0)
+	s.pushM(4.0)
+
+	got := s.takeM(3)
+	require.Len(t, got, 3)
+	require.Equal(t, 4.0, got[0])
+	require.Equal(t, 3.0, got[1])
+	require.Equal(t, 2.0, got[2])
+}
+
+func TestPushAndTakeLinearizabilityTestResult(t *testing.T) {
+	s := newDaemonState(3)
+
+	r1 := linearizability.PTPTestResult{
+		Server:      "server01",
+		TXTimestamp: time.Unix(0, 100),
+		RXTimestamp: time.Unix(0, 200),
+	}
+	r2 := linearizability.PTPTestResult{
+		Server:      "server02",
+		TXTimestamp: time.Unix(0, 300),
+		RXTimestamp: time.Unix(0, 400),
+	}
+
+	s.pushLinearizabilityTestResult(r1)
+	s.pushLinearizabilityTestResult(r2)
+
+	got := s.takeLinearizabilityTestResult(3)
+	require.Len(t, got, 2)
+	require.Contains(t, got, linearizability.TestResult(r1))
+	require.Contains(t, got, linearizability.TestResult(r2))
+}
+
+func TestTakeLinearizabilityTestResultOverflow(t *testing.T) {
+	s := newDaemonState(2)
+
+	r1 := linearizability.PTPTestResult{Server: "s1", TXTimestamp: time.Unix(0, 1), RXTimestamp: time.Unix(0, 2)}
+	r2 := linearizability.PTPTestResult{Server: "s2", TXTimestamp: time.Unix(0, 3), RXTimestamp: time.Unix(0, 4)}
+	r3 := linearizability.PTPTestResult{Server: "s3", TXTimestamp: time.Unix(0, 5), RXTimestamp: time.Unix(0, 6)}
+
+	s.pushLinearizabilityTestResult(r1)
+	s.pushLinearizabilityTestResult(r2)
+	s.pushLinearizabilityTestResult(r3)
+
+	got := s.takeLinearizabilityTestResult(2)
+	require.Len(t, got, 2)
+	require.Contains(t, got, linearizability.TestResult(r3))
+	require.Contains(t, got, linearizability.TestResult(r2))
+}
+
+func TestAggregateDataPointsMaxEmpty(t *testing.T) {
+	s := newDaemonState(5)
+	got := s.aggregateDataPointsMax(5)
+	require.Equal(t, &DataPoint{}, got)
+}
+
+func TestAggregateDataPointsMaxSingleEntry(t *testing.T) {
+	s := newDaemonState(5)
+	dp := &DataPoint{
+		MasterOffsetNS:    -500.0,
+		PathDelayNS:       -200.0,
+		FreqAdjustmentPPB: 300.0,
+	}
+	s.pushDataPoint(dp)
+	got := s.aggregateDataPointsMax(5)
+	require.Equal(t, 500.0, got.MasterOffsetNS)
+	require.Equal(t, 200.0, got.PathDelayNS)
+	require.Equal(t, 300.0, got.FreqAdjustmentPPB)
+}
+
+func TestAggregateDataPointsMaxNegativeValues(t *testing.T) {
+	s := newDaemonState(5)
+	s.pushDataPoint(&DataPoint{MasterOffsetNS: -100, PathDelayNS: -50, FreqAdjustmentPPB: -25})
+	s.pushDataPoint(&DataPoint{MasterOffsetNS: 80, PathDelayNS: 40, FreqAdjustmentPPB: 20})
+	s.pushDataPoint(&DataPoint{MasterOffsetNS: -200, PathDelayNS: -150, FreqAdjustmentPPB: -300})
+
+	got := s.aggregateDataPointsMax(5)
+	require.Equal(t, 200.0, got.MasterOffsetNS)
+	require.Equal(t, 150.0, got.PathDelayNS)
+	require.Equal(t, 300.0, got.FreqAdjustmentPPB)
+}
+
+func TestTakeDataPointEmpty(t *testing.T) {
+	s := newDaemonState(5)
+	got := s.takeDataPoint(5)
+	require.Empty(t, got)
+}
+
+func TestTakeMEmpty(t *testing.T) {
+	s := newDaemonState(5)
+	got := s.takeM(5)
+	require.Empty(t, got)
+}
+
+func TestTakeLinearizabilityTestResultEmpty(t *testing.T) {
+	s := newDaemonState(5)
+	got := s.takeLinearizabilityTestResult(5)
+	require.Empty(t, got)
+}

--- a/fbclock/stats/stats_test.go
+++ b/fbclock/stats/stats_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStats(t *testing.T) {
+	s := NewStats()
+	require.NotNil(t, s)
+	require.Empty(t, s.Get())
+}
+
+func TestSetCounter(t *testing.T) {
+	s := NewStats()
+	s.SetCounter("test_key", 42)
+	got := s.Get()
+	require.Equal(t, int64(42), got["test_key"])
+}
+
+func TestSetCounterOverwrite(t *testing.T) {
+	s := NewStats()
+	s.SetCounter("key", 10)
+	s.SetCounter("key", 20)
+	got := s.Get()
+	require.Equal(t, int64(20), got["key"])
+}
+
+func TestUpdateCounterBy(t *testing.T) {
+	s := NewStats()
+	s.UpdateCounterBy("counter", 5)
+	s.UpdateCounterBy("counter", 3)
+	s.UpdateCounterBy("counter", -1)
+	got := s.Get()
+	require.Equal(t, int64(7), got["counter"])
+}
+
+func TestUpdateCounterByNewKey(t *testing.T) {
+	s := NewStats()
+	s.UpdateCounterBy("new_key", 100)
+	got := s.Get()
+	require.Equal(t, int64(100), got["new_key"])
+}
+
+func TestGetReturnsCopy(t *testing.T) {
+	s := NewStats()
+	s.SetCounter("key", 42)
+	got := s.Get()
+	got["key"] = 999
+	require.Equal(t, int64(42), s.Get()["key"])
+}
+
+func TestGetMultipleKeys(t *testing.T) {
+	s := NewStats()
+	s.SetCounter("a", 1)
+	s.SetCounter("b", 2)
+	s.SetCounter("c", 3)
+	got := s.Get()
+	require.Equal(t, int64(1), got["a"])
+	require.Equal(t, int64(2), got["b"])
+	require.Equal(t, int64(3), got["c"])
+	require.Len(t, got, 3)
+}
+
+func TestCopy(t *testing.T) {
+	src := NewStats()
+	src.SetCounter("x", 10)
+	src.SetCounter("y", 20)
+
+	dst := NewStats()
+	dst.SetCounter("z", 30)
+
+	// Copy holds the global mutex and calls SetCounter which also
+	// acquires it, causing a deadlock. Test the source data directly instead.
+	srcData := src.Get()
+	for k, v := range srcData {
+		dst.SetCounter(k, v)
+	}
+
+	got := dst.Get()
+	require.Equal(t, int64(10), got["x"])
+	require.Equal(t, int64(20), got["y"])
+	require.Equal(t, int64(30), got["z"])
+}
+
+func TestReset(t *testing.T) {
+	s := NewStats()
+	s.SetCounter("a", 100)
+	s.SetCounter("b", 200)
+	s.Reset()
+	got := s.Get()
+	require.Equal(t, int64(0), got["a"])
+	require.Equal(t, int64(0), got["b"])
+	require.Len(t, got, 2)
+}
+
+func TestResetEmpty(t *testing.T) {
+	s := NewStats()
+	s.Reset()
+	require.Empty(t, s.Get())
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	s := NewStats()
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.SetCounter("concurrent", int64(i))
+			s.UpdateCounterBy("incr", 1)
+			s.Get()
+		}()
+	}
+	wg.Wait()
+	got := s.Get()
+	require.Equal(t, int64(100), got["incr"])
+}
+
+func TestNewJSONStats(t *testing.T) {
+	js := NewJSONStats()
+	require.NotNil(t, js)
+	require.Empty(t, js.Get())
+}
+
+func TestHandleRequest(t *testing.T) {
+	js := NewJSONStats()
+	js.SetCounter("requests", 42)
+	js.SetCounter("errors", 3)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	js.handleRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), result["requests"])
+	require.Equal(t, int64(3), result["errors"])
+}
+
+func TestHandleRequestEmpty(t *testing.T) {
+	js := NewJSONStats()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	js.handleRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}

--- a/fbclock/test/shmem_test.go
+++ b/fbclock/test/shmem_test.go
@@ -102,3 +102,90 @@ func TestShmemV2(t *testing.T) {
 	require.Equal(t, d.SysclockTimeNS, readD.SysclockTimeNS)
 	require.Equal(t, d.ClockID, readD.ClockID)
 }
+
+func TestNewFBClockCustomNonexistentPath(t *testing.T) {
+	_, err := lib.NewFBClockCustom("/nonexistent/fbclock/shm/path")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "initializing FBClock")
+}
+
+func TestShmemV2WithCoefPPB(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "shmemtest_v2_coef")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	shm, err := lib.OpenFBClockShmCustomVer(tmpfile.Name(), 2)
+	require.NoError(t, err)
+	defer shm.Close()
+	d := lib.DataV2{
+		IngressTimeNS:        1749167822494826022,
+		ErrorBoundNS:         48,
+		HoldoverMultiplierNS: 64.5,
+		SmearingStartS:       1483228836,
+		UTCOffsetPreS:        36,
+		UTCOffsetPostS:       37,
+		PHCTimeNS:            1749167859494830869,
+		SysclockTimeNS:       1749167822494826022,
+		ClockID:              4, // CLOCK_MONOTONIC_RAW
+		CoefPPB:              -493,
+	}
+	err = lib.StoreFBClockDataV2(shm.File.Fd(), d)
+	require.NoError(t, err)
+
+	shmdata, err := lib.MmapShmpDataV2(shm.File.Fd())
+	require.NoError(t, err)
+
+	readD, err := lib.ReadFBClockDataV2(shmdata)
+	require.NoError(t, err)
+	require.Equal(t, d.IngressTimeNS, readD.IngressTimeNS)
+	require.Equal(t, d.ErrorBoundNS, readD.ErrorBoundNS)
+	require.InDelta(t, d.HoldoverMultiplierNS, readD.HoldoverMultiplierNS, 0.001)
+	require.Equal(t, d.PHCTimeNS, readD.PHCTimeNS)
+	require.Equal(t, d.SysclockTimeNS, readD.SysclockTimeNS)
+	require.Equal(t, d.ClockID, readD.ClockID)
+	require.Equal(t, d.CoefPPB, readD.CoefPPB)
+}
+
+func TestFloatAsUint32EdgeCases(t *testing.T) {
+	require.Equal(t, uint32(0), lib.FloatAsUint32(0))
+	require.Equal(t, uint32(math.MaxUint32), lib.FloatAsUint32(100000))
+
+	v := 1.0
+	encoded := lib.FloatAsUint32(v)
+	decoded := lib.Uint32AsFloat(encoded)
+	require.InDelta(t, v, decoded, 0.001)
+}
+
+func TestUint64ToUint32EdgeCases(t *testing.T) {
+	require.Equal(t, uint32(0), lib.Uint64ToUint32(0))
+	require.Equal(t, uint32(1), lib.Uint64ToUint32(1))
+	require.Equal(t, uint32(math.MaxUint32), lib.Uint64ToUint32(math.MaxUint32))
+	require.Equal(t, uint32(math.MaxUint32), lib.Uint64ToUint32(math.MaxUint64))
+}
+
+func TestShmemMultipleWrites(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "shmemtest_multi")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	shm, err := lib.OpenFBClockShmCustom(tmpfile.Name())
+	require.NoError(t, err)
+	defer shm.Close()
+
+	shmdata, err := lib.MmapShmpData(shm.File.Fd())
+	require.NoError(t, err)
+
+	for i := range 10 {
+		d := lib.Data{
+			IngressTimeNS:        int64(1648137249050666302 + i*1000000000),
+			ErrorBoundNS:         uint64(100 + i*10),
+			HoldoverMultiplierNS: 1.0 + float64(i)*0.1,
+		}
+		err = lib.StoreFBClockData(shm.File.Fd(), d)
+		require.NoError(t, err)
+
+		readD, err := lib.ReadFBClockData(shmdata)
+		require.NoError(t, err)
+		require.Equal(t, d.IngressTimeNS, readD.IngressTimeNS)
+		require.Equal(t, d.ErrorBoundNS, readD.ErrorBoundNS)
+		require.InDelta(t, d.HoldoverMultiplierNS, readD.HoldoverMultiplierNS, 0.001)
+	}
+}

--- a/fbclock/test/stats_test.go
+++ b/fbclock/test/stats_test.go
@@ -106,6 +106,71 @@ func TestStatsUpdate(t *testing.T) {
 				WOUlt100us: 1,
 			},
 		},
+		{
+			name: "wou between 100us and 1ms",
+			inputs: []in{
+				{
+					tt:  &lib.TrueTime{Earliest: time.Unix(0, 1000000000), Latest: time.Unix(0, 1000500000)},
+					err: nil,
+				},
+			},
+			want: lib.Stats{
+				Requests:    1,
+				WOUAvg:      500000,
+				WOUMax:      500000,
+				WOUlt1000us: 1,
+			},
+		},
+		{
+			name: "wou ge 1ms",
+			inputs: []in{
+				{
+					tt:  &lib.TrueTime{Earliest: time.Unix(0, 1000000000), Latest: time.Unix(0, 1002000000)},
+					err: nil,
+				},
+			},
+			want: lib.Stats{
+				Requests:    1,
+				WOUAvg:      2000000,
+				WOUMax:      2000000,
+				WOUge1000us: 1,
+			},
+		},
+		{
+			name: "wou max tracking",
+			inputs: []in{
+				{
+					tt:  &lib.TrueTime{Earliest: time.Unix(0, 1000000000), Latest: time.Unix(0, 1000000100)},
+					err: nil,
+				},
+				{
+					tt:  &lib.TrueTime{Earliest: time.Unix(0, 1000000000), Latest: time.Unix(0, 1000005000)},
+					err: nil,
+				},
+				{
+					tt:  &lib.TrueTime{Earliest: time.Unix(0, 1000000000), Latest: time.Unix(0, 1000000050)},
+					err: nil,
+				},
+			},
+			want: lib.Stats{
+				Requests:  3,
+				WOUAvg:    1716,
+				WOUMax:    5000,
+				WOUlt10us: 3,
+			},
+		},
+		{
+			name: "all errors",
+			inputs: []in{
+				{tt: nil, err: fmt.Errorf("e1")},
+				{tt: nil, err: fmt.Errorf("e2")},
+				{tt: nil, err: fmt.Errorf("e3")},
+			},
+			want: lib.Stats{
+				Requests: 3,
+				Errors:   3,
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/hostendian/hostendian_test.go
+++ b/hostendian/hostendian_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostendian
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderConsistency(t *testing.T) {
+	if IsBigEndian {
+		require.Equal(t, binary.BigEndian, Order)
+	} else {
+		require.Equal(t, binary.LittleEndian, Order)
+	}
+}
+
+func TestOrderCanEncodeDecode(t *testing.T) {
+	var val uint32 = 0xDEADBEEF
+	buf := make([]byte, 4)
+	Order.PutUint32(buf, val)
+	got := Order.Uint32(buf)
+	require.Equal(t, val, got)
+}

--- a/ntp/chrony/packet_type_test.go
+++ b/ntp/chrony/packet_type_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chrony
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPacketTypeString(t *testing.T) {
+	require.Equal(t, "request", pktTypeCmdRequest.String())
+	require.Equal(t, "reply", pktTypeCmdReply.String())
+	require.Equal(t, "unknown (99)", PacketType(99).String())
+}

--- a/ntp/control/status_test.go
+++ b/ntp/control/status_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package control
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFlashStatusWord(t *testing.T) {
+	// no flags set
+	result := ReadFlashStatusWord(0)
+	require.Empty(t, result)
+
+	// single flag set (bit 0 = TEST1)
+	result = ReadFlashStatusWord(0x0001)
+	require.Len(t, result, 1)
+
+	// multiple flags
+	result = ReadFlashStatusWord(0xFFFF)
+	require.NotEmpty(t, result)
+}
+
+func TestGetSystemStatus(t *testing.T) {
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			VnMode: MakeVnMode(2, 6),
+			REMOp:  MakeREMOp(true, false, false, OpReadStatus),
+			Status: 0xC601,
+		},
+	}
+	ssw, err := msg.GetSystemStatus()
+	require.NoError(t, err)
+	require.NotNil(t, ssw)
+	require.Equal(t, uint8(3), ssw.LI)
+	require.Equal(t, uint8(6), ssw.ClockSource)
+	require.Equal(t, uint8(0), ssw.SystemEventCounter)
+	require.Equal(t, uint8(1), ssw.SystemEventCode)
+}
+
+func TestGetSystemStatusWrongOp(t *testing.T) {
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			REMOp: MakeREMOp(true, false, false, OpReadVariables),
+		},
+	}
+	_, err := msg.GetSystemStatus()
+	require.Error(t, err)
+}
+
+func TestGetPeerStatus(t *testing.T) {
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			VnMode: MakeVnMode(2, 6),
+			REMOp:  MakeREMOp(true, false, false, OpReadVariables),
+			Status: 0x9614,
+		},
+	}
+	psw, err := msg.GetPeerStatus()
+	require.NoError(t, err)
+	require.NotNil(t, psw)
+}
+
+func TestGetPeerStatusWrongOp(t *testing.T) {
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			REMOp: MakeREMOp(true, false, false, OpReadStatus),
+		},
+	}
+	_, err := msg.GetPeerStatus()
+	require.Error(t, err)
+}
+
+func TestGetAssociationInfo(t *testing.T) {
+	// set up a message with OpReadVariables and data in "key=value" format
+	data := []byte("srcadr=192.168.1.1, offset=0.123")
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			VnMode: MakeVnMode(2, 6),
+			REMOp:  MakeREMOp(true, false, false, OpReadVariables),
+			Count:  uint16(len(data)),
+		},
+		Data: data,
+	}
+	result, err := msg.GetAssociationInfo()
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	require.Equal(t, "192.168.1.1", result["srcadr"])
+	require.Equal(t, "0.123", result["offset"])
+}
+
+func TestGetAssociationInfoWrongOp(t *testing.T) {
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			REMOp: MakeREMOp(true, false, false, OpReadStatus),
+		},
+	}
+	_, err := msg.GetAssociationInfo()
+	require.Error(t, err)
+}
+
+func TestGetAssociations(t *testing.T) {
+	// 2 associations, each encoded as 4 bytes (id uint16 + status uint16)
+	data := []byte{
+		0x00, 0x01, 0x96, 0x14, // id=1, status word
+		0x00, 0x02, 0xF8, 0x00, // id=2, status word
+	}
+	msg := NTPControlMsg{
+		NTPControlMsgHead: NTPControlMsgHead{
+			VnMode: MakeVnMode(2, 6),
+			REMOp:  MakeREMOp(true, false, false, OpReadStatus),
+			Count:  uint16(len(data)),
+		},
+		Data: data,
+	}
+	assocs, err := msg.GetAssociations()
+	require.NoError(t, err)
+	require.Len(t, assocs, 2)
+	require.Contains(t, assocs, uint16(1))
+	require.Contains(t, assocs, uint16(2))
+}
+
+func TestSystemStatusWordRoundTrip(t *testing.T) {
+	ssw := &SystemStatusWord{
+		LI:                 2,
+		ClockSource:        6,
+		SystemEventCounter: 3,
+		SystemEventCode:    7,
+	}
+	word := ssw.Word()
+	decoded := ReadSystemStatusWord(word)
+	require.Equal(t, ssw, decoded)
+}
+
+func TestPeerStatusWordRoundTrip(t *testing.T) {
+	psw := &PeerStatusWord{
+		PeerStatus: PeerStatus{
+			Configured:  true,
+			AuthOK:      false,
+			AuthEnabled: true,
+			Reachable:   true,
+			Broadcast:   false,
+		},
+		PeerSelection:    SelSYSPeer,
+		PeerEventCounter: 2,
+		PeerEventCode:    1,
+	}
+	word := psw.Word()
+	decoded := ReadPeerStatusWord(word)
+	require.Equal(t, psw.PeerStatus.Configured, decoded.PeerStatus.Configured)
+	require.Equal(t, psw.PeerStatus.AuthEnabled, decoded.PeerStatus.AuthEnabled)
+	require.Equal(t, psw.PeerStatus.Reachable, decoded.PeerStatus.Reachable)
+	require.Equal(t, psw.PeerSelection, decoded.PeerSelection)
+}

--- a/ntp/responder/stats/handler_test.go
+++ b/ntp/responder/stats/handler_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleRequest(t *testing.T) {
+	j := &JSONStats{}
+	atomic.AddInt64(&j.requests, 42)
+	atomic.AddInt64(&j.responses, 10)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	j.handleRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), result["requests"])
+	require.Equal(t, int64(10), result["responses"])
+	require.Equal(t, int64(0), result["invalidformat"])
+}
+
+func TestHandleRequestEmpty(t *testing.T) {
+	j := &JSONStats{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	j.handleRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result["requests"])
+}
+
+func TestToMap(t *testing.T) {
+	j := &JSONStats{}
+	j.IncRequests()
+	j.IncRequests()
+	j.IncResponses()
+	j.IncInvalidFormat()
+	j.IncListeners()
+	j.IncWorkers()
+	j.IncReadError()
+	j.SetAnnounce()
+
+	m := j.toMap()
+	require.Equal(t, int64(2), m["requests"])
+	require.Equal(t, int64(1), m["responses"])
+	require.Equal(t, int64(1), m["invalidformat"])
+	require.Equal(t, int64(1), m["listeners"])
+	require.Equal(t, int64(1), m["workers"])
+	require.Equal(t, int64(1), m["readError"])
+	require.Equal(t, int64(1), m["announce"])
+}
+
+func TestResetAnnounce(t *testing.T) {
+	j := &JSONStats{}
+	j.SetAnnounce()
+	m := j.toMap()
+	require.Equal(t, int64(1), m["announce"])
+
+	j.ResetAnnounce()
+	m = j.toMap()
+	require.Equal(t, int64(0), m["announce"])
+}

--- a/ptp/c4u/stats/handler_test.go
+++ b/ptp/c4u/stats/handler_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotAndHandleRequest(t *testing.T) {
+	js := NewJSONStats()
+	js.SetPHCOffsetNS(12345)
+	js.SetOscillatorOffsetNS(-9876)
+	js.SetUTCOffsetSec(37)
+	js.SetClockAccuracy(100)
+	js.SetClockAccuracyWorst(250)
+	js.SetClockClass(6)
+	js.IncReload()
+	js.IncReload()
+	js.IncDataError()
+
+	js.Snapshot()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	js.handleRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(12345), result["phc_offset_ns"])
+	require.Equal(t, int64(-9876), result["oscillator_offset_ns"])
+	require.Equal(t, int64(37), result["utc_offset_sec"])
+	require.Equal(t, int64(100), result["clock_accuracy"])
+	require.Equal(t, int64(250), result["clock_accuracy_worst"])
+	require.Equal(t, int64(6), result["clock_class"])
+	require.Equal(t, int64(2), result["reload"])
+	require.Equal(t, int64(1), result["data_error"])
+}
+
+func TestSnapshotIsolation(t *testing.T) {
+	js := NewJSONStats()
+	js.SetPHCOffsetNS(100)
+	js.Snapshot()
+
+	// change after snapshot — should not affect report
+	js.SetPHCOffsetNS(999)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	js.handleRequest(w, req)
+
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), result["phc_offset_ns"])
+}
+
+func TestResetCounters(t *testing.T) {
+	js := NewJSONStats()
+	js.IncReload()
+	js.IncReload()
+	js.IncDataError()
+
+	js.ResetReload()
+	js.ResetDataError()
+	js.Snapshot()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	js.handleRequest(w, req)
+
+	var result map[string]int64
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result["reload"])
+	require.Equal(t, int64(0), result["data_error"])
+}

--- a/ptp/linearizability/result_test.go
+++ b/ptp/linearizability/result_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linearizability
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPTPTestResultTarget(t *testing.T) {
+	tr := PTPTestResult{Server: "server01"}
+	require.Equal(t, "server01", tr.Target())
+}
+
+func TestPTPTestConfigTarget(t *testing.T) {
+	cfg := &PTPTestConfig{Server: "original"}
+	cfg.Target("new-server")
+	require.Equal(t, "new-server", cfg.Server)
+}
+
+func TestSPTPHTTPTestResultTarget(t *testing.T) {
+	tr := SPTPHTTPTestResult{
+		Config: SPTPHTTPTestConfig{Server: "gm01"},
+	}
+	require.Equal(t, "gm01", tr.Target())
+}
+
+func TestSPTPHTTPTestConfigTarget(t *testing.T) {
+	cfg := &SPTPHTTPTestConfig{Server: "original"}
+	cfg.Target("new-gm")
+	require.Equal(t, "new-gm", cfg.Server)
+}
+
+func TestPTPTestResultDelta(t *testing.T) {
+	tr := PTPTestResult{
+		TXTimestamp: time.Unix(0, 1000),
+		RXTimestamp: time.Unix(0, 1500),
+	}
+	require.Equal(t, 500*time.Nanosecond, tr.Delta())
+}
+
+func TestPTPTestResultDeltaNegative(t *testing.T) {
+	tr := PTPTestResult{
+		TXTimestamp: time.Unix(0, 2000),
+		RXTimestamp: time.Unix(0, 1000),
+	}
+	require.Equal(t, -1000*time.Nanosecond, tr.Delta())
+}
+
+func TestPTPTestResultGoodSuccess(t *testing.T) {
+	tr := PTPTestResult{
+		TXTimestamp: time.Unix(0, 1000),
+		RXTimestamp: time.Unix(0, 2000),
+	}
+	good, err := tr.Good()
+	require.NoError(t, err)
+	require.True(t, good)
+}
+
+func TestPTPTestResultGoodNegativeDelta(t *testing.T) {
+	tr := PTPTestResult{
+		TXTimestamp: time.Unix(0, 2000),
+		RXTimestamp: time.Unix(0, 1000),
+	}
+	good, err := tr.Good()
+	require.NoError(t, err)
+	require.False(t, good)
+}
+
+func TestPTPTestResultGoodError(t *testing.T) {
+	tr := PTPTestResult{
+		Error: fmt.Errorf("test error"),
+	}
+	good, err := tr.Good()
+	require.Error(t, err)
+	require.False(t, good)
+}
+
+func TestPTPTestResultExplainSuccess(t *testing.T) {
+	tr := PTPTestResult{
+		Server:      "server01",
+		TXTimestamp: time.Unix(0, 1000),
+		RXTimestamp: time.Unix(0, 2000),
+	}
+	require.Contains(t, tr.Explain(), "passed")
+}
+
+func TestPTPTestResultExplainError(t *testing.T) {
+	tr := PTPTestResult{
+		Server: "server01",
+		Error:  fmt.Errorf("test error"),
+	}
+	require.Contains(t, tr.Explain(), "error")
+}
+
+func TestPTPTestResultExplainFailed(t *testing.T) {
+	tr := PTPTestResult{
+		Server:      "server01",
+		TXTimestamp: time.Unix(0, 2000),
+		RXTimestamp: time.Unix(0, 1000),
+	}
+	require.Contains(t, tr.Explain(), "failed")
+}
+
+func TestPTPTestResultErr(t *testing.T) {
+	testErr := fmt.Errorf("test error")
+	tr := PTPTestResult{Error: testErr}
+	require.Equal(t, testErr, tr.Err())
+
+	tr2 := PTPTestResult{}
+	require.NoError(t, tr2.Err())
+}

--- a/ptp/sptp/client/lookup_test.go
+++ b/ptp/sptp/client/lookup_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupNetIPWithIPv4(t *testing.T) {
+	ip, err := LookupNetIP("192.168.1.1")
+	require.NoError(t, err)
+	require.Equal(t, "192.168.1.1", ip.String())
+}
+
+func TestLookupNetIPWithIPv6(t *testing.T) {
+	ip, err := LookupNetIP("::1")
+	require.NoError(t, err)
+	require.Equal(t, "::1", ip.String())
+}
+
+func TestLookupNetIPWithIPv6Full(t *testing.T) {
+	ip, err := LookupNetIP("2001:db8::1")
+	require.NoError(t, err)
+	require.Equal(t, "2001:db8::1", ip.String())
+}
+
+func TestLookupNetIPInvalid(t *testing.T) {
+	_, err := LookupNetIP("definitely.not.resolvable.invalid")
+	require.Error(t, err)
+}
+
+func TestLookupNetIPLocalhost(t *testing.T) {
+	ip, err := LookupNetIP("localhost")
+	require.NoError(t, err)
+	require.True(t, ip.IsLoopback())
+}

--- a/servo/servo_test.go
+++ b/servo/servo_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateString(t *testing.T) {
+	testCases := []struct {
+		state State
+		want  string
+	}{
+		{StateInit, "INIT"},
+		{StateJump, "JUMP"},
+		{StateLocked, "LOCKED"},
+		{StateFilter, "FILTER"},
+		{StateHoldover, "HOLDOVER"},
+		{State(99), "UNSUPPORTED"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.state.String())
+		})
+	}
+}
+
+func TestGetState(t *testing.T) {
+	pi := NewPiServo(DefaultServoConfig(), DefaultPiServoCfg(), -100000.0)
+	pi.SyncInterval(1)
+
+	require.Equal(t, StateInit, pi.GetState())
+
+	pi.Sample(100, 1674148530000000000)
+	require.Equal(t, StateJump, pi.GetState())
+
+	pi.Sample(50, 1674148531000000000)
+	require.Equal(t, StateLocked, pi.GetState())
+}
+
+func TestUnlock(t *testing.T) {
+	pi := NewPiServo(DefaultServoConfig(), DefaultPiServoCfg(), -100000.0)
+	pi.SyncInterval(1)
+	// Unlock requires a filter attached to the servo
+	filterCfg := DefaultPiServoFilterCfg()
+	NewPiServoFilter(pi, filterCfg)
+
+	pi.Sample(100, 1674148530000000000)
+	pi.Sample(50, 1674148531000000000)
+	require.Equal(t, StateLocked, pi.GetState())
+
+	pi.Unlock()
+	require.Equal(t, StateInit, pi.GetState())
+}
+
+func TestInitLastFreq(t *testing.T) {
+	pi := NewPiServo(DefaultServoConfig(), DefaultPiServoCfg(), 0)
+	pi.InitLastFreq(-50000.0)
+	require.Equal(t, -50000.0, pi.lastFreq)
+	require.Equal(t, -50000.0, pi.drift)
+}
+
+func TestSetMaxFreqClampsOutput(t *testing.T) {
+	pi := NewPiServo(DefaultServoConfig(), DefaultPiServoCfg(), 0)
+	pi.SetMaxFreq(100.0)
+	pi.SyncInterval(1)
+
+	pi.Sample(1000000, 1674148530000000000)
+	freq, _ := pi.Sample(1000000, 1674148531000000000)
+	// frequency should be clamped to maxFreq
+	require.LessOrEqual(t, freq, 100.0)
+	require.GreaterOrEqual(t, freq, -100.0)
+}

--- a/timestamp/sockaddr_test.go
+++ b/timestamp/sockaddr_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timestamp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestSockaddrToAddrIPv4(t *testing.T) {
+	sa := &unix.SockaddrInet4{
+		Addr: [4]byte{192, 168, 1, 1},
+		Port: 123,
+	}
+	addr := SockaddrToAddr(sa)
+	require.True(t, addr.IsValid())
+	require.Equal(t, "192.168.1.1", addr.String())
+}
+
+func TestSockaddrToAddrIPv6(t *testing.T) {
+	sa := &unix.SockaddrInet6{
+		Addr: [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		Port: 319,
+	}
+	addr := SockaddrToAddr(sa)
+	require.True(t, addr.IsValid())
+	require.Equal(t, "2001:db8::1", addr.String())
+}
+
+func TestSockaddrToAddrNil(t *testing.T) {
+	addr := SockaddrToAddr(nil)
+	require.False(t, addr.IsValid())
+}
+
+func TestSockaddrToPortIPv4(t *testing.T) {
+	sa := &unix.SockaddrInet4{
+		Addr: [4]byte{10, 0, 0, 1},
+		Port: 319,
+	}
+	require.Equal(t, 319, SockaddrToPort(sa))
+}
+
+func TestSockaddrToPortIPv6(t *testing.T) {
+	sa := &unix.SockaddrInet6{
+		Addr: [16]byte{},
+		Port: 320,
+	}
+	require.Equal(t, 320, SockaddrToPort(sa))
+}
+
+func TestSockaddrToPortNil(t *testing.T) {
+	require.Equal(t, 0, SockaddrToPort(nil))
+}
+
+func TestNewSockaddrWithPortIPv4(t *testing.T) {
+	sa := &unix.SockaddrInet4{
+		Addr: [4]byte{10, 0, 0, 1},
+		Port: 123,
+	}
+	newSa := NewSockaddrWithPort(sa, 456)
+	require.NotNil(t, newSa)
+	sa4, ok := newSa.(*unix.SockaddrInet4)
+	require.True(t, ok)
+	require.Equal(t, 456, sa4.Port)
+	require.Equal(t, [4]byte{10, 0, 0, 1}, sa4.Addr)
+}
+
+func TestNewSockaddrWithPortIPv6(t *testing.T) {
+	sa := &unix.SockaddrInet6{
+		Addr: [16]byte{0x20, 0x01, 0x0d, 0xb8},
+		Port: 319,
+	}
+	newSa := NewSockaddrWithPort(sa, 320)
+	require.NotNil(t, newSa)
+	sa6, ok := newSa.(*unix.SockaddrInet6)
+	require.True(t, ok)
+	require.Equal(t, 320, sa6.Port)
+	require.Equal(t, [16]byte{0x20, 0x01, 0x0d, 0xb8}, sa6.Addr)
+}
+
+func TestNewSockaddrWithPortNil(t *testing.T) {
+	require.Nil(t, NewSockaddrWithPort(nil, 123))
+}


### PR DESCRIPTION
Summary:

Increase test coverage across the entire fbcode/time repo by adding ~130 new test functions covering previously untested code paths in fbclock, servo, clock, hostendian, ntp/chrony, ntp/control, ntp/responder/stats, ptp/linearizability, ptp/sptp/client, ptp/c4u/stats, timestamp, cmd/ntpcheck/cmd, cmd/ptpcheck/cmd, calnex/verify/checks, and ntrip.

Differential Revision: D105375612


