### PR TITLE
Fix golangci-lint nilnil and revive signals (#526)

### DIFF
--- a/cmd/ntpcheck/cmd/utils.go
+++ b/cmd/ntpcheck/cmd/utils.go
@@ -115,7 +115,10 @@ func receiveNTPPacketWithRetries(connFd int, buf, oob []byte, tries int) (*ntp.P
 		return nil, clientReceiveTime, err
 	}
 	response, err := ntp.BytesToPacket(buf[:n])
-	return response, clientReceiveTime, err
+	if err != nil {
+		return nil, clientReceiveTime, err
+	}
+	return response, clientReceiveTime, nil
 }
 
 // ntpDate prints data similar to 'ntptime' command output

--- a/fbclock/daemon/config.go
+++ b/fbclock/daemon/config.go
@@ -97,5 +97,8 @@ func ReadConfig(path string) (*Config, error) {
 	}
 	c := Config{}
 	err = yaml.UnmarshalStrict(data, &c)
-	return &c, err
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
 }

--- a/ntp/control/packet.go
+++ b/ntp/control/packet.go
@@ -51,7 +51,7 @@ func NormalizeData(data []byte) (map[string]string, error) {
 		result[k] = v
 	}
 	if len(result) == 0 {
-		return result, fmt.Errorf("malformed packet, no k=v pairs decoded")
+		return nil, fmt.Errorf("malformed packet, no k=v pairs decoded")
 	}
 	return result, nil
 }
@@ -348,7 +348,7 @@ func (n NTPControlMsg) GetPeerStatus() (*PeerStatusWord, error) {
 func (n NTPControlMsg) GetAssociations() (map[uint16]*PeerStatusWord, error) {
 	result := map[uint16]*PeerStatusWord{}
 	if n.GetOperation() != OpReadStatus {
-		return result, fmt.Errorf("no peer list supported for operation=%d", n.GetOperation())
+		return nil, fmt.Errorf("no peer list supported for operation=%d", n.GetOperation())
 	}
 	for i := 0; i < int(n.Count/4); i++ {
 		assoc := n.Data[i*4 : i*4+4]                         // 2 uint16 encoded as 4 bytes
@@ -361,13 +361,12 @@ func (n NTPControlMsg) GetAssociations() (map[uint16]*PeerStatusWord, error) {
 
 // GetAssociationInfo returns parsed normalized variables if present
 func (n NTPControlMsg) GetAssociationInfo() (map[string]string, error) {
-	result := map[string]string{}
 	if n.GetOperation() != OpReadVariables {
-		return result, fmt.Errorf("no variables supported for operation=%d", n.GetOperation())
+		return nil, fmt.Errorf("no variables supported for operation=%d", n.GetOperation())
 	}
 	data, err := NormalizeData(n.Data)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	return data, nil
 }

--- a/phc/unix/types.go
+++ b/phc/unix/types.go
@@ -154,13 +154,13 @@ func Recvmsg(a int, b, c []byte, d int) (int, int, int, Sockaddr, error) {
 // Cross-platform constants from golang.org/x/sys/unix
 
 const (
-	AF_INET             = unix.AF_INET  //nolint:revive
-	EAGAIN              = unix.EAGAIN   //nolint:revive
-	EINVAL              = unix.EINVAL   //nolint:revive
-	ENOENT              = unix.ENOENT   //nolint:revive
-	ENOTSUP             = unix.ENOTSUP  //nolint:revive
-	IFNAMSIZ            = unix.IFNAMSIZ //nolint:revive
-	POLLERR             = unix.POLLERR  //nolint:revive
+	AF_INET             = unix.AF_INET //nolint:revive
+	EAGAIN              = unix.EAGAIN
+	EINVAL              = unix.EINVAL
+	ENOENT              = unix.ENOENT
+	ENOTSUP             = unix.ENOTSUP
+	IFNAMSIZ            = unix.IFNAMSIZ
+	POLLERR             = unix.POLLERR
 	POLLIN              = unix.POLLIN
 	POLLPRI             = unix.POLLPRI
 	SizeofPtr           = unix.SizeofPtr

--- a/ptp/ptp4u/server/server.go
+++ b/ptp/ptp4u/server/server.go
@@ -261,7 +261,7 @@ func readPacketBuf(connFd int, buf []byte) (int, unix.Sockaddr, error) {
 		return 0, nil, err
 	}
 
-	return n, saddr, err
+	return n, saddr, nil
 }
 
 func updateSockaddrWithPort(sa unix.Sockaddr, port int) {


### PR DESCRIPTION
Summary:

Fix lint issues triggered by the Go 1.25 bump (D105819402):
- nilnil: don't return both non-nil value and error
- revive: remove unnecessary //nolint:revive on ENOENT

Differential Revision: D105831114


