### PR TITLE
fix codecov uploads: bump action to v4, pass token, refresh badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,6 @@ jobs:
       - name: Run coverage
         run: sudo --preserve-env=PATH capsh --inh=cap_net_raw --print -- -c "go test -v -race -coverprofile=coverage.txt -covermode=atomic ./..."
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![lint](https://github.com/facebook/time/actions/workflows/lint.yml/badge.svg)](https://github.com/facebook/time/actions/workflows/lint.yml)
 [![test](https://github.com/facebook/time/actions/workflows/test.yml/badge.svg)](https://github.com/facebook/time/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/facebook/time/branch/main/graph/badge.svg?token=QC44PEpHRi)](https://codecov.io/gh/facebook/time)
+[![codecov](https://codecov.io/gh/facebook/time/branch/main/graph/badge.svg?token=vucpIU4aIq)](https://codecov.io/gh/facebook/time)
 [![Go Report Card](https://goreportcard.com/badge/github.com/facebook/time)](https://goreportcard.com/report/github.com/facebook/time)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/facebook/time)
 [![GoDoc](https://pkg.go.dev/badge/github.com/facebook/time?status.svg)](https://pkg.go.dev/github.com/facebook/time?tab=doc)


### PR DESCRIPTION
Codecov now requires a token for uploads, so the v3 tokenless setup was silently 429'ing since early May. Bumps codecov-action to v4 and passes CODECOV_TOKEN via env per Codecov's docs. Also refreshes the badge token in the README.