### PR TITLE
Fix clock tests for unsynced build environments (#523)

### DIFF
--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -51,16 +51,24 @@ func TestSetTimeNegative(t *testing.T) {
 }
 
 func TestFrequencyPPB(t *testing.T) {
+	tx := &unix.Timex{}
+	wantState, err := unix.Adjtimex(tx)
+	require.NoError(t, err)
+
 	freqPPB, state, err := FrequencyPPB(0)
 	require.NoError(t, err)
-	require.Equal(t, 0, state)
-	require.False(t, freqPPB != freqPPB) // not NaN
+	require.Equal(t, wantState, state)
+	require.Equal(t, float64(tx.Freq)/PPBToTimexPPM, freqPPB)
 }
 
 func TestMaxFreqPPB(t *testing.T) {
+	tx := &unix.Timex{}
+	wantState, err := unix.Adjtimex(tx)
+	require.NoError(t, err)
+
 	maxFreq, state, err := MaxFreqPPB(0)
 	require.NoError(t, err)
-	require.Equal(t, 0, state)
+	require.Equal(t, wantState, state)
 	require.Equal(t, 500000.0, maxFreq)
 }
 

--- a/fbclock/stats/stats_test.go
+++ b/fbclock/stats/stats_test.go
@@ -119,11 +119,13 @@ func TestConcurrentAccess(t *testing.T) {
 	s := NewStats()
 	var wg sync.WaitGroup
 	for i := range 100 {
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			s.SetCounter("concurrent", int64(i))
 			s.UpdateCounterBy("incr", 1)
 			s.Get()
-		})
+		}()
 	}
 	wg.Wait()
 	got := s.Get()


### PR DESCRIPTION
Summary:

Remove state==TIME_OK assertion from TestFrequencyPPB and TestMaxFreqPPB. Build containers don't run NTP/chrony so clock_adjtime returns TIME_ERROR (5), not TIME_OK (0). The state value is system-dependent and not part of the function contract being tested.

Differential Revision: D105576098


