### PR TITLE
Add ntripper: bridge u-blox GNSS receivers to NTRIP casters

### DIFF
--- a/cmd/ntripper/main.go
+++ b/cmd/ntripper/main.go
@@ -14,26 +14,35 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// ntripper reads RTCM3 correction data from an oscillatord Unix socket and
-// pushes it to an NTRIP caster. It supports connecting through an HTTP
-// CONNECT proxy with TLS client certificate authentication.
+// ntripper reads RTCM3 and UBX-RXM-RAWX data from an oscillatord Unix socket
+// and pushes RTCM corrections to an NTRIP caster using the SOURCE protocol.
+// When RAWX observations are available, ntripper generates MSM7 messages with
+// proper carrier phase from raw observations, bypassing the receiver's limited
+// native RTCM engine.
 //
 // Usage:
 //
-//	ntripper -caster caster.example.com:2101 -mountpoint /MOUNT01 -password secret
-//	ntripper -caster caster.example.com:2101 -mountpoint /MOUNT01 -password secret \
+//	ntripper -caster caster.example.com:2101 -username MyMount -password secret
+//	ntripper -caster caster.example.com:2101 -username MyMount -password secret \
 //	         -proxy proxy.example.com:8082 -proxy-cert /path/to/cert.pem
 package main
 
 import (
+	"cmp"
 	"context"
+	"encoding/binary"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
+	"maps"
+	"math"
 	"net"
 	"os"
 	"os/signal"
+	"slices"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -43,6 +52,7 @@ import (
 )
 
 type config struct {
+	dumpW             io.Writer
 	socket            string
 	caster            string
 	mountpoint        string
@@ -52,10 +62,15 @@ type config struct {
 	proxy             string
 	proxyCert         string
 	proxyKey          string
+	logLevel          string
+	dump              string
+	parse             string
 	reconnectInterval time.Duration
 	monitoringPort    int
-	logLevel          string
+	ntripVersion      int
 	dryRun            bool
+	chunked           bool
+	rawxStats         bool
 }
 
 func main() {
@@ -70,8 +85,8 @@ func main() {
 	flag.StringVar(&cfg.password, "password", "",
 		"NTRIP SOURCE password")
 	flag.StringVar(&cfg.username, "username", "",
-		"NTRIP username (optional)")
-	flag.StringVar(&cfg.userAgent, "useragent", "NTRIP rtcm/1.0",
+		"NTRIP username (also used as mountpoint if -mountpoint not set)")
+	flag.StringVar(&cfg.userAgent, "useragent", "NTRIP ntripper/1.0",
 		"NTRIP source agent string")
 	flag.StringVar(&cfg.proxy, "proxy", "",
 		"HTTP CONNECT proxy address (host:port)")
@@ -87,10 +102,36 @@ func main() {
 		"log level (debug, info, warn, error)")
 	flag.BoolVar(&cfg.dryRun, "dry-run", false,
 		"read frames from socket and print to stdout instead of pushing to caster")
+	flag.StringVar(&cfg.dump, "dump", "",
+		"tee the exact outgoing RTCM stream sent to the caster into this file")
+	flag.StringVar(&cfg.parse, "parse", "",
+		"validate the RTCM3 framing of a captured dump file and exit")
+	flag.IntVar(&cfg.ntripVersion, "ntrip-version", 1,
+		"NTRIP protocol version: 1 (SOURCE) or 2 (HTTP POST)")
+	flag.BoolVar(&cfg.chunked, "chunked", true,
+		"NTRIP v2 only: send body using HTTP chunked transfer encoding")
+	flag.BoolVar(&cfg.rawxStats, "rawx-stats", false,
+		"read the socket and report the GNSS/signal breakdown of raw RAWX observations, then exit")
 	flag.Parse()
 
-	if !cfg.dryRun && (cfg.caster == "" || cfg.mountpoint == "" || cfg.password == "") {
-		fmt.Fprintln(os.Stderr, "required flags: -caster, -mountpoint, -password")
+	if cfg.parse != "" {
+		if err := parseStream(cfg.parse); err != nil {
+			fmt.Fprintln(os.Stderr, "parse error:", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if !cfg.dryRun && !cfg.rawxStats && (cfg.caster == "" || cfg.password == "") {
+		fmt.Fprintln(os.Stderr, "required flags: -caster, -password")
+		flag.Usage()
+		os.Exit(1)
+	}
+	if cfg.mountpoint == "" && cfg.username != "" {
+		cfg.mountpoint = cfg.username
+	}
+	if !cfg.dryRun && !cfg.rawxStats && cfg.mountpoint == "" {
+		fmt.Fprintln(os.Stderr, "required: -mountpoint or -username")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -99,6 +140,17 @@ func main() {
 	}
 
 	logger := setupLogger(cfg.logLevel)
+
+	if cfg.dump != "" {
+		f, err := os.Create(cfg.dump)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "cannot open dump file:", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		cfg.dumpW = f
+		logger.Info("dumping outgoing RTCM stream", "path", cfg.dump)
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
@@ -127,8 +179,12 @@ func setupLogger(level string) *slog.Logger {
 }
 
 func run(ctx context.Context, cfg config, logger *slog.Logger, st *stats.JSONStats) {
+	// The ephemeris collector persists across caster reconnects so it keeps
+	// accumulating navigation subframes; a full GPS ephemeris takes ~30s to
+	// assemble, longer than a single caster connection often lasts.
+	ephColl := rtcm.NewEphCollector()
 	for ctx.Err() == nil {
-		err := runOnce(ctx, cfg, logger, st)
+		err := runOnce(ctx, cfg, logger, st, ephColl)
 		if err == nil || ctx.Err() != nil {
 			return
 		}
@@ -151,19 +207,23 @@ func run(ctx context.Context, cfg config, logger *slog.Logger, st *stats.JSONSta
 	}
 }
 
-// runOnce connects to the socket and caster, then streams data until an error
-// occurs or the context is cancelled.
-func runOnce(ctx context.Context, cfg config, logger *slog.Logger, st *stats.JSONStats) error {
-	sockConn, err := connectSocket(ctx, cfg, logger)
-	if err != nil {
-		return fmt.Errorf("socket: %w", err)
-	}
-	defer sockConn.Close()
-
-	st.SetConnected(1)
-
+func runOnce(ctx context.Context, cfg config, logger *slog.Logger, st *stats.JSONStats, ephColl *rtcm.EphCollector) error {
 	if cfg.dryRun {
+		sockConn, err := connectSocket(ctx, cfg, logger)
+		if err != nil {
+			return fmt.Errorf("socket: %w", err)
+		}
+		defer sockConn.Close()
 		return printFrames(ctx, sockConn, logger, st)
+	}
+
+	if cfg.rawxStats {
+		sockConn, err := connectSocket(ctx, cfg, logger)
+		if err != nil {
+			return fmt.Errorf("socket: %w", err)
+		}
+		defer sockConn.Close()
+		return rawxStats(ctx, sockConn, logger)
 	}
 
 	client, err := connectCaster(ctx, cfg, logger)
@@ -172,7 +232,69 @@ func runOnce(ctx context.Context, cfg config, logger *slog.Logger, st *stats.JSO
 	}
 	defer client.Close()
 
-	return streamFrames(ctx, sockConn, client, logger, st)
+	st.SetConnected(1)
+	stationID := parseStationID(cfg.username)
+
+	// oscillatord closes the RTCM socket every ~5s.
+	// Keep caster alive and reconnect the socket seamlessly. The ephemeris
+	// collector is shared across caster reconnects (created in run).
+	for ctx.Err() == nil {
+		sockConn, err := connectSocket(ctx, cfg, logger)
+		if err != nil {
+			return fmt.Errorf("socket: %w", err)
+		}
+
+		err = streamFrames(ctx, sockConn, client, logger, st, stationID, ephColl)
+		sockConn.Close()
+
+		if err == nil || ctx.Err() != nil {
+			return err
+		}
+
+		// Write errors mean caster is dead — need full reconnect.
+		if isWriteError(err) {
+			return err
+		}
+
+		// Socket EOF — just reconnect socket immediately.
+		logger.Debug("socket EOF, reconnecting")
+	}
+	return ctx.Err()
+}
+
+// casterWriteError marks a failure writing to the caster (as opposed to reading
+// the local oscillatord socket). It signals runOnce to reestablish the caster
+// connection rather than just reopening the socket.
+type casterWriteError struct {
+	err  error
+	what string
+}
+
+func (e *casterWriteError) Error() string { return "writing " + e.what + ": " + e.err.Error() }
+
+func (e *casterWriteError) Unwrap() error { return e.err }
+
+// casterWrite wraps an error returned while writing to the caster.
+func casterWrite(what string, err error) error {
+	return &casterWriteError{what: what, err: err}
+}
+
+func isWriteError(err error) bool {
+	var e *casterWriteError
+	return errors.As(err, &e)
+}
+
+func parseStationID(username string) uint16 {
+	for i := len(username) - 1; i >= 0; i-- {
+		if username[i] < '0' || username[i] > '9' {
+			if i < len(username)-1 {
+				n, _ := strconv.Atoi(username[i+1:])
+				return uint16(n & 0xFFFF)
+			}
+			break
+		}
+	}
+	return 1
 }
 
 func connectSocket(ctx context.Context, cfg config, logger *slog.Logger) (net.Conn, error) {
@@ -196,10 +318,16 @@ func connectCaster(ctx context.Context, cfg config, logger *slog.Logger) (*ntrip
 		Password:   cfg.password,
 		Username:   cfg.username,
 		UserAgent:  cfg.userAgent,
+		Version:    cfg.ntripVersion,
+		Chunked:    cfg.chunked,
 	}
 
 	opts := []ntrip.Option{
 		ntrip.WithLogger(logger),
+	}
+
+	if cfg.dumpW != nil {
+		opts = append(opts, ntrip.WithDump(cfg.dumpW))
 	}
 
 	if cfg.proxy != "" {
@@ -223,25 +351,192 @@ func streamFrames(
 	client *ntrip.Client,
 	logger *slog.Logger,
 	st *stats.JSONStats,
+	stationID uint16,
+	ephColl *rtcm.EphCollector,
 ) error {
-	scanner := rtcm.NewScanner(sockConn)
+	scanner := rtcm.NewMixedScanner(sockConn)
 	var frameCount uint64
+	var rawxCount uint64
+
+	// Inject RTCM 1033 on connect and every 30s.
+	msg1033 := rtcm.Encode1033(rtcm.AntennaDescriptor{
+		StationID:      stationID,
+		AntennaType:    "ADVNULLANTENNA",
+		AntennaSetupID: 0,
+		ReceiverType:   "u-blox F9T",
+		ReceiverFW:     "2.20",
+	})
+	if _, err := client.Write(msg1033); err != nil {
+		return casterWrite("initial 1033", err)
+	}
+	logger.Info("injected RTCM 1033", "bytes", len(msg1033))
+
+	// Send any ephemeris already collected so a freshly (re)connected caster
+	// has satellite positions immediately, without waiting ~30s to reassemble.
+	for _, eph := range ephColl.All() {
+		if _, err := client.Write(eph); err != nil {
+			return casterWrite("cached ephemeris", err)
+		}
+		frameCount++
+	}
+	lastMsg1033 := time.Now()
 
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		frame := scanner.Frame()
-		st.IncFramesReceived()
+		switch scanner.Type() {
+		case rtcm.MsgUBX:
+			if scanner.UBXClass() != rtcm.UBXClassRXM {
+				continue
+			}
+			// UBX-RXM-SFRBX: decode navigation subframes into RTCM 1019
+			// (GPS ephemeris) so the caster can position the satellites.
+			if scanner.UBXMsgID() == rtcm.UBXMsgSFRBX {
+				if eph := ephColl.AddSFRBX(scanner.UBXPayload()); eph != nil {
+					if _, err := client.Write(eph); err != nil {
+						return casterWrite("ephemeris", err)
+					}
+					frameCount++
+					logger.Info("sent GPS ephemeris (1019)", "bytes", len(eph))
+				}
+				continue
+			}
+			if scanner.UBXMsgID() != rtcm.UBXMsgRAWX {
+				continue
+			}
 
-		if _, err := client.Write(frame.Raw); err != nil {
-			return fmt.Errorf("writing to caster: %w", err)
+			epoch, err := rtcm.ParseRawx(scanner.UBXPayload())
+			if err != nil {
+				logger.Warn("RAWX parse error", "error", err)
+				continue
+			}
+
+			rawxCount++
+			gpsTowMs := uint32(math.Mod(epoch.RcvTow*1000.0, 604800000.0))
+
+			if rawxCount <= 5 || rawxCount%60 == 0 {
+				logger.Info("RAWX epoch",
+					"rawx_count", rawxCount,
+					"obs", len(epoch.Observations),
+					"gpsTowMs", gpsTowMs,
+					"frames_sent", frameCount,
+					"age_s", time.Now().Unix()-(int64(315964800)+int64(epoch.Week)*604800-int64(epoch.LeapS)+int64(gpsTowMs/1000)),
+				)
+			}
+
+			// Per-constellation MSM epoch time (30-bit DF004-style field):
+			//   GPS/Galileo: GPS time of week (ms).
+			//   BeiDou: BeiDou time = GPS time - 14 s.
+			//   GLONASS: 3-bit day-of-week | 27-bit ms-of-day in GLONASS time
+			//            (UTC + 3 h); GLONASS time = GPS time - leap seconds + 3 h.
+			bdsEpoch := (gpsTowMs + 604800000 - 14000) % 604800000
+			utcMs := (gpsTowMs + 604800000 - uint32(epoch.LeapS&0x7F)*1000) % 604800000
+			gloMs := (utcMs + 3*3600*1000) % 604800000
+			gloEpoch := (gloMs/86400000)<<27 | (gloMs % 86400000)
+
+			// Generate MSM7 for all constellations the F9T provides (L1). Collect
+			// first so the MSM multiple-message bit (DF393) can be set on all but
+			// the last message of the epoch, as the MSM spec requires.
+			gens := []struct {
+				gnss    uint8
+				epochMs uint32
+			}{
+				{rtcm.GnssGPS, gpsTowMs},
+				{rtcm.GnssGalileo, gpsTowMs},
+				{rtcm.GnssGLONASS, gloEpoch},
+				{rtcm.GnssBeiDou, bdsEpoch},
+			}
+			var msmFrames [][]byte
+			for _, g := range gens {
+				frame, err := rtcm.EncodeMSM7(stationID, g.gnss, g.epochMs, epoch.Observations)
+				if err != nil {
+					logger.Warn("MSM7 encode error", "gnss", g.gnss, "error", err)
+					continue
+				}
+				if frame == nil {
+					continue
+				}
+				// Validate frame before sending.
+				if frame[0] != rtcm.Preamble {
+					logger.Error("BAD FRAME: wrong preamble", "gnss", g.gnss, "byte0", frame[0])
+					continue
+				}
+				pl := int(frame[1]&0x03)<<8 | int(frame[2])
+				if pl+6 != len(frame) {
+					logger.Error("BAD FRAME: length mismatch", "gnss", g.gnss, "header_len", pl, "frame_len", len(frame))
+					continue
+				}
+				msmFrames = append(msmFrames, frame)
+			}
+
+			// Mark every MSM message except the last in this epoch with the
+			// multiple-message bit, then recompute CRC.
+			for i := range len(msmFrames) - 1 {
+				setMSMMultipleBit(msmFrames[i])
+			}
+
+			for _, frame := range msmFrames {
+				crc := rtcm.CRC24Q(frame[:len(frame)-rtcm.CRCSize])
+				stored := uint32(frame[len(frame)-3])<<16 | uint32(frame[len(frame)-2])<<8 | uint32(frame[len(frame)-1])
+				if crc != stored {
+					logger.Error("BAD FRAME: CRC mismatch", "computed", crc, "stored", stored)
+					continue
+				}
+				if _, err := client.Write(frame); err != nil {
+					return casterWrite("MSM7", err)
+				}
+				frameCount++
+			}
+
+		case rtcm.MsgRTCM3:
+			frame := scanner.Frame()
+			st.IncFramesReceived()
+
+			// Drop native MSM — replaced by RAWX-generated MSM7.
+			if frame.MessageType >= 1071 && frame.MessageType <= 1137 {
+				continue
+			}
+
+			// Forward 1005 (station position) and 1230 (GLONASS bias).
+			raw := frame.Raw
+			if frame.MessageType == 1005 && len(raw) >= 8 {
+				raw = rtcm.Patch1005RefStation(raw)
+			}
+			raw = rtcm.PatchStationID(raw, stationID)
+
+			// Validate patched frame before sending.
+			pl := int(raw[1]&0x03)<<8 | int(raw[2])
+			if pl+6 != len(raw) {
+				logger.Error("BAD NATIVE FRAME: length mismatch", "type", frame.MessageType, "header_len", pl, "frame_len", len(raw))
+				continue
+			}
+			crc := rtcm.CRC24Q(raw[:3+pl])
+			stored := uint32(raw[len(raw)-3])<<16 | uint32(raw[len(raw)-2])<<8 | uint32(raw[len(raw)-1])
+			if crc != stored {
+				logger.Error("BAD NATIVE FRAME: CRC mismatch", "type", frame.MessageType)
+				continue
+			}
+
+			if _, err := client.Write(raw); err != nil {
+				return casterWrite("RTCM", err)
+			}
+			frameCount++
 		}
 
-		frameCount++
-		if frameCount%100 == 0 {
-			logger.Debug("frames forwarded", "count", frameCount)
+		// Inject 1033 and re-send ephemeris periodically.
+		if time.Since(lastMsg1033) >= 30*time.Second {
+			if _, err := client.Write(msg1033); err != nil {
+				return casterWrite("1033", err)
+			}
+			for _, eph := range ephColl.All() {
+				if _, err := client.Write(eph); err != nil {
+					return casterWrite("ephemeris", err)
+				}
+				frameCount++
+			}
+			lastMsg1033 = time.Now()
 		}
 	}
 
@@ -254,7 +549,7 @@ func streamFrames(
 
 func printFrames(ctx context.Context, sockConn net.Conn, logger *slog.Logger, st *stats.JSONStats) error {
 	logger.Info("dry-run mode: printing frames to stdout")
-	scanner := rtcm.NewScanner(sockConn)
+	scanner := rtcm.NewMixedScanner(sockConn)
 	var frameCount uint64
 
 	for scanner.Scan() {
@@ -262,17 +557,129 @@ func printFrames(ctx context.Context, sockConn net.Conn, logger *slog.Logger, st
 			return err
 		}
 
-		frame := scanner.Frame()
-		frameCount++
-		st.IncFramesReceived()
-
-		fmt.Printf("frame=%d type=%d len=%d\n", frameCount, frame.MessageType, len(frame.Raw))
+		switch scanner.Type() {
+		case rtcm.MsgUBX:
+			if scanner.UBXClass() == rtcm.UBXClassRXM && scanner.UBXMsgID() == rtcm.UBXMsgRAWX {
+				epoch, err := rtcm.ParseRawx(scanner.UBXPayload())
+				if err != nil {
+					fmt.Printf("RAWX parse error: %v\n", err)
+					continue
+				}
+				fmt.Printf("RAWX: obs=%d tow=%.3f week=%d\n",
+					len(epoch.Observations), epoch.RcvTow, epoch.Week)
+			}
+		case rtcm.MsgRTCM3:
+			frame := scanner.Frame()
+			frameCount++
+			st.IncFramesReceived()
+			fmt.Printf("frame=%d type=%d len=%d\n", frameCount, frame.MessageType, len(frame.Raw))
+		}
 	}
 
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("reading from socket: %w", err)
 	}
 	return fmt.Errorf("socket closed (EOF)")
+}
+
+// rawxStats reads UBX-RXM-RAWX messages from the socket and reports, per
+// GNSS and signal ID, how many measurements are present and how many are
+// usable (valid, nonzero pseudorange and CNR). It is a diagnostic for checking
+// which signals (e.g. L1 vs L2) the receiver is actually tracking.
+func rawxStats(ctx context.Context, sockConn net.Conn, logger *slog.Logger) error {
+	logger.Info("rawx-stats: sampling RAWX signals from socket")
+	scanner := rtcm.NewMixedScanner(sockConn)
+
+	gnssName := map[uint8]string{0: "GPS", 1: "SBAS", 2: "GAL", 3: "BDS", 5: "QZSS", 6: "GLO"}
+	type key struct {
+		gnss uint8
+		sig  uint8
+	}
+	total := map[key]int{}
+	usable := map[key]int{}
+	epochs := 0
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		if scanner.Type() != rtcm.MsgUBX ||
+			scanner.UBXClass() != rtcm.UBXClassRXM || scanner.UBXMsgID() != rtcm.UBXMsgRAWX {
+			continue
+		}
+		p := scanner.UBXPayload()
+		if len(p) < 16 {
+			continue
+		}
+		numMeas := int(p[11])
+		if len(p) < 16+numMeas*32 {
+			continue
+		}
+		for i := range numMeas {
+			off := 16 + i*32
+			prMes := math.Float64frombits(binary.LittleEndian.Uint64(p[off : off+8]))
+			gnss := p[off+20]
+			sig := p[off+22]
+			cno := p[off+26]
+			prValid := p[off+30]&0x01 != 0
+			k := key{gnss, sig}
+			total[k]++
+			if prValid && prMes > 0 && cno > 0 {
+				usable[k]++
+			}
+		}
+		epochs++
+		if epochs >= 5 {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading from socket: %w", err)
+	}
+
+	fmt.Printf("\n=== RAWX signal breakdown over %d epoch(s) ===\n", epochs)
+	fmt.Printf("%-6s %-4s %-8s %-8s\n", "GNSS", "sig", "total", "usable")
+	seen := map[key]bool{}
+	for k := range total {
+		seen[k] = true
+	}
+	for k := range usable {
+		seen[k] = true
+	}
+	keys := slices.SortedFunc(maps.Keys(seen), func(a, b key) int {
+		if a.gnss != b.gnss {
+			return cmp.Compare(a.gnss, b.gnss)
+		}
+		return cmp.Compare(a.sig, b.sig)
+	})
+	for _, k := range keys {
+		name := gnssName[k.gnss]
+		if name == "" {
+			name = fmt.Sprintf("g%d", k.gnss)
+		}
+		fmt.Printf("%-6s %-4d %-8d %-8d\n", name, k.sig, total[k], usable[k])
+	}
+	fmt.Printf("\nReminder: GPS sig 0=L1C/A, 3=L2CL, 4=L2CM; GAL sig 0=E1C, 1=E1B, 5=E5bI, 6=E5bQ.\n")
+	fmt.Printf("If only sig 0 appears per constellation, the receiver is L1-only and L2 must be enabled in the F9T config.\n")
+	return nil
+}
+
+// setMSMMultipleBit sets the MSM multiple-message bit (DF393) in an encoded MSM
+// frame and recomputes the CRC. DF393 is payload bit 54 (right after the 12-bit
+// message number, 12-bit station ID, and 30-bit epoch). It must be set on every
+// MSM message of an epoch except the last, so a caster groups them into one
+// epoch instead of treating each as a separate, conflicting epoch.
+func setMSMMultipleBit(frame []byte) {
+	pl := int(frame[1]&0x03)<<8 | int(frame[2])
+	if len(frame) < rtcm.HeaderSize+pl+rtcm.CRCSize {
+		return
+	}
+	// Payload bit 54 → byte 6 of payload, bit 1 from MSB.
+	frame[rtcm.HeaderSize+6] |= 1 << 1
+	crc := rtcm.CRC24Q(frame[:rtcm.HeaderSize+pl])
+	frame[len(frame)-3] = byte((crc >> 16) & 0xFF)
+	frame[len(frame)-2] = byte((crc >> 8) & 0xFF)
+	frame[len(frame)-1] = byte(crc & 0xFF)
 }
 
 func sleep(ctx context.Context, d time.Duration) bool {
@@ -284,4 +691,61 @@ func sleep(ctx context.Context, d time.Duration) bool {
 	case <-ctx.Done():
 		return false
 	}
+}
+
+// parseStream walks a captured outgoing dump and reports whether it is a clean
+// sequence of valid RTCM3 frames. Any byte that is not part of a CRC-valid
+// frame is counted as a gap, which indicates stream corruption (a framing bug).
+// Zero gap bytes means our framing is correct and a caster's "not in RTCM3
+// format" rejection is a protocol/transport problem, not a framing one.
+func parseStream(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("parsing %d bytes from %s\n", len(data), path)
+
+	pos := 0
+	frames := 0
+	gapBytes := 0
+	tailBytes := 0
+	typeCounts := map[uint16]int{}
+
+	for pos < len(data) {
+		if data[pos] != rtcm.Preamble {
+			gapBytes++
+			pos++
+			continue
+		}
+		frame, err := rtcm.ParseFrame(data[pos:])
+		if err != nil {
+			// A 0xD3 that does not start a complete CRC-valid frame. If the
+			// remaining bytes are too few, it is just a truncated tail.
+			if errors.Is(err, rtcm.ErrFrameTooShort) {
+				tailBytes = len(data) - pos
+				break
+			}
+			gapBytes++
+			pos++
+			continue
+		}
+		frames++
+		typeCounts[frame.MessageType]++
+		pos += len(frame.Raw)
+	}
+
+	fmt.Printf("valid frames=%d gap_bytes=%d tail_bytes=%d\n", frames, gapBytes, tailBytes)
+	for t, c := range typeCounts {
+		fmt.Printf("  type %d: %d frames\n", t, c)
+	}
+	switch {
+	case gapBytes > 0:
+		fmt.Printf("RESULT: FRAMING BUG — %d bytes are not part of any valid RTCM3 frame\n", gapBytes)
+	case frames == 0:
+		fmt.Printf("RESULT: no RTCM3 frames found\n")
+	default:
+		fmt.Printf("RESULT: CLEAN — every byte belongs to a valid RTCM3 frame; " +
+			"a caster rejection is protocol/transport, not framing\n")
+	}
+	return nil
 }

--- a/cmd/ntripper/main_test.go
+++ b/cmd/ntripper/main_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/facebook/time/rtcm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStationID(t *testing.T) {
+	tests := map[string]uint16{
+		"MOUNT01":             1,  // trailing "01" -> 1
+		"STATION42":           42, // trailing digits
+		"REF000":              0,  // trailing "000" -> 0
+		"NoDigitsHere":        1,  // no trailing digits -> default
+		"":                    1,  // empty -> default
+		"4095":                1,  // all digits, no non-digit prefix -> default
+		"CleanlyEvidentIbex1": 1,  // trailing "1"
+	}
+	for in, want := range tests {
+		require.Equalf(t, want, parseStationID(in), "parseStationID(%q)", in)
+	}
+}
+
+func TestIsWriteError(t *testing.T) {
+	require.True(t, isWriteError(casterWrite("MSM7", errors.New("broken pipe"))))
+	// Still detected when wrapped further upstream.
+	require.True(t, isWriteError(fmt.Errorf("runOnce: %w", casterWrite("1033", os.ErrClosed))))
+	require.False(t, isWriteError(errors.New("socket closed (EOF)")))
+	require.False(t, isWriteError(fmt.Errorf("reading from socket: %w", os.ErrDeadlineExceeded)))
+}
+
+func TestSetMSMMultipleBit(t *testing.T) {
+	obs := []rtcm.RawxObservation{
+		{PrMes: 20000000, CpMes: 105000000, DoMes: -100, GnssID: rtcm.GnssGPS, SvID: 5, SigID: 0, CNO: 45, PrValid: true, CpValid: true},
+	}
+	frame, err := rtcm.EncodeMSM7(1, rtcm.GnssGPS, 100000, obs)
+	require.NoError(t, err)
+
+	// DF393 (multiple message bit) is payload bit 54; the encoder leaves it 0.
+	require.Equal(t, uint32(0), multipleBit(frame))
+
+	setMSMMultipleBit(frame)
+	require.Equal(t, uint32(1), multipleBit(frame), "multiple-message bit set")
+
+	// CRC must be recomputed and valid.
+	pl := int(frame[1]&0x03)<<8 | int(frame[2])
+	stored := uint32(frame[len(frame)-3])<<16 | uint32(frame[len(frame)-2])<<8 | uint32(frame[len(frame)-1])
+	require.Equal(t, rtcm.CRC24Q(frame[:rtcm.HeaderSize+pl]), stored)
+}
+
+// multipleBit reads DF393 (payload bit 54: after msgnum(12)+staid(12)+epoch(30)).
+func multipleBit(frame []byte) uint32 {
+	r := rtcm.NewBitReader(frame[rtcm.HeaderSize:])
+	r.Skip(54)
+	return r.ReadBits(1)
+}
+
+func TestSetMSMMultipleBitShortFrameNoPanic(t *testing.T) {
+	require.NotPanics(t, func() { setMSMMultipleBit([]byte{0xD3, 0x00, 0x05}) })
+}
+
+func TestSetupLogger(t *testing.T) {
+	for _, lvl := range []string{"debug", "info", "warn", "error", "unknown"} {
+		require.NotNil(t, setupLogger(lvl), "level %q", lvl)
+	}
+}
+
+func TestParseStreamCleanFile(t *testing.T) {
+	// A file of back-to-back valid RTCM3 frames parses without error.
+	a := rtcm.Encode1033(rtcm.AntennaDescriptor{StationID: 1, AntennaType: "A"})
+	b := rtcm.Encode1033(rtcm.AntennaDescriptor{StationID: 2, AntennaType: "BB"})
+	path := filepath.Join(t.TempDir(), "stream.rtcm3")
+	require.NoError(t, os.WriteFile(path, append(append([]byte{}, a...), b...), 0o644))
+	require.NoError(t, parseStream(path))
+}
+
+func TestParseStreamMissingFile(t *testing.T) {
+	require.Error(t, parseStream(filepath.Join(t.TempDir(), "does-not-exist")))
+}

--- a/ntrip/client.go
+++ b/ntrip/client.go
@@ -15,22 +15,25 @@ limitations under the License.
 */
 
 // Package ntrip provides an NTRIP client for pushing RTCM correction data
-// to an NTRIP caster. It implements the NTRIP v1 SOURCE protocol and
-// supports connecting through an HTTP CONNECT proxy with TLS client
-// certificate authentication.
+// to an NTRIP caster. It implements both the NTRIP v1 SOURCE protocol and the
+// NTRIP v2 (HTTP POST) protocol, and supports connecting through an HTTP
+// CONNECT proxy with TLS client certificate authentication.
 package ntrip
 
 import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"strings"
+	"time"
 )
 
-const defaultUserAgent = "NTRIP rtcm/1.0"
+const defaultUserAgent = "NTRIP ntripper/1.0"
 
 // Config holds the NTRIP caster connection parameters.
 type Config struct {
@@ -38,13 +41,19 @@ type Config struct {
 	Caster string
 	// Mountpoint is the caster mountpoint (e.g., "/MOUNT01").
 	Mountpoint string
-	// Password is the NTRIP v1 SOURCE password.
+	// Password is the NTRIP SOURCE / Basic auth password.
 	Password string
-	// Username is an optional username for identification.
+	// Username is the NTRIP username (used for v2 Basic auth).
 	Username string
 	// UserAgent is the source agent string sent to the caster.
-	// Defaults to "NTRIP rtcm/1.0" if empty.
+	// Defaults to "NTRIP ntripper/1.0" if empty.
 	UserAgent string
+	// Version selects the NTRIP protocol version: 1 (SOURCE) or 2 (HTTP POST).
+	// Defaults to 1 if zero.
+	Version int
+	// Chunked, when true (NTRIP v2 only), sends the body using HTTP chunked
+	// transfer encoding, as required by the NTRIP 2.0 NtripServer standard.
+	Chunked bool
 }
 
 // ProxyConfig holds the HTTP CONNECT proxy parameters.
@@ -74,13 +83,21 @@ func WithLogger(logger *slog.Logger) Option {
 	}
 }
 
+// WithDump tees every byte sent to the caster into w, for offline inspection
+// of the exact RTCM stream the caster receives.
+func WithDump(w io.Writer) Option {
+	return func(c *Client) {
+		c.dump = w
+	}
+}
+
 // Client is an NTRIP v1 SOURCE client that pushes RTCM data to a caster.
-// It implements io.WriteCloser.
 type Client struct {
-	config Config
 	proxy  *ProxyConfig
 	logger *slog.Logger
 	conn   net.Conn
+	dump   io.Writer
+	config Config
 }
 
 // NewClient creates a new NTRIP client with the given configuration.
@@ -100,33 +117,69 @@ func NewClient(cfg Config, opts ...Option) *Client {
 
 // Connect establishes a connection to the NTRIP caster. If a proxy is
 // configured, it first establishes an HTTP CONNECT tunnel through the proxy
-// with TLS client certificate authentication. Then it performs the NTRIP v1
-// SOURCE handshake.
+// with TLS client certificate authentication. Then it performs the NTRIP
+// handshake (v1 SOURCE or v2 HTTP POST) and waits for the caster's
+// acceptance response before allowing data writes.
 func (c *Client) Connect(ctx context.Context) error {
 	conn, err := c.dial(ctx)
 	if err != nil {
 		return fmt.Errorf("dialing caster: %w", err)
 	}
 
-	if err := c.sourceHandshake(conn); err != nil {
+	if c.config.Version == 2 {
+		err = c.postHandshake(conn)
+	} else {
+		err = c.sourceHandshake(conn)
+	}
+	if err != nil {
 		conn.Close()
-		return fmt.Errorf("NTRIP SOURCE handshake: %w", err)
+		return fmt.Errorf("NTRIP handshake: %w", err)
+	}
+
+	// Wait for caster response before allowing data writes.
+	// v1 casters reply "ICY 200 OK", v2 casters reply "HTTP/1.1 200 OK".
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		conn.Close()
+		return fmt.Errorf("setting read deadline: %w", err)
+	}
+	// TCP may split the response across segments, so read the full status line
+	// rather than relying on whatever a single Read happens to return.
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("reading caster response: %w", err)
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		conn.Close()
+		return fmt.Errorf("clearing read deadline: %w", err)
+	}
+	resp := strings.TrimSpace(statusLine)
+	c.logger.Info("received from caster", "data", resp)
+	if !strings.Contains(resp, "200") {
+		conn.Close()
+		return fmt.Errorf("caster rejected: %s", resp)
 	}
 
 	c.conn = conn
-	c.logger.Info("connected to NTRIP caster",
-		"caster", c.config.Caster,
-		"mountpoint", c.config.Mountpoint,
-	)
-	return nil
-}
 
-// Write sends RTCM data to the caster. The client must be connected.
-func (c *Client) Write(p []byte) (int, error) {
-	if c.conn == nil {
-		return 0, fmt.Errorf("not connected")
-	}
-	return c.conn.Write(p)
+	// Drain any further responses from the caster in the background, reusing the
+	// reader so bytes buffered past the status line are not lost.
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := reader.Read(buf)
+			if n > 0 {
+				c.logger.Info("received from caster", "data", string(buf[:n]))
+			}
+			if err != nil {
+				c.logger.Debug("caster read closed", "error", err)
+				return
+			}
+		}
+	}()
+
+	return nil
 }
 
 // Close closes the connection to the caster.
@@ -139,17 +192,40 @@ func (c *Client) Close() error {
 	return err
 }
 
+// Write sends raw RTCM data to the caster. In NTRIP v2 chunked mode each call
+// is wrapped in a single HTTP chunk. The dump (if any) always receives the raw
+// RTCM bytes, not the chunk framing, so captures remain valid RTCM3 streams.
+func (c *Client) Write(p []byte) (int, error) {
+	if c.conn == nil {
+		return 0, fmt.Errorf("not connected")
+	}
+	if c.dump != nil {
+		_, _ = c.dump.Write(p)
+	}
+	if c.config.Version == 2 && c.config.Chunked {
+		buf := make([]byte, 0, len(p)+16)
+		buf = append(buf, fmt.Sprintf("%X\r\n", len(p))...)
+		buf = append(buf, p...)
+		buf = append(buf, '\r', '\n')
+		if _, err := c.conn.Write(buf); err != nil {
+			return 0, err
+		}
+		return len(p), nil
+	}
+	return c.conn.Write(p)
+}
+
 // dial establishes a TCP connection to the caster, optionally through a proxy.
 func (c *Client) dial(ctx context.Context) (net.Conn, error) {
 	if c.proxy != nil {
 		return c.dialViaProxy(ctx)
 	}
-	var d net.Dialer
+	d := net.Dialer{KeepAlive: 30 * time.Second}
 	return d.DialContext(ctx, "tcp", c.config.Caster)
 }
 
 // dialViaProxy establishes a connection through an HTTP CONNECT proxy with
-// TLS client certificate authentication.
+// TLS client certificate authentication, creating a raw TCP tunnel.
 func (c *Client) dialViaProxy(ctx context.Context) (net.Conn, error) {
 	cert, err := tls.LoadX509KeyPair(c.proxy.CertFile, c.proxy.KeyFile)
 	if err != nil {
@@ -166,7 +242,7 @@ func (c *Client) dialViaProxy(ctx context.Context) (net.Conn, error) {
 		ServerName:   host,
 	}
 
-	var d net.Dialer
+	d := net.Dialer{KeepAlive: 30 * time.Second}
 	rawConn, err := d.DialContext(ctx, "tcp", c.proxy.Address)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to proxy: %w", err)
@@ -178,7 +254,6 @@ func (c *Client) dialViaProxy(ctx context.Context) (net.Conn, error) {
 		return nil, fmt.Errorf("proxy TLS handshake: %w", err)
 	}
 
-	// Send HTTP CONNECT request.
 	connectReq := fmt.Sprintf(
 		"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n",
 		c.config.Caster, c.config.Caster,
@@ -188,7 +263,6 @@ func (c *Client) dialViaProxy(ctx context.Context) (net.Conn, error) {
 		return nil, fmt.Errorf("sending CONNECT request: %w", err)
 	}
 
-	// Read proxy response.
 	reader := bufio.NewReader(tlsConn)
 	line, err := reader.ReadString('\n')
 	if err != nil {
@@ -200,7 +274,6 @@ func (c *Client) dialViaProxy(ctx context.Context) (net.Conn, error) {
 		return nil, fmt.Errorf("proxy CONNECT failed: %s", strings.TrimSpace(line))
 	}
 
-	// Consume remaining response headers.
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -214,59 +287,13 @@ func (c *Client) dialViaProxy(ctx context.Context) (net.Conn, error) {
 
 	c.logger.Debug("proxy tunnel established", "proxy", c.proxy.Address)
 
-	// Return a connection that reads from the buffered reader (which may
-	// have consumed bytes beyond the CONNECT response) and writes directly.
 	return &bufferedConn{
 		reader: reader,
 		Conn:   tlsConn,
 	}, nil
 }
 
-// sourceHandshake performs the NTRIP v1 SOURCE handshake.
-// Protocol:
-//
-//	Client sends:  SOURCE <password> <mountpoint>\r\n
-//	               Source-Agent: <useragent>\r\n
-//	               \r\n
-//	Server sends:  ICY 200 OK\r\n
-//	               \r\n
-func (c *Client) sourceHandshake(conn net.Conn) error {
-	req := fmt.Sprintf(
-		"SOURCE %s %s\r\nSource-Agent: %s\r\n\r\n",
-		c.config.Password, c.config.Mountpoint, c.config.UserAgent,
-	)
-	if _, err := conn.Write([]byte(req)); err != nil {
-		return fmt.Errorf("sending SOURCE request: %w", err)
-	}
-
-	reader := bufio.NewReader(conn)
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("reading caster response: %w", err)
-	}
-
-	line = strings.TrimSpace(line)
-	if !strings.HasPrefix(line, "ICY 200") {
-		return fmt.Errorf("caster rejected connection: %s", line)
-	}
-
-	// Consume remaining response headers until empty line.
-	for {
-		hdr, err := reader.ReadString('\n')
-		if err != nil {
-			return fmt.Errorf("reading caster response headers: %w", err)
-		}
-		if strings.TrimSpace(hdr) == "" {
-			break
-		}
-	}
-
-	return nil
-}
-
 // bufferedConn wraps a net.Conn to use a bufio.Reader for reads.
-// This is needed after proxy CONNECT because the bufio.Reader may have
-// buffered data beyond the HTTP response that we need to read.
 type bufferedConn struct {
 	reader *bufio.Reader
 	net.Conn
@@ -274,4 +301,61 @@ type bufferedConn struct {
 
 func (c *bufferedConn) Read(p []byte) (int, error) {
 	return c.reader.Read(p)
+}
+
+// sourceHandshake sends the NTRIP v1 SOURCE request and streams raw RTCM
+// data after the headers. The request uses a bare mountpoint (no leading
+// slash) plus a STR line, matching the de-facto format produced by RTKLIB's
+// str2str that NTRIP casters accept.
+func (c *Client) sourceHandshake(conn net.Conn) error {
+	mount := strings.TrimPrefix(c.config.Mountpoint, "/")
+	req := fmt.Sprintf(
+		"SOURCE %s %s\r\nSource-Agent: %s\r\nSTR: \r\n\r\n",
+		c.config.Password, mount, c.config.UserAgent,
+	)
+
+	c.logger.Info("sending SOURCE request",
+		"caster", c.config.Caster,
+		"mountpoint", mount,
+	)
+	if _, err := conn.Write([]byte(req)); err != nil {
+		return fmt.Errorf("sending SOURCE request: %w", err)
+	}
+
+	return nil
+}
+
+// postHandshake sends the NTRIP v2 (HTTP POST) server request. The caster keeps
+// the connection open and ingests the request body as an RTCM stream. Some
+// casters that advertise "Ntrip-Version: Ntrip/2.0" require this and do not
+// enter stream-ingestion mode for a bare v1 SOURCE request.
+func (c *Client) postHandshake(conn net.Conn) error {
+	mount := strings.TrimPrefix(c.config.Mountpoint, "/")
+	auth := base64.StdEncoding.EncodeToString(
+		[]byte(c.config.Username + ":" + c.config.Password),
+	)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "POST /%s HTTP/1.1\r\n", mount)
+	fmt.Fprintf(&b, "Host: %s\r\n", c.config.Caster)
+	fmt.Fprintf(&b, "Ntrip-Version: Ntrip/2.0\r\n")
+	fmt.Fprintf(&b, "User-Agent: %s\r\n", c.config.UserAgent)
+	fmt.Fprintf(&b, "Authorization: Basic %s\r\n", auth)
+	// A streaming source keeps the connection open; do not announce close.
+	fmt.Fprintf(&b, "Connection: keep-alive\r\n")
+	if c.config.Chunked {
+		fmt.Fprintf(&b, "Transfer-Encoding: chunked\r\n")
+	}
+	fmt.Fprintf(&b, "\r\n")
+
+	c.logger.Info("sending NTRIP v2 POST request",
+		"caster", c.config.Caster,
+		"mountpoint", mount,
+		"chunked", c.config.Chunked,
+	)
+	if _, err := conn.Write([]byte(b.String())); err != nil {
+		return fmt.Errorf("sending POST request: %w", err)
+	}
+
+	return nil
 }

--- a/ntrip/client_test.go
+++ b/ntrip/client_test.go
@@ -18,15 +18,13 @@ package ntrip
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	"fmt"
+	"encoding/base64"
 	"io"
 	"log/slog"
 	"net"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,10 +37,10 @@ func TestSourceHandshakeSuccess(t *testing.T) {
 		Caster:     "caster.example.com:2101",
 		Mountpoint: "/MOUNT01",
 		Password:   "secret",
-		UserAgent:  "TestAgent/1.0",
+		Username:   "user1",
+		UserAgent:  "NTRIP TestAgent/1.0",
 	})
 
-	// Run handshake in a goroutine.
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- ntripClient.sourceHandshake(client)
@@ -52,60 +50,61 @@ func TestSourceHandshakeSuccess(t *testing.T) {
 	reader := bufio.NewReader(server)
 	line, err := reader.ReadString('\n')
 	require.NoError(t, err)
-	require.Equal(t, "SOURCE secret /MOUNT01\r\n", line)
+	require.Equal(t, "SOURCE secret MOUNT01\r\n", line)
 
 	line, err = reader.ReadString('\n')
 	require.NoError(t, err)
-	require.Equal(t, "Source-Agent: TestAgent/1.0\r\n", line)
+	require.Equal(t, "Source-Agent: NTRIP TestAgent/1.0\r\n", line)
+
+	line, err = reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "STR: \r\n", line)
 
 	line, err = reader.ReadString('\n')
 	require.NoError(t, err)
 	require.Equal(t, "\r\n", line)
 
-	// Send successful response.
-	_, err = server.Write([]byte("ICY 200 OK\r\n\r\n"))
-	require.NoError(t, err)
-
 	require.NoError(t, <-errCh)
 }
 
-func TestSourceHandshakeRejected(t *testing.T) {
+func TestSourceHandshakeRequestFormat(t *testing.T) {
 	client, server := net.Pipe()
 	defer server.Close()
 
-	ntripClient := NewClient(Config{
+	cfg := Config{
 		Caster:     "caster.example.com:2101",
-		Mountpoint: "/MOUNT01",
-		Password:   "wrong",
-	})
+		Mountpoint: "/EXAMPLE_MOUNT",
+		Password:   "my$ecr3t",
+		Username:   "user1",
+		UserAgent:  "NTRIP MyApp/1.0",
+	}
+	ntripClient := NewClient(cfg)
 
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- ntripClient.sourceHandshake(client)
 	}()
 
-	// Consume the SOURCE request.
+	// Read the complete request.
 	reader := bufio.NewReader(server)
+	var request strings.Builder
 	for {
 		line, err := reader.ReadString('\n')
 		require.NoError(t, err)
+		request.WriteString(line)
 		if strings.TrimSpace(line) == "" {
 			break
 		}
 	}
 
-	// Send rejection.
-	_, err := server.Write([]byte("ERROR - Bad Password\r\n\r\n"))
-	require.NoError(t, err)
-
-	err = <-errCh
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "caster rejected connection")
-	require.Contains(t, err.Error(), "Bad Password")
+	expected := "SOURCE my$ecr3t EXAMPLE_MOUNT\r\nSource-Agent: NTRIP MyApp/1.0\r\nSTR: \r\n\r\n"
+	require.Equal(t, expected, request.String())
+	require.NoError(t, <-errCh)
 }
 
-func TestSourceHandshakeConnectionClosed(t *testing.T) {
+func TestSourceHandshakeMountpointStripsSlash(t *testing.T) {
 	client, server := net.Pipe()
+	defer server.Close()
 
 	ntripClient := NewClient(Config{
 		Caster:     "caster.example.com:2101",
@@ -118,22 +117,109 @@ func TestSourceHandshakeConnectionClosed(t *testing.T) {
 		errCh <- ntripClient.sourceHandshake(client)
 	}()
 
-	// Consume the SOURCE request then close.
 	reader := bufio.NewReader(server)
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	// NTRIP v1 SOURCE uses a bare mountpoint with no leading slash, matching
+	// str2str/RTKLIB; the configured "/MOUNT01" must be stripped to "MOUNT01".
+	require.Equal(t, "SOURCE secret MOUNT01\r\n", line)
+	require.NoError(t, <-errCh)
+}
+
+func TestSourceHandshakeWriteError(t *testing.T) {
+	client, server := net.Pipe()
+	server.Close() // Close immediately to cause write error.
+
+	ntripClient := NewClient(Config{
+		Caster:     "caster.example.com:2101",
+		Mountpoint: "/MOUNT01",
+		Password:   "secret",
+	})
+
+	err := ntripClient.sourceHandshake(client)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sending SOURCE request")
+}
+
+func TestPostHandshakeRequestFormat(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	cfg := Config{
+		Caster:     "caster.example.com:2101",
+		Mountpoint: "/MOUNT01",
+		Password:   "secret",
+		Username:   "user1",
+		UserAgent:  "NTRIP MyApp/1.0",
+		Version:    2,
+		Chunked:    true,
+	}
+	ntripClient := NewClient(cfg)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ntripClient.postHandshake(client)
+	}()
+
+	reader := bufio.NewReader(server)
+	var requestLine string
+	headers := map[string]string{}
 	for {
 		line, err := reader.ReadString('\n')
-		if err != nil {
+		require.NoError(t, err)
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
 			break
 		}
-		if strings.TrimSpace(line) == "" {
-			break
+		if requestLine == "" {
+			requestLine = line
+			continue
 		}
+		k, v, _ := strings.Cut(line, ": ")
+		headers[k] = v
 	}
-	server.Close()
 
-	err := <-errCh
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "reading caster response")
+	require.Equal(t, "POST /MOUNT01 HTTP/1.1", requestLine)
+	require.Equal(t, "caster.example.com:2101", headers["Host"])
+	require.Equal(t, "Ntrip/2.0", headers["Ntrip-Version"])
+	require.Equal(t, "NTRIP MyApp/1.0", headers["User-Agent"])
+	require.Equal(t, "chunked", headers["Transfer-Encoding"])
+	want := base64.StdEncoding.EncodeToString([]byte("user1:secret"))
+	require.Equal(t, "Basic "+want, headers["Authorization"])
+	require.NoError(t, <-errCh)
+}
+
+func TestClientWriteChunked(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	c := &Client{
+		config: Config{Version: 2, Chunked: true},
+		conn:   client,
+		logger: slog.Default(),
+	}
+
+	data := []byte{0xD3, 0x00, 0x04, 0x3E, 0xD0, 0x00, 0x03} // 7 bytes
+	go func() {
+		n, err := c.Write(data)
+		require.NoError(t, err)
+		require.Equal(t, len(data), n)
+	}()
+
+	reader := bufio.NewReader(server)
+	sizeLine, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "7\r\n", sizeLine) // chunk size in hex
+
+	buf := make([]byte, len(data))
+	_, err = io.ReadFull(reader, buf)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+
+	crlf := make([]byte, 2)
+	_, err = io.ReadFull(reader, crlf)
+	require.NoError(t, err)
+	require.Equal(t, "\r\n", string(crlf))
 }
 
 func TestClientWriteNotConnected(t *testing.T) {
@@ -150,6 +236,7 @@ func TestClientWriteForwarding(t *testing.T) {
 	c := &Client{
 		config: Config{Caster: "localhost:2101", Mountpoint: "/M", Password: "p"},
 		conn:   client,
+		logger: slog.Default(),
 	}
 
 	data := []byte{0xD3, 0x00, 0x04, 0x3E, 0xD0, 0x00, 0x03}
@@ -176,19 +263,19 @@ func TestClientClose(t *testing.T) {
 	c := &Client{
 		config: Config{Caster: "localhost:2101", Mountpoint: "/M", Password: "p"},
 		conn:   client,
+		logger: slog.Default(),
 	}
 
 	require.NoError(t, c.Close())
 	require.Nil(t, c.conn)
 
-	// Writing after close should fail.
 	_, err := c.Write([]byte("data"))
 	require.Error(t, err)
 }
 
 func TestClientConnectDialFailure(t *testing.T) {
 	c := NewClient(Config{
-		Caster:     "localhost:1", // Unlikely to be listening
+		Caster:     "localhost:1",
 		Mountpoint: "/M",
 		Password:   "p",
 	})
@@ -200,7 +287,6 @@ func TestClientConnectDialFailure(t *testing.T) {
 }
 
 func TestClientConnectFullHandshake(t *testing.T) {
-	// Create a TCP listener to simulate a caster.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listener.Close()
@@ -211,7 +297,6 @@ func TestClientConnectFullHandshake(t *testing.T) {
 		Password:   "testpass",
 	})
 
-	// Accept and respond in a goroutine.
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -231,7 +316,7 @@ func TestClientConnectFullHandshake(t *testing.T) {
 			}
 		}
 		// Send success response.
-		_, _ = conn.Write([]byte("ICY 200 OK\r\n\r\n"))
+		_, _ = conn.Write([]byte("ICY 200 OK\r\n"))
 
 		// Keep connection alive for the test.
 		buf := make([]byte, 1)
@@ -243,7 +328,6 @@ func TestClientConnectFullHandshake(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	// Verify we can write data.
 	_, err = c.Write([]byte("test data"))
 	require.NoError(t, err)
 }
@@ -265,79 +349,6 @@ func TestProxyConfigInvalidCertPath(t *testing.T) {
 	require.Contains(t, err.Error(), "loading proxy TLS certificate")
 }
 
-func TestSourceHandshakeMultipleResponseHeaders(t *testing.T) {
-	client, server := net.Pipe()
-	defer server.Close()
-
-	ntripClient := NewClient(Config{
-		Caster:     "caster.example.com:2101",
-		Mountpoint: "/MOUNT01",
-		Password:   "secret",
-	})
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- ntripClient.sourceHandshake(client)
-	}()
-
-	// Consume SOURCE request.
-	reader := bufio.NewReader(server)
-	for {
-		line, err := reader.ReadString('\n')
-		require.NoError(t, err)
-		if strings.TrimSpace(line) == "" {
-			break
-		}
-	}
-
-	// Send response with extra headers (some casters do this).
-	response := "ICY 200 OK\r\nServer: NTRIP Caster 2.0\r\nDate: Wed, 15 Apr 2026\r\n\r\n"
-	_, err := server.Write([]byte(response))
-	require.NoError(t, err)
-
-	require.NoError(t, <-errCh)
-}
-
-func TestSourceHandshakeRequestFormat(t *testing.T) {
-	// Verify the exact wire format of the SOURCE request.
-	client, server := net.Pipe()
-	defer server.Close()
-
-	cfg := Config{
-		Caster:     "caster.example.com:2101",
-		Mountpoint: "/EXAMPLE_MOUNT",
-		Password:   "my$ecr3t",
-		UserAgent:  "NTRIP MyApp/1.0",
-	}
-	ntripClient := NewClient(cfg)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- ntripClient.sourceHandshake(client)
-	}()
-
-	// Read the complete request.
-	reader := bufio.NewReader(server)
-	var request strings.Builder
-	for {
-		line, err := reader.ReadString('\n')
-		require.NoError(t, err)
-		request.WriteString(line)
-		if strings.TrimSpace(line) == "" {
-			break
-		}
-	}
-
-	expected := fmt.Sprintf(
-		"SOURCE %s %s\r\nSource-Agent: %s\r\n\r\n",
-		cfg.Password, cfg.Mountpoint, cfg.UserAgent,
-	)
-	require.Equal(t, expected, request.String())
-
-	_, _ = server.Write([]byte("ICY 200 OK\r\n\r\n"))
-	require.NoError(t, <-errCh)
-}
-
 func TestWithLogger(t *testing.T) {
 	customLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	c := NewClient(Config{
@@ -348,70 +359,11 @@ func TestWithLogger(t *testing.T) {
 	require.Same(t, customLogger, c.logger)
 }
 
-func TestBufferedConnReadPassesThroughBufferedBytes(t *testing.T) {
-	// Verifies bufferedConn.Read delegates to the embedded bufio.Reader. Does not exercise the underlying net.Conn — see TestConnectHandshakeFailure for the end-to-end path.
-	payload := []byte{0xD3, 0x00, 0x04, 0x3E, 0xD0, 0x00, 0x03}
-
-	client, server := net.Pipe()
-	t.Cleanup(func() {
-		client.Close()
-		server.Close()
-	})
-
-	bc := &bufferedConn{
-		reader: bufio.NewReader(bytes.NewReader(payload)),
-		Conn:   client,
-	}
-
-	buf := make([]byte, len(payload))
-	n, err := io.ReadFull(bc, buf)
-	require.NoError(t, err)
-	require.Equal(t, len(payload), n)
-	require.Equal(t, payload, buf)
-}
-
-func TestConnectHandshakeFailure(t *testing.T) {
-	// Connect should wrap a sourceHandshake error with "NTRIP SOURCE handshake".
-	// Simulates a caster that accepts the TCP connection but returns a
-	// non-ICY 200 response (here, an HTTP-style 401 a misconfigured proxy
-	// might send) and exercises Connect's handshake-error branch.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { listener.Close() })
-
-	go func() {
-		conn, err := listener.Accept()
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-
-		// Consume the SOURCE request.
-		reader := bufio.NewReader(conn)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return
-			}
-			if strings.TrimSpace(line) == "" {
-				break
-			}
-		}
-		// Respond with a non-ICY-200 line, then close.
-		_, _ = conn.Write([]byte("HTTP/1.1 401 Unauthorized\r\n\r\n"))
-	}()
-
+func TestDefaultUserAgent(t *testing.T) {
 	c := NewClient(Config{
-		Caster:     listener.Addr().String(),
+		Caster:     "localhost:2101",
 		Mountpoint: "/M",
-		Password:   "wrong",
+		Password:   "p",
 	})
-
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	err = c.Connect(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "NTRIP SOURCE handshake")
-	require.Contains(t, err.Error(), "caster rejected connection")
-	require.Nil(t, c.conn)
+	require.Equal(t, "NTRIP ntripper/1.0", c.config.UserAgent)
 }

--- a/rtcm/bits.go
+++ b/rtcm/bits.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+// BitReader reads arbitrary numbers of bits from a byte slice.
+type BitReader struct {
+	data []byte
+	pos  int // current bit position
+}
+
+// NewBitReader creates a BitReader over the given byte slice.
+func NewBitReader(data []byte) *BitReader {
+	return &BitReader{data: data}
+}
+
+// ReadBits reads n bits (1-32) as an unsigned value.
+func (r *BitReader) ReadBits(n int) uint32 {
+	var val uint32
+	for range n {
+		byteIdx := r.pos / 8
+		bitIdx := 7 - (r.pos % 8)
+		if byteIdx < len(r.data) {
+			val = (val << 1) | uint32((r.data[byteIdx]>>bitIdx)&1)
+		} else {
+			val <<= 1
+		}
+		r.pos++
+	}
+	return val
+}
+
+// ReadSignedBits reads n bits as a signed two's complement value.
+func (r *BitReader) ReadSignedBits(n int) int32 {
+	val := r.ReadBits(n)
+	if val&(1<<(n-1)) != 0 {
+		val |= ^uint32(0) << n
+	}
+	//nolint:gosec // intentional two's-complement reinterpret of an n-bit field
+	return int32(val)
+}
+
+// Pos returns the current bit position.
+func (r *BitReader) Pos() int {
+	return r.pos
+}
+
+// Skip advances the position by n bits.
+func (r *BitReader) Skip(n int) {
+	r.pos += n
+}
+
+// BitWriter writes arbitrary numbers of bits to a byte slice.
+type BitWriter struct {
+	data []byte
+	pos  int
+}
+
+// NewBitWriter creates a BitWriter with the given initial capacity in bytes.
+func NewBitWriter(capacity int) *BitWriter {
+	return &BitWriter{data: make([]byte, capacity)}
+}
+
+// WriteBits writes n bits (1-32) from the least significant bits of val.
+func (w *BitWriter) WriteBits(val uint32, n int) {
+	for i := n - 1; i >= 0; i-- {
+		byteIdx := w.pos / 8
+		bitIdx := 7 - (w.pos % 8)
+		for byteIdx >= len(w.data) {
+			w.data = append(w.data, 0)
+		}
+		if (val>>i)&1 == 1 {
+			w.data[byteIdx] |= 1 << bitIdx
+		}
+		w.pos++
+	}
+}
+
+// WriteSignedBits writes n bits of a signed value in two's complement.
+func (w *BitWriter) WriteSignedBits(val int32, n int) {
+	//nolint:gosec // intentional two's-complement reinterpret into an n-bit field
+	w.WriteBits(uint32(val)&((1<<n)-1), n)
+}
+
+// Pos returns the current bit position.
+func (w *BitWriter) Pos() int {
+	return w.pos
+}
+
+// Bytes returns the written data, trimmed to the byte boundary.
+func (w *BitWriter) Bytes() []byte {
+	byteLen := (w.pos + 7) / 8
+	if byteLen > len(w.data) {
+		return w.data
+	}
+	return w.data[:byteLen]
+}

--- a/rtcm/bits_test.go
+++ b/rtcm/bits_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitWriterReaderRoundTrip(t *testing.T) {
+	type field struct {
+		val   uint32
+		width int
+	}
+	fields := []field{
+		{0, 1}, {1, 1},
+		{0x2, 2}, {0x5, 4}, {0x7F, 7}, {0xFF, 8},
+		{0x3FF, 10}, {0xFFF, 12}, {0x1FFFF, 17},
+		{0x3FFFFF, 22}, {0xFFFFFF, 24}, {0xFFFFFFFF, 32},
+		{0, 30}, {123456, 20},
+	}
+
+	w := NewBitWriter(64)
+	bitsWritten := 0
+	for _, f := range fields {
+		w.WriteBits(f.val, f.width)
+		bitsWritten += f.width
+	}
+	require.Equal(t, bitsWritten, w.Pos(), "writer bit position")
+
+	r := NewBitReader(w.Bytes())
+	for _, f := range fields {
+		got := r.ReadBits(f.width)
+		require.Equalf(t, f.val, got, "round-trip width=%d", f.width)
+	}
+	require.Equal(t, bitsWritten, r.Pos(), "reader bit position")
+}
+
+func TestBitWriterReaderSigned(t *testing.T) {
+	type field struct {
+		val   int32
+		width int
+	}
+	fields := []field{
+		{0, 8}, {1, 8}, {-1, 8}, {127, 8}, {-128, 8},
+		{-2097152, 22}, {2097151, 22}, // 22-bit signed extremes
+		{-8388608, 24}, {8388607, 24}, // 24-bit signed extremes
+		{-519, 16}, {12345, 16},
+	}
+
+	w := NewBitWriter(64)
+	for _, f := range fields {
+		w.WriteSignedBits(f.val, f.width)
+	}
+
+	r := NewBitReader(w.Bytes())
+	for _, f := range fields {
+		got := r.ReadSignedBits(f.width)
+		require.Equalf(t, f.val, got, "signed round-trip width=%d", f.width)
+	}
+}
+
+func TestBitReaderSkip(t *testing.T) {
+	w := NewBitWriter(16)
+	w.WriteBits(0xAB, 8)
+	w.WriteBits(0xCD, 8)
+	w.WriteBits(0xEF, 8)
+
+	r := NewBitReader(w.Bytes())
+	r.Skip(8)
+	require.Equal(t, 8, r.Pos())
+	require.Equal(t, uint32(0xCD), r.ReadBits(8))
+	require.Equal(t, uint32(0xEF), r.ReadBits(8))
+}
+
+func TestBitWriterBytePadding(t *testing.T) {
+	// 12 bits written -> 2 bytes, low 4 bits of the last byte are zero padding.
+	w := NewBitWriter(4)
+	w.WriteBits(0xABC, 12)
+	b := w.Bytes()
+	require.Len(t, b, 2)
+	require.Equal(t, byte(0xAB), b[0])
+	require.Equal(t, byte(0xC0), b[1]) // 0xC in high nibble, padding in low
+}
+
+func TestBitWriterEmpty(t *testing.T) {
+	w := NewBitWriter(0)
+	require.Equal(t, 0, w.Pos())
+	require.Empty(t, w.Bytes())
+}

--- a/rtcm/encode.go
+++ b/rtcm/encode.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import "encoding/binary"
+
+// AntennaDescriptor holds parameters for generating RTCM 1033
+// (Receiver and Antenna Descriptor) messages.
+type AntennaDescriptor struct {
+	AntennaType    string
+	AntennaSerial  string
+	ReceiverType   string
+	ReceiverFW     string
+	ReceiverSerial string
+	StationID      uint16
+	AntennaSetupID uint8
+}
+
+// Encode1033 generates a complete RTCM 1033 frame (header + payload + CRC).
+func Encode1033(desc AntennaDescriptor) []byte {
+	// Build the bit-packed payload.
+	// RTCM 1033 fields:
+	//   DF002: Message Number (12 bits) = 1033
+	//   DF003: Reference Station ID (12 bits)
+	//   DF227: Descriptor Counter N (8 bits)
+	//   DF228: Antenna Descriptor (N bytes)
+	//   DF229: Antenna Setup ID (8 bits)
+	//   DF230: Serial Number Counter M (8 bits)
+	//   DF231: Antenna Serial Number (M bytes)
+	//   DF232: Receiver Type Counter I (8 bits)
+	//   DF233: Receiver Type (I bytes)
+	//   DF234: Firmware Counter J (8 bits)
+	//   DF235: Receiver Firmware (J bytes)
+	//   DF236: Serial Counter K (8 bits)
+	//   DF237: Receiver Serial (K bytes)
+
+	payloadSize := 3 + // 12+12 bits = 24 bits = 3 bytes for msg number + station ID
+		1 + len(desc.AntennaType) +
+		1 + // setup ID
+		1 + len(desc.AntennaSerial) +
+		1 + len(desc.ReceiverType) +
+		1 + len(desc.ReceiverFW) +
+		1 + len(desc.ReceiverSerial)
+
+	payload := make([]byte, payloadSize)
+	offset := 0
+
+	// DF002 (12 bits) + DF003 (12 bits) = 24 bits = 3 bytes
+	// Message number 1033 = 0x409 in upper 12 bits
+	// Station ID in lower 12 bits
+	val := (uint32(1033) << 12) | uint32(desc.StationID&0x0FFF)
+	payload[0] = byte((val >> 16) & 0xFF)
+	payload[1] = byte((val >> 8) & 0xFF)
+	payload[2] = byte(val & 0xFF)
+	offset = 3
+
+	// Antenna descriptor
+	payload[offset] = byte(len(desc.AntennaType) & 0xFF)
+	offset++
+	copy(payload[offset:], desc.AntennaType)
+	offset += len(desc.AntennaType)
+
+	// Antenna setup ID
+	payload[offset] = desc.AntennaSetupID
+	offset++
+
+	// Antenna serial number
+	payload[offset] = byte(len(desc.AntennaSerial) & 0xFF)
+	offset++
+	copy(payload[offset:], desc.AntennaSerial)
+	offset += len(desc.AntennaSerial)
+
+	// Receiver type
+	payload[offset] = byte(len(desc.ReceiverType) & 0xFF)
+	offset++
+	copy(payload[offset:], desc.ReceiverType)
+	offset += len(desc.ReceiverType)
+
+	// Receiver firmware
+	payload[offset] = byte(len(desc.ReceiverFW) & 0xFF)
+	offset++
+	copy(payload[offset:], desc.ReceiverFW)
+	offset += len(desc.ReceiverFW)
+
+	// Receiver serial
+	payload[offset] = byte(len(desc.ReceiverSerial) & 0xFF)
+	offset++
+	copy(payload[offset:], desc.ReceiverSerial)
+
+	// Build complete frame: header (3) + payload + CRC (3)
+	frameLen := HeaderSize + len(payload) + CRCSize
+	frame := make([]byte, frameLen)
+
+	// Header: preamble + 6 reserved bits (0) + 10-bit length
+	frame[0] = Preamble
+	binary.BigEndian.PutUint16(frame[1:3], uint16(len(payload)&0xFFFF))
+
+	// Payload
+	copy(frame[HeaderSize:], payload)
+
+	putCRC(frame)
+	return frame
+}

--- a/rtcm/encode_test.go
+++ b/rtcm/encode_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stationIDOf decodes DF003 (reference station ID), payload bits 12..23.
+func stationIDOf(payload []byte) uint16 {
+	return uint16(payload[1]&0x0F)<<8 | uint16(payload[2])
+}
+
+func TestEncode1033RoundTrip(t *testing.T) {
+	desc := AntennaDescriptor{
+		StationID:    1234,
+		AntennaType:  "ADVNULLANTENNA",
+		ReceiverType: "u-blox F9T",
+		ReceiverFW:   "2.20",
+	}
+	frame := Encode1033(desc)
+
+	f, err := ParseFrame(frame) // also validates CRC-24Q
+	require.NoError(t, err)
+	require.Equal(t, uint16(1033), f.MessageType)
+	require.Equal(t, uint16(1234), stationIDOf(f.Payload))
+	require.Contains(t, string(f.Payload), "ADVNULLANTENNA")
+	require.Contains(t, string(f.Payload), "u-blox F9T")
+	require.Contains(t, string(f.Payload), "2.20")
+}
+
+func TestPatchStationID(t *testing.T) {
+	orig := Encode1033(AntennaDescriptor{StationID: 1, AntennaType: "X"})
+	patched := PatchStationID(orig, 4090)
+
+	f, err := ParseFrame(patched) // CRC must still validate after the patch
+	require.NoError(t, err)
+	require.Equal(t, uint16(1033), f.MessageType)
+	require.Equal(t, uint16(4090), stationIDOf(f.Payload))
+	require.NotEqual(t, orig[len(orig)-3:], patched[len(patched)-3:], "CRC recomputed")
+}
+
+func TestPatchStationIDShortFrameUnchanged(t *testing.T) {
+	short := []byte{0xD3, 0x00}
+	require.Equal(t, short, PatchStationID(short, 5))
+}
+
+func TestPatch1005RefStation(t *testing.T) {
+	// Synthetic 1005 frame: message number 1005 in the first 12 bits, 19-byte
+	// payload (the size of a real 1005), reference-station indicator clear.
+	payload := make([]byte, 19)
+	payload[0] = byte(TypeStationARP >> 4)
+	payload[1] = byte((TypeStationARP & 0x0F) << 4)
+	frame := frameRTCM(payload)
+
+	require.Equal(t, byte(0), frame[7]&0x40, "indicator initially clear")
+
+	patched := Patch1005RefStation(frame)
+	f, err := ParseFrame(patched) // CRC must validate
+	require.NoError(t, err)
+	require.Equal(t, TypeStationARP, f.MessageType)
+	require.Equal(t, byte(0x40), patched[7]&0x40, "reference station indicator set")
+}
+
+func TestPatch1005ShortFrameUnchanged(t *testing.T) {
+	short := make([]byte, 7)
+	require.Equal(t, short, Patch1005RefStation(short))
+}

--- a/rtcm/ephemeris.go
+++ b/rtcm/ephemeris.go
@@ -1,0 +1,233 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import "encoding/binary"
+
+// EphCollector assembles GPS broadcast ephemeris from UBX-RXM-SFRBX navigation
+// subframes and emits RTCM 1019 (GPS ephemeris) messages. Casters need
+// ephemeris to position the satellites referenced by the MSM observations;
+// without it they report "lack usable measurements".
+type EphCollector struct {
+	subfrm   map[uint8]*[3][30]byte // PRN -> packed subframes 1,2,3 (24-bit words)
+	have     map[uint8][3]bool
+	latest   map[uint8][]byte // PRN -> latest encoded RTCM 1019 frame
+	lastIODE map[uint8]uint32 // PRN -> IODE of the last emitted ephemeris
+}
+
+// NewEphCollector creates an empty GPS ephemeris collector.
+func NewEphCollector() *EphCollector {
+	return &EphCollector{
+		subfrm:   map[uint8]*[3][30]byte{},
+		have:     map[uint8][3]bool{},
+		latest:   map[uint8][]byte{},
+		lastIODE: map[uint8]uint32{},
+	}
+}
+
+// All returns the latest cached RTCM 1019 frame for every satellite with a
+// complete ephemeris, for sending on (re)connect and periodically.
+func (c *EphCollector) All() [][]byte {
+	out := make([][]byte, 0, len(c.latest))
+	for _, f := range c.latest {
+		out = append(out, f)
+	}
+	return out
+}
+
+// AddSFRBX consumes a UBX-RXM-SFRBX payload (the UBX message payload, without
+// the UBX header/checksum). When a payload completes GPS LNAV subframes 1-3 for
+// a satellite with a consistent IODE/IODC, it returns the encoded RTCM 1019
+// frame. Otherwise it returns nil.
+func (c *EphCollector) AddSFRBX(payload []byte) []byte {
+	if len(payload) < 8 {
+		return nil
+	}
+	gnssID := payload[0]
+	svID := payload[1]
+	numWords := int(payload[4])
+
+	if gnssID != GnssGPS { // GPS LNAV only for now
+		return nil
+	}
+	if numWords < 10 || len(payload) < 8+numWords*4 {
+		return nil
+	}
+
+	// Each 32-bit dword carries a 30-bit nav word; the top 24 bits are data.
+	var words [10]uint32
+	for i := range 10 {
+		dw := binary.LittleEndian.Uint32(payload[8+i*4 : 12+i*4])
+		words[i] = (dw >> 6) & 0xFFFFFF
+	}
+	id := (words[1] >> 2) & 7 // subframe ID from the HOW word
+	if id < 1 || id > 3 {
+		return nil // only subframes 1-3 carry ephemeris
+	}
+
+	// Pack the 10 24-bit words into a 30-byte subframe buffer.
+	bw := NewBitWriter(30)
+	for i := range 10 {
+		bw.WriteBits(words[i], 24)
+	}
+	var buf [30]byte
+	copy(buf[:], bw.Bytes())
+
+	sf := c.subfrm[svID]
+	if sf == nil {
+		sf = &[3][30]byte{}
+		c.subfrm[svID] = sf
+	}
+	sf[id-1] = buf
+	hv := c.have[svID]
+	hv[id-1] = true
+	c.have[svID] = hv
+
+	if hv[0] && hv[1] && hv[2] {
+		// Only emit when the broadcast ephemeris actually changes (new IODE);
+		// otherwise the same ephemeris would be re-sent on every subframe.
+		iode := getbitu(sf[1][:], 48, 8)
+		if last, ok := c.lastIODE[svID]; ok && last == iode {
+			return nil
+		}
+		frame := encode1019(svID, sf)
+		if frame == nil {
+			return nil
+		}
+		c.latest[svID] = frame
+		c.lastIODE[svID] = iode
+		return frame
+	}
+	return nil
+}
+
+// getbitu reads n bits (MSB-first) at bit offset pos as an unsigned value.
+func getbitu(buf []byte, pos, n int) uint32 {
+	var v uint32
+	for i := pos; i < pos+n; i++ {
+		v = (v << 1) | uint32((buf[i/8]>>(7-i%8))&1)
+	}
+	return v
+}
+
+// getbits reads n bits at bit offset pos as a two's complement signed value.
+func getbits(buf []byte, pos, n int) int32 {
+	v := getbitu(buf, pos, n)
+	if n < 32 && v&(1<<(n-1)) != 0 {
+		v |= ^uint32(0) << n // sign extend
+	}
+	//nolint:gosec // intentional two's-complement reinterpret of an n-bit field
+	return int32(v)
+}
+
+// encode1019 builds an RTCM 1019 GPS ephemeris frame directly from the raw
+// subframe bit fields. Every RTCM 1019 field shares the same scaling as the
+// corresponding LNAV field, so the values are copied bit-for-bit with no
+// physical-unit conversion.
+func encode1019(prn uint8, sf *[3][30]byte) []byte {
+	b1, b2, b3 := sf[0][:], sf[1][:], sf[2][:]
+
+	// Subframe 1.
+	week := getbitu(b1, 48, 10)
+	code := getbitu(b1, 58, 2)
+	sva := getbitu(b1, 60, 4)
+	svh := getbitu(b1, 64, 6)
+	iodc0 := getbitu(b1, 70, 2)
+	flag := getbitu(b1, 72, 1)
+	tgd := getbits(b1, 160, 8)
+	iodc1 := getbitu(b1, 168, 8)
+	toc := getbitu(b1, 176, 16)
+	af2 := getbits(b1, 192, 8)
+	af1 := getbits(b1, 200, 16)
+	af0 := getbits(b1, 216, 22)
+	iodc := (iodc0 << 8) | iodc1
+
+	// Subframe 2.
+	iode2 := getbitu(b2, 48, 8)
+	crs := getbits(b2, 56, 16)
+	deln := getbits(b2, 72, 16)
+	m0 := getbits(b2, 88, 32)
+	cuc := getbits(b2, 120, 16)
+	ecc := getbitu(b2, 136, 32)
+	cus := getbits(b2, 168, 16)
+	sqrtA := getbitu(b2, 184, 32)
+	toe := getbitu(b2, 216, 16)
+	fit := getbitu(b2, 232, 1)
+
+	// Subframe 3.
+	cic := getbits(b3, 48, 16)
+	omg0 := getbits(b3, 64, 32)
+	cis := getbits(b3, 96, 16)
+	i0 := getbits(b3, 112, 32)
+	crc := getbits(b3, 144, 16)
+	omg := getbits(b3, 160, 32)
+	omgd := getbits(b3, 192, 24)
+	iode3 := getbitu(b3, 216, 8)
+	idot := getbits(b3, 224, 14)
+
+	// Drop a partially-updated ephemeris (IODE/IODC must agree).
+	if iode2 != iode3 || iode2 != (iodc&0xFF) {
+		return nil
+	}
+
+	w := NewBitWriter(64)
+	w.WriteBits(1019, 12)
+	w.WriteBits(uint32(prn), 6)
+	w.WriteBits(week, 10)
+	w.WriteBits(sva, 4)
+	w.WriteBits(code, 2)
+	w.WriteSignedBits(idot, 14)
+	w.WriteBits(iode2, 8)
+	w.WriteBits(toc, 16)
+	w.WriteSignedBits(af2, 8)
+	w.WriteSignedBits(af1, 16)
+	w.WriteSignedBits(af0, 22)
+	w.WriteBits(iodc, 10)
+	w.WriteSignedBits(crs, 16)
+	w.WriteSignedBits(deln, 16)
+	w.WriteSignedBits(m0, 32)
+	w.WriteSignedBits(cuc, 16)
+	w.WriteBits(ecc, 32)
+	w.WriteSignedBits(cus, 16)
+	w.WriteBits(sqrtA, 32)
+	w.WriteBits(toe, 16)
+	w.WriteSignedBits(cic, 16)
+	w.WriteSignedBits(omg0, 32)
+	w.WriteSignedBits(cis, 16)
+	w.WriteSignedBits(i0, 32)
+	w.WriteSignedBits(crc, 16)
+	w.WriteSignedBits(omg, 32)
+	w.WriteSignedBits(omgd, 24)
+	w.WriteSignedBits(tgd, 8)
+	w.WriteBits(svh, 6)
+	w.WriteBits(flag, 1)
+	w.WriteBits(fit, 1)
+
+	return frameRTCM(w.Bytes())
+}
+
+// frameRTCM wraps an RTCM3 payload with the 3-byte header and CRC-24Q.
+func frameRTCM(payload []byte) []byte {
+	frameLen := HeaderSize + len(payload) + CRCSize
+	frame := make([]byte, frameLen)
+	frame[0] = Preamble
+	frame[1] = byte((len(payload) >> 8) & 0x03)
+	frame[2] = byte(len(payload) & 0xFF)
+	copy(frame[HeaderSize:], payload)
+	putCRC(frame)
+	return frame
+}

--- a/rtcm/ephemeris_test.go
+++ b/rtcm/ephemeris_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setbitu sets n bits (MSB-first) at bit offset pos.
+func setbitu(buf []byte, pos, n int, val uint32) {
+	for i := range n {
+		idx := pos + i
+		if (val>>uint(n-1-i))&1 == 1 {
+			buf[idx/8] |= 1 << uint(7-idx%8)
+		} else {
+			buf[idx/8] &^= 1 << uint(7-idx%8)
+		}
+	}
+}
+
+// gpsSubframe builds a 30-byte GPS LNAV subframe (ten 24-bit words) with the
+// given subframe ID encoded in the HOW word.
+func gpsSubframe(id uint32) []byte {
+	sf := make([]byte, 30)
+	setbitu(sf, 24, 24, id<<2) // (word1>>2)&7 == id
+	return sf
+}
+
+// buildEph builds GPS LNAV subframes 1-3 for a satellite with a consistent
+// IODE/IODC. The optional fields callback sets additional ephemeris values.
+func buildEph(iode uint32, fields func(s1, s2, s3 []byte)) (s1, s2, s3 []byte) {
+	s1, s2, s3 = gpsSubframe(1), gpsSubframe(2), gpsSubframe(3)
+	setbitu(s1, 70, 2, 1)     // IODC MSBs
+	setbitu(s1, 168, 8, iode) // IODC LSBs -> iodc&0xFF == iode
+	setbitu(s2, 48, 8, iode)  // IODE (subframe 2)
+	setbitu(s3, 216, 8, iode) // IODE (subframe 3)
+	if fields != nil {
+		fields(s1, s2, s3)
+	}
+	return
+}
+
+// sfrbx wraps a subframe in a UBX-RXM-SFRBX payload (reverses the >>6 word
+// extraction the decoder performs).
+func sfrbx(gnss, prn uint8, sf []byte) []byte {
+	p := make([]byte, 8+10*4)
+	p[0] = gnss
+	p[1] = prn
+	p[4] = 10
+	for i := range 10 {
+		binary.LittleEndian.PutUint32(p[8+i*4:12+i*4], getbitu(sf, i*24, 24)<<6)
+	}
+	return p
+}
+
+type decoded1019 struct {
+	prn, week, iode, iodc, toe uint32
+	m0                         int32
+	ecc, sqrtA                 uint32
+}
+
+// decode1019 reads an RTCM 1019 frame field by field in spec order (no hardcoded
+// offsets), validating framing, CRC, and that the fields exactly fill the payload.
+func decode1019(t *testing.T, frame []byte) decoded1019 {
+	t.Helper()
+	require.Equal(t, Preamble, frame[0])
+	pl := int(frame[1]&0x03)<<8 | int(frame[2])
+	require.Equal(t, HeaderSize+pl+CRCSize, len(frame))
+	stored := uint32(frame[len(frame)-3])<<16 | uint32(frame[len(frame)-2])<<8 | uint32(frame[len(frame)-1])
+	require.Equal(t, CRC24Q(frame[:HeaderSize+pl]), stored)
+
+	r := NewBitReader(frame[HeaderSize : HeaderSize+pl])
+	require.Equal(t, uint32(1019), r.ReadBits(12))
+
+	var d decoded1019
+	d.prn = r.ReadBits(6)
+	d.week = r.ReadBits(10)
+	r.ReadBits(4)        // SV accuracy
+	r.ReadBits(2)        // code on L2
+	r.ReadSignedBits(14) // IDOT
+	d.iode = r.ReadBits(8)
+	r.ReadBits(16)       // toc
+	r.ReadSignedBits(8)  // af2
+	r.ReadSignedBits(16) // af1
+	r.ReadSignedBits(22) // af0
+	d.iodc = r.ReadBits(10)
+	r.ReadSignedBits(16) // crs
+	r.ReadSignedBits(16) // delta-n
+	d.m0 = r.ReadSignedBits(32)
+	r.ReadSignedBits(16) // cuc
+	d.ecc = r.ReadBits(32)
+	r.ReadSignedBits(16) // cus
+	d.sqrtA = r.ReadBits(32)
+	d.toe = r.ReadBits(16)
+	r.ReadSignedBits(16) // cic
+	r.ReadSignedBits(32) // OMEGA0
+	r.ReadSignedBits(16) // cis
+	r.ReadSignedBits(32) // i0
+	r.ReadSignedBits(16) // crc
+	r.ReadSignedBits(32) // omega
+	r.ReadSignedBits(24) // OMEGADOT
+	r.ReadSignedBits(8)  // tgd
+	r.ReadBits(6)        // SV health
+	r.ReadBits(1)        // L2 P data flag
+	r.ReadBits(1)        // fit interval
+
+	require.LessOrEqual(t, r.Pos(), pl*8)
+	require.Less(t, pl*8-r.Pos(), 8, "1019 fields exactly fill the payload")
+	return d
+}
+
+func TestEphCollectorEmits1019(t *testing.T) {
+	const prn = uint8(5)
+	const iode, week = uint32(0x42), uint32(0x2AB)
+	m0 := int32(-123456)
+	s1, s2, s3 := buildEph(iode, func(s1, s2, s3 []byte) {
+		setbitu(s1, 48, 10, week)
+		setbitu(s2, 88, 32, uint32(m0))  // M0
+		setbitu(s2, 136, 32, 0x0A000000) // eccentricity
+		setbitu(s2, 184, 32, 0x51234567) // sqrtA
+		setbitu(s2, 216, 16, 450)        // toe (raw 16-bit)
+	})
+
+	c := NewEphCollector()
+	require.Nil(t, c.AddSFRBX(sfrbx(GnssGPS, prn, s1)), "no emit before subframe 3")
+	require.Nil(t, c.AddSFRBX(sfrbx(GnssGPS, prn, s2)), "no emit before subframe 3")
+	frame := c.AddSFRBX(sfrbx(GnssGPS, prn, s3))
+	require.NotNil(t, frame)
+
+	d := decode1019(t, frame)
+	require.Equal(t, uint32(prn), d.prn)
+	require.Equal(t, week, d.week)
+	require.Equal(t, iode, d.iode)
+	require.Equal(t, iode, d.iodc&0xFF)
+	require.Equal(t, m0, d.m0)
+	require.Equal(t, uint32(0x0A000000), d.ecc)
+	require.Equal(t, uint32(0x51234567), d.sqrtA)
+	require.Equal(t, uint32(450), d.toe)
+}
+
+func TestEphCollectorEmitsOnlyOnIODEChange(t *testing.T) {
+	c := NewEphCollector()
+	feed := func(iode uint32) bool {
+		s1, s2, s3 := buildEph(iode, nil)
+		emitted := false
+		for _, s := range [][]byte{s1, s2, s3} {
+			if c.AddSFRBX(sfrbx(GnssGPS, 9, s)) != nil {
+				emitted = true
+			}
+		}
+		return emitted
+	}
+	require.True(t, feed(0x10), "first ephemeris emitted")
+	require.False(t, feed(0x10), "unchanged ephemeris not re-emitted")
+	require.True(t, feed(0x20), "new IODE emitted")
+}
+
+func TestEphCollectorAllPerSatellite(t *testing.T) {
+	c := NewEphCollector()
+	for _, prn := range []uint8{3, 11} {
+		s1, s2, s3 := buildEph(0x30, nil)
+		c.AddSFRBX(sfrbx(GnssGPS, prn, s1))
+		c.AddSFRBX(sfrbx(GnssGPS, prn, s2))
+		require.NotNil(t, c.AddSFRBX(sfrbx(GnssGPS, prn, s3)))
+	}
+	all := c.All()
+	require.Len(t, all, 2)
+
+	prns := map[uint32]bool{}
+	for _, f := range all {
+		prns[decode1019(t, f).prn] = true
+	}
+	require.True(t, prns[3] && prns[11], "one cached 1019 per satellite")
+}
+
+func TestEphCollectorIncompleteNoEmit(t *testing.T) {
+	c := NewEphCollector()
+	s1, s2, _ := buildEph(0x10, nil)
+	require.Nil(t, c.AddSFRBX(sfrbx(GnssGPS, 5, s1)))
+	require.Nil(t, c.AddSFRBX(sfrbx(GnssGPS, 5, s2)))
+	require.Empty(t, c.All())
+}
+
+func TestEphCollectorIODEMismatchDropped(t *testing.T) {
+	c := NewEphCollector()
+	s1, s2, s3 := buildEph(0x10, nil)
+	setbitu(s3, 216, 8, 0x99) // subframe 3 IODE disagrees
+	c.AddSFRBX(sfrbx(GnssGPS, 7, s1))
+	c.AddSFRBX(sfrbx(GnssGPS, 7, s2))
+	require.Nil(t, c.AddSFRBX(sfrbx(GnssGPS, 7, s3)))
+	require.Empty(t, c.All())
+}
+
+func TestEphCollectorNonGPSIgnored(t *testing.T) {
+	c := NewEphCollector()
+	require.Nil(t, c.AddSFRBX(sfrbx(GnssGalileo, 1, gpsSubframe(3))))
+	require.Empty(t, c.All())
+}
+
+func TestEphCollectorShortPayloadIgnored(t *testing.T) {
+	c := NewEphCollector()
+	require.Nil(t, c.AddSFRBX([]byte{0x00, 0x01}))
+}

--- a/rtcm/mixed_scanner.go
+++ b/rtcm/mixed_scanner.go
@@ -1,0 +1,201 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MsgType indicates the type of message returned by MixedScanner.
+type MsgType int
+
+const (
+	MsgRTCM3 MsgType = iota
+	MsgUBX
+)
+
+// MixedScanner reads both RTCM3 frames and UBX frames from a byte stream.
+// It detects the frame type by preamble (0xD3 for RTCM3, 0xB5 for UBX).
+type MixedScanner struct {
+	reader  *bufio.Reader
+	err     error
+	ubx     []byte // raw UBX payload when msgType == MsgUBX
+	frame   Frame  // valid when msgType == MsgRTCM3
+	msgType MsgType
+	ubxCls  byte
+	ubxMsg  byte
+}
+
+// NewMixedScanner creates a scanner that reads both RTCM3 and UBX frames.
+func NewMixedScanner(r io.Reader) *MixedScanner {
+	return &MixedScanner{
+		reader: bufio.NewReaderSize(r, MaxFrameSize*2),
+	}
+}
+
+// Scan reads the next frame from the stream (either RTCM3 or UBX).
+func (s *MixedScanner) Scan() bool {
+	for {
+		b, err := s.reader.ReadByte()
+		if err != nil {
+			if err != io.EOF {
+				s.err = fmt.Errorf("reading preamble: %w", err)
+			}
+			return false
+		}
+
+		switch b {
+		case Preamble: // 0xD3 — RTCM3
+			if s.scanRTCM() {
+				return true
+			}
+		case UBXSync1: // 0xB5 — potential UBX
+			if s.scanUBX() {
+				return true
+			}
+		}
+	}
+}
+
+// scanRTCM attempts to read an RTCM3 frame after the preamble was consumed.
+func (s *MixedScanner) scanRTCM() bool {
+	headerRest, err := s.reader.Peek(2)
+	if err != nil {
+		if err != io.EOF && !errors.Is(err, io.ErrUnexpectedEOF) {
+			s.err = fmt.Errorf("reading RTCM header: %w", err)
+		}
+		return false
+	}
+
+	if headerRest[0]&0xFC != 0 {
+		return false
+	}
+
+	payloadLen := int(binary.BigEndian.Uint16(headerRest) & 0x03FF)
+	remaining := 2 + payloadLen + CRCSize
+
+	body, err := s.reader.Peek(remaining)
+	if err != nil {
+		if errors.Is(err, bufio.ErrBufferFull) {
+			return false
+		}
+		if err != io.EOF && !errors.Is(err, io.ErrUnexpectedEOF) {
+			s.err = fmt.Errorf("reading RTCM body: %w", err)
+		}
+		return false
+	}
+
+	frameData := make([]byte, 1+remaining)
+	frameData[0] = Preamble
+	copy(frameData[1:], body)
+
+	frame, parseErr := ParseFrame(frameData)
+	if parseErr != nil {
+		return false
+	}
+
+	if _, err := s.reader.Discard(remaining); err != nil {
+		s.err = fmt.Errorf("discarding RTCM frame: %w", err)
+		return false
+	}
+
+	s.msgType = MsgRTCM3
+	s.frame = frame
+	return true
+}
+
+// scanUBX attempts to read a UBX frame after 0xB5 was consumed.
+func (s *MixedScanner) scanUBX() bool {
+	// Need sync2 + class + id + len(2) = 5 more bytes to determine frame size.
+	header, err := s.reader.Peek(5)
+	if err != nil {
+		return false
+	}
+
+	if header[0] != UBXSync2 {
+		return false // not a valid UBX frame
+	}
+
+	cls := header[1]
+	msg := header[2]
+	payloadLen := int(binary.LittleEndian.Uint16(header[3:5]))
+	remaining := 5 + payloadLen + UBXChecksumLen // sync2 + class + id + len + payload + checksum
+
+	frameBody, err := s.reader.Peek(remaining)
+	if err != nil {
+		return false
+	}
+
+	// Verify checksum over class + id + len + payload.
+	var ckA, ckB uint8
+	for i := 1; i < 5+payloadLen; i++ { // start at class (index 1 in peeked data, which is header[1])
+		ckA += frameBody[i]
+		ckB += ckA
+	}
+	if ckA != frameBody[remaining-2] || ckB != frameBody[remaining-1] {
+		return false
+	}
+
+	// Extract payload.
+	payload := make([]byte, payloadLen)
+	copy(payload, frameBody[5:5+payloadLen])
+
+	if _, err := s.reader.Discard(remaining); err != nil {
+		s.err = fmt.Errorf("discarding UBX frame: %w", err)
+		return false
+	}
+
+	s.msgType = MsgUBX
+	s.ubx = payload
+	s.ubxCls = cls
+	s.ubxMsg = msg
+	return true
+}
+
+// Type returns the type of the last scanned message.
+func (s *MixedScanner) Type() MsgType {
+	return s.msgType
+}
+
+// Frame returns the RTCM3 frame (valid only when Type() == MsgRTCM3).
+func (s *MixedScanner) Frame() Frame {
+	return s.frame
+}
+
+// UBXPayload returns the UBX payload (valid only when Type() == MsgUBX).
+func (s *MixedScanner) UBXPayload() []byte {
+	return s.ubx
+}
+
+// UBXClass returns the UBX message class.
+func (s *MixedScanner) UBXClass() byte {
+	return s.ubxCls
+}
+
+// UBXMsgID returns the UBX message ID.
+func (s *MixedScanner) UBXMsgID() byte {
+	return s.ubxMsg
+}
+
+// Err returns the first non-EOF error.
+func (s *MixedScanner) Err() error {
+	return s.err
+}

--- a/rtcm/mixed_scanner_test.go
+++ b/rtcm/mixed_scanner_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannerUBXFrame(t *testing.T) {
+	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	frame := buildUBXFrame(UBXMsgSFRBX, payload)
+
+	s := NewMixedScanner(bytes.NewReader(frame))
+	require.True(t, s.Scan())
+	require.Equal(t, MsgUBX, s.Type())
+	require.Equal(t, UBXClassRXM, s.UBXClass())
+	require.Equal(t, UBXMsgSFRBX, s.UBXMsgID())
+	require.Equal(t, payload, s.UBXPayload())
+
+	require.False(t, s.Scan())
+	require.NoError(t, s.Err())
+}
+
+func TestScannerMixedUBXAndRTCM(t *testing.T) {
+	rtcmA := Encode1033(AntennaDescriptor{StationID: 1, AntennaType: "A"})
+	ubx := buildUBXFrame(UBXMsgRAWX, []byte{1, 2, 3, 4, 5})
+	rtcmB := Encode1033(AntennaDescriptor{StationID: 2, AntennaType: "BB"})
+
+	var buf bytes.Buffer
+	buf.Write(rtcmA)
+	buf.Write(ubx)
+	buf.Write(rtcmB)
+
+	s := NewMixedScanner(&buf)
+
+	require.True(t, s.Scan())
+	require.Equal(t, MsgRTCM3, s.Type())
+	require.Equal(t, uint16(1033), s.Frame().MessageType)
+
+	require.True(t, s.Scan())
+	require.Equal(t, MsgUBX, s.Type())
+	require.Equal(t, UBXClassRXM, s.UBXClass())
+	require.Equal(t, UBXMsgRAWX, s.UBXMsgID())
+	require.Equal(t, []byte{1, 2, 3, 4, 5}, s.UBXPayload())
+
+	require.True(t, s.Scan())
+	require.Equal(t, MsgRTCM3, s.Type())
+	require.Equal(t, uint16(1033), s.Frame().MessageType)
+
+	require.False(t, s.Scan())
+	require.NoError(t, s.Err())
+}
+
+func TestScannerUBXBadChecksumResyncs(t *testing.T) {
+	bad := buildUBXFrame(UBXMsgRAWX, []byte{0x11, 0x22, 0x33})
+	bad[len(bad)-1] ^= 0xFF // corrupt the checksum
+	good := Encode1033(AntennaDescriptor{StationID: 3, AntennaType: "CCC"})
+
+	var buf bytes.Buffer
+	buf.Write(bad)
+	buf.Write(good)
+
+	s := NewMixedScanner(&buf)
+	// The corrupt UBX frame is rejected; the scanner recovers and yields the
+	// following valid RTCM3 frame.
+	require.True(t, s.Scan())
+	require.Equal(t, MsgRTCM3, s.Type())
+	require.Equal(t, uint16(1033), s.Frame().MessageType)
+}

--- a/rtcm/msm_encode.go
+++ b/rtcm/msm_encode.go
@@ -1,0 +1,393 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"math"
+	"slices"
+)
+
+const speedOfLight = 299792458.0 // m/s
+
+// GNSS signal wavelengths in meters.
+var signalWavelength = map[uint8]map[uint8]float64{
+	GnssGPS:     {0: speedOfLight / 1575.42e6, 3: speedOfLight / 1227.60e6, 4: speedOfLight / 1227.60e6, 6: speedOfLight / 1176.45e6, 7: speedOfLight / 1176.45e6},
+	GnssGalileo: {0: speedOfLight / 1575.42e6, 1: speedOfLight / 1575.42e6, 5: speedOfLight / 1176.45e6, 6: speedOfLight / 1176.45e6},
+	GnssGLONASS: {0: speedOfLight / 1602.0e6, 2: speedOfLight / 1246.0e6},
+	GnssBeiDou:  {0: speedOfLight / 1561.098e6, 2: speedOfLight / 1207.14e6},
+}
+
+// MSM7 message types per constellation.
+var msm7MsgType = map[uint8]uint16{
+	GnssGPS:     1077,
+	GnssGLONASS: 1087,
+	GnssGalileo: 1097,
+	GnssBeiDou:  1127,
+}
+
+// Signal ID to MSM signal mask bit index mapping (DF395).
+// Bit position is 0-based from MSB (bit 0 = signal 1, bit 1 = signal 2, etc.)
+// Only include primary signals to ensure single-signal frames.
+var signalMaskBit = map[uint8]map[uint8]int{
+	GnssGPS:     {0: 1}, // L1C/A only
+	GnssGalileo: {0: 1}, // E1C only
+	GnssGLONASS: {0: 1}, // L1OF only
+	GnssBeiDou:  {0: 1}, // B1I only
+}
+
+// EncodeMSM7 generates an RTCM MSM7 frame for one constellation from RAWX observations.
+// Only observations matching gnssID are included. stationID and epochMs are encoded
+// into the MSM header.
+func EncodeMSM7(stationID uint16, gnssID uint8, epochMs uint32, obs []RawxObservation) ([]byte, error) {
+	msgType, ok := msm7MsgType[gnssID]
+	if !ok {
+		return nil, nil // unsupported constellation
+	}
+
+	// Filter observations for this constellation with valid signal mapping.
+	var filtered []RawxObservation
+	for i := range obs {
+		if obs[i].GnssID != gnssID {
+			continue
+		}
+		// Skip ghost observations. u-blox receivers report satellites they
+		// track for timing without RF acquisition as zero-valued measurements
+		// (PrMes=0, CpMes=0, CNO=0). Encoding them yields all-zero MSM cells
+		// that prevent a caster from computing a position. A correct MSM
+		// encoder never emits cells for untracked signals. This encoder is the
+		// single output chokepoint, so it rejects them regardless of the caller.
+		if !obs[i].PrValid || obs[i].PrMes <= 0 || obs[i].CNO == 0 {
+			continue
+		}
+		// Only include observations with a known signal mask bit mapping.
+		if bits, ok := signalMaskBit[gnssID]; ok {
+			if _, ok := bits[obs[i].SigID]; !ok {
+				continue // unmapped signal ID, skip
+			}
+		}
+		filtered = append(filtered, obs[i])
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+
+	// Determine unique satellites and signals.
+	satSet := map[uint8]bool{}
+	sigSet := map[uint8]bool{}
+	for _, o := range filtered {
+		satSet[o.SvID] = true
+		sigSet[o.SigID] = true
+	}
+
+	sats := sortedKeys(satSet)
+	sigs := sortedKeys(sigSet)
+
+	// Build satellite mask (64 bits).
+	var satMaskHi, satMaskLo uint32
+	for _, sv := range sats {
+		bit := int(sv) - 1 // SVs are 1-based
+		if bit < 32 {
+			satMaskHi |= 1 << (31 - bit)
+		} else if bit < 64 {
+			satMaskLo |= 1 << (63 - bit)
+		}
+	}
+
+	// Build signal mask (32 bits).
+	var sigMask uint32
+	for _, sig := range sigs {
+		if bits, ok := signalMaskBit[gnssID]; ok {
+			if bit, ok := bits[sig]; ok {
+				sigMask |= 1 << (31 - bit)
+			}
+		}
+	}
+
+	// Build cell mask and cell list.
+	numSat := len(sats)
+	type cell struct {
+		satIdx int
+		sigIdx int
+		obs    RawxObservation
+	}
+	var cells []cell
+	var cellMaskBits []bool
+
+	// Map svID → satIdx, sigID → sigIdx
+	satIdx := map[uint8]int{}
+	for i, sv := range sats {
+		satIdx[sv] = i
+	}
+	sigIdx := map[uint8]int{}
+	for i, sig := range sigs {
+		sigIdx[sig] = i
+	}
+
+	// Build cell mask row by row (sat-major)
+	obsMap := map[[2]uint8]RawxObservation{}
+	for _, o := range filtered {
+		obsMap[[2]uint8{o.SvID, o.SigID}] = o
+	}
+
+	for _, sv := range sats {
+		for _, sig := range sigs {
+			if o, exists := obsMap[[2]uint8{sv, sig}]; exists {
+				cellMaskBits = append(cellMaskBits, true)
+				cells = append(cells, cell{satIdx: satIdx[sv], sigIdx: sigIdx[sig], obs: o})
+			} else {
+				cellMaskBits = append(cellMaskBits, false)
+			}
+		}
+	}
+
+	// Compute per-satellite rough range (ms) and rough phase range rate (m/s).
+	type satInfo struct {
+		roughRangeMs float64
+		roughRateMps float64
+	}
+	satData := make([]satInfo, numSat)
+	for _, c := range cells {
+		if satData[c.satIdx].roughRangeMs == 0 {
+			rangeMs := c.obs.PrMes / speedOfLight * 1000.0 // convert m to light-ms
+			satData[c.satIdx].roughRangeMs = rangeMs
+			// Rough phase range rate (DF399) is the satellite range rate in
+			// integer m/s: -Doppler[Hz] * wavelength[m]. The raw Doppler in Hz
+			// is NOT the range rate; encoding it directly produces a nonsensical
+			// phase range rate that makes casters reject the measurements.
+			wavelength := getWavelength(gnssID, c.obs.SigID, c.obs.FreqID)
+			satData[c.satIdx].roughRateMps = math.Round(-float64(c.obs.DoMes) * wavelength)
+		}
+	}
+
+	// --- Encode MSM7 ---
+	w := NewBitWriter(512)
+
+	// Header
+	w.WriteBits(uint32(msgType), 12)
+	w.WriteBits(uint32(stationID), 12)
+	w.WriteBits(epochMs, 30)
+	w.WriteBits(0, 1) // multiple message: no
+	w.WriteBits(0, 3) // IODS
+	w.WriteBits(0, 7) // reserved
+	w.WriteBits(0, 2) // clock steering
+	w.WriteBits(0, 2) // ext clock
+	w.WriteBits(0, 1) // smoothing
+	w.WriteBits(0, 3) // smoothing interval
+	w.WriteBits(satMaskHi, 32)
+	w.WriteBits(satMaskLo, 32)
+	w.WriteBits(sigMask, 32)
+
+	// Cell mask
+	for _, bit := range cellMaskBits {
+		if bit {
+			w.WriteBits(1, 1)
+		} else {
+			w.WriteBits(0, 1)
+		}
+	}
+
+	// Satellite data: rough range integer ms (8 bits per sat)
+	for i := range numSat {
+		intMs := uint32(math.Floor(satData[i].roughRangeMs))
+		if intMs > 254 {
+			intMs = 255 // invalid marker
+		}
+		w.WriteBits(intMs, 8)
+	}
+
+	// Satellite data: extended info (4 bits per sat)
+	for range numSat {
+		w.WriteBits(0, 4)
+	}
+
+	// Satellite data: rough range modulo (10 bits per sat)
+	for i := range numSat {
+		fracMs := satData[i].roughRangeMs - math.Floor(satData[i].roughRangeMs)
+		mod := min(uint32(math.Round(fracMs*1024.0)), 1023)
+		w.WriteBits(mod, 10)
+	}
+
+	// Satellite data: rough phase range rate (14 bits signed per sat, m/s)
+	for i := range numSat {
+		rate := int32(satData[i].roughRateMps)
+		if rate > 8191 {
+			rate = 8191
+		} else if rate < -8191 {
+			rate = -8191
+		}
+		w.WriteSignedBits(rate, 14)
+	}
+
+	// Signal data: fine pseudorange (20 bits signed per cell)
+	for _, c := range cells {
+		rangeMs := c.obs.PrMes / speedOfLight * 1000.0
+		roughMs := math.Floor(satData[c.satIdx].roughRangeMs) +
+			math.Round((satData[c.satIdx].roughRangeMs-math.Floor(satData[c.satIdx].roughRangeMs))*1024.0)/1024.0
+		fineMs := rangeMs - roughMs
+		// Scale: 2^-29 ms → value = fineMs / 2^-29 = fineMs * 2^29
+		val := int32(math.Round(fineMs * (1 << 29)))
+		if val > (1<<19 - 1) {
+			val = 1<<19 - 1
+		} else if val < -(1 << 19) {
+			val = -(1 << 19)
+		}
+		w.WriteSignedBits(val, 20)
+	}
+
+	// Signal data: fine phase range (24 bits signed per cell)
+	for _, c := range cells {
+		if !c.obs.CpValid {
+			w.WriteSignedBits(-1<<23, 24) // invalid marker
+			continue
+		}
+		wavelength := getWavelength(gnssID, c.obs.SigID, c.obs.FreqID)
+		rangeMs := c.obs.PrMes / speedOfLight * 1000.0
+		roughMs := math.Floor(satData[c.satIdx].roughRangeMs) +
+			math.Round((satData[c.satIdx].roughRangeMs-math.Floor(satData[c.satIdx].roughRangeMs))*1024.0)/1024.0
+		// Phase in ms: cpMes * wavelength / speedOfLight * 1000
+		phaseMs := c.obs.CpMes * wavelength / speedOfLight * 1000.0
+		finePhaseMs := phaseMs - roughMs
+		// Wrap to ±0.5 ms range
+		for finePhaseMs > 0.5 {
+			finePhaseMs -= 1.0
+		}
+		for finePhaseMs < -0.5 {
+			finePhaseMs += 1.0
+		}
+		_ = rangeMs
+		// Scale: 2^-31 ms
+		val := int32(math.Round(finePhaseMs * (1 << 31)))
+		if val > (1<<23 - 1) {
+			val = 1<<23 - 1
+		} else if val < -(1<<23 - 1) {
+			val = -(1<<23 - 1)
+		}
+		w.WriteSignedBits(val, 24)
+	}
+
+	// Signal data: lock time indicator (10 bits per cell)
+	for _, c := range cells {
+		w.WriteBits(uint32(lockTimeMsToExt(c.obs.Locktime)), 10)
+	}
+
+	// Signal data: half-cycle ambiguity indicator (DF420, 1 bit per cell).
+	// DF420 = 1 means a half-cycle ambiguity is present, i.e. the carrier
+	// phase is NOT fully resolved. The u-blox HalfCyc flag is the opposite
+	// ("half cycle valid"), so it must be inverted here. Writing it directly
+	// flags every observation as ambiguous, making casters discard all
+	// carrier phase ("lack usable measurements").
+	for _, c := range cells {
+		if c.obs.HalfCyc {
+			w.WriteBits(0, 1)
+		} else {
+			w.WriteBits(1, 1)
+		}
+	}
+
+	// Signal data: CNR (10 bits per cell, 0.0625 dB-Hz units)
+	for _, c := range cells {
+		val := min(
+			// convert 1 dB-Hz to 0.0625 dB-Hz
+			uint32(c.obs.CNO)*16, 1023)
+		w.WriteBits(val, 10)
+	}
+
+	// Signal data: fine phase range rate (15 bits signed per cell)
+	for _, c := range cells {
+		// Doppler in Hz → phase range rate = -doppler * wavelength (m/s)
+		// Fine rate = total rate - rough rate, in 0.0001 m/s units
+		wavelength := getWavelength(gnssID, c.obs.SigID, c.obs.FreqID)
+		totalRate := -float64(c.obs.DoMes) * wavelength
+		fineRate := totalRate - satData[c.satIdx].roughRateMps
+		// Scale: 0.0001 m/s
+		val := int32(math.Round(fineRate * 10000.0))
+		if val > (1<<14 - 1) {
+			val = 1<<14 - 1
+		} else if val < -(1 << 14) {
+			val = -(1 << 14)
+		}
+		w.WriteSignedBits(val, 15)
+	}
+
+	// Build complete frame.
+	payload := w.Bytes()
+	frameLen := HeaderSize + len(payload) + CRCSize
+	frame := make([]byte, frameLen)
+	frame[0] = Preamble
+	frame[1] = byte((len(payload) >> 8) & 0x03)
+	frame[2] = byte(len(payload) & 0xFF)
+	copy(frame[HeaderSize:], payload)
+
+	putCRC(frame)
+
+	return frame, nil
+}
+
+// getWavelength returns the signal wavelength for a given GNSS/signal combination.
+func getWavelength(gnssID, sigID, freqID uint8) float64 {
+	if gnssID == GnssGLONASS {
+		// GLONASS FDMA: frequency depends on slot
+		k := int(freqID) - 7 // slot offset
+		if sigID == 0 {
+			return speedOfLight / (1602.0e6 + float64(k)*562.5e3)
+		}
+		return speedOfLight / (1246.0e6 + float64(k)*437.5e3)
+	}
+	if sigs, ok := signalWavelength[gnssID]; ok {
+		if wl, ok := sigs[sigID]; ok {
+			return wl
+		}
+	}
+	return speedOfLight / 1575.42e6 // default GPS L1
+}
+
+// lockTimeMsToExt converts lock time in ms to the 10-bit extended indicator.
+func lockTimeMsToExt(ms uint16) uint16 {
+	switch {
+	case ms < 64:
+		return ms
+	case ms < 128:
+		return 64 + (ms-64)/2
+	case ms < 256:
+		return 96 + (ms-128)/4
+	case ms < 512:
+		return 128 + (ms-256)/8
+	case ms < 1024:
+		return 160 + (ms-512)/16
+	case ms < 2048:
+		return 192 + (ms-1024)/32
+	case ms < 4096:
+		return 224 + (ms-2048)/64
+	case ms < 8192:
+		return 256 + (ms-4096)/128
+	case ms < 16384:
+		return 288 + (ms-8192)/256
+	case ms < 32768:
+		return 320 + (ms-16384)/512
+	default:
+		return 352 + (ms-32768)/1024
+	}
+}
+
+func sortedKeys(m map[uint8]bool) []uint8 {
+	keys := make([]uint8, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/rtcm/msm_encode_test.go
+++ b/rtcm/msm_encode_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// decodedMSM7 holds the fields of an MSM7 message decoded for testing.
+type decodedMSM7 struct {
+	msgType, stationID uint16
+	epoch              uint32
+	multiple           bool
+	sats               []int // 1-based satellite IDs from the satellite mask
+	sigs               []int // 1-based signal IDs from the signal mask
+	cells              []bool
+	roughInt, roughMod []uint32
+	roughRate          []int32
+	finePR, finePhase  []int32
+	lock, half, cnr    []uint32
+	fineRate           []int32
+}
+
+// decodeMSM7 fully decodes an MSM7 frame by reading every field sequentially in
+// spec order (no hardcoded bit offsets), validating framing and CRC along the
+// way. It is the inverse of EncodeMSM7 and is used to verify encoder output.
+func decodeMSM7(t *testing.T, frame []byte) decodedMSM7 {
+	t.Helper()
+	require.NotNil(t, frame)
+	require.Equal(t, Preamble, frame[0])
+
+	pl := int(frame[1]&0x03)<<8 | int(frame[2])
+	require.Equal(t, HeaderSize+pl+CRCSize, len(frame), "declared length matches frame size")
+	stored := uint32(frame[len(frame)-3])<<16 | uint32(frame[len(frame)-2])<<8 | uint32(frame[len(frame)-1])
+	require.Equal(t, CRC24Q(frame[:HeaderSize+pl]), stored, "CRC-24Q")
+
+	r := NewBitReader(frame[HeaderSize : HeaderSize+pl])
+	var d decodedMSM7
+	d.msgType = uint16(r.ReadBits(12))
+	d.stationID = uint16(r.ReadBits(12))
+	d.epoch = r.ReadBits(30)
+	d.multiple = r.ReadBits(1) == 1
+	r.ReadBits(3) // IODS
+	r.ReadBits(7) // reserved
+	r.ReadBits(2) // clock steering
+	r.ReadBits(2) // external clock
+	r.ReadBits(1) // smoothing indicator
+	r.ReadBits(3) // smoothing interval
+
+	for i := range 64 {
+		if r.ReadBits(1) == 1 {
+			d.sats = append(d.sats, i+1)
+		}
+	}
+	for i := range 32 {
+		if r.ReadBits(1) == 1 {
+			d.sigs = append(d.sigs, i+1)
+		}
+	}
+	nsat, nsig := len(d.sats), len(d.sigs)
+	ncell := 0
+	for range nsat * nsig {
+		on := r.ReadBits(1) == 1
+		d.cells = append(d.cells, on)
+		if on {
+			ncell++
+		}
+	}
+
+	// Satellite data.
+	for range nsat {
+		d.roughInt = append(d.roughInt, r.ReadBits(8))
+	}
+	for range nsat {
+		r.ReadBits(4) // extended satellite info
+	}
+	for range nsat {
+		d.roughMod = append(d.roughMod, r.ReadBits(10))
+	}
+	for range nsat {
+		d.roughRate = append(d.roughRate, r.ReadSignedBits(14))
+	}
+
+	// Signal data.
+	for range ncell {
+		d.finePR = append(d.finePR, r.ReadSignedBits(20))
+	}
+	for range ncell {
+		d.finePhase = append(d.finePhase, r.ReadSignedBits(24))
+	}
+	for range ncell {
+		d.lock = append(d.lock, r.ReadBits(10))
+	}
+	for range ncell {
+		d.half = append(d.half, r.ReadBits(1))
+	}
+	for range ncell {
+		d.cnr = append(d.cnr, r.ReadBits(10))
+	}
+	for range ncell {
+		d.fineRate = append(d.fineRate, r.ReadSignedBits(15))
+	}
+
+	// Everything after the last field is byte padding (< 8 bits).
+	require.LessOrEqual(t, r.Pos(), pl*8)
+	require.Less(t, pl*8-r.Pos(), 8, "field layout exactly fills the payload")
+	return d
+}
+
+func gpsObs(sv uint8, pr, cp float64, dop float32, cno uint8) RawxObservation {
+	return RawxObservation{
+		PrMes: pr, CpMes: cp, DoMes: dop, GnssID: GnssGPS, SvID: sv, SigID: 0,
+		Locktime: 63000, CNO: cno, PrValid: true, CpValid: true, HalfCyc: true,
+	}
+}
+
+func ghostObs(sv uint8) RawxObservation {
+	return RawxObservation{GnssID: GnssGPS, SvID: sv, SigID: 0, PrValid: true}
+}
+
+func TestEncodeMSM7ValidFrame(t *testing.T) {
+	const stationID, epochMs = uint16(7), uint32(288093000)
+	obs := []RawxObservation{
+		gpsObs(4, 20960834.6, 110135576.123, -3722.4, 43),
+		gpsObs(8, 18864369.0, 99121456.789, -1825.4, 49),
+		gpsObs(9, 19008414.2, 99878123.456, -2474.4, 45),
+		gpsObs(21, 23242403.8, 122120987.654, -1072.4, 40),
+		gpsObs(27, 21312585.2, 111983456.321, -3452.4, 42),
+		ghostObs(1), // timing-only track, must be excluded
+	}
+
+	frame, err := EncodeMSM7(stationID, GnssGPS, epochMs, obs)
+	require.NoError(t, err)
+
+	d := decodeMSM7(t, frame)
+	require.Equal(t, TypeGPSMSM7, d.msgType)
+	require.Equal(t, stationID, d.stationID)
+	require.Equal(t, epochMs, d.epoch)
+	require.False(t, d.multiple, "encoder leaves the multiple-message bit clear")
+	require.Equal(t, []int{4, 8, 9, 21, 27}, d.sats, "ghost SV1 excluded")
+	require.Equal(t, []int{2}, d.sigs, "GPS L1 C/A is RTCM signal 2")
+	require.Len(t, d.cells, 5)
+	require.NotContains(t, d.sats, 1)
+}
+
+func TestEncodeMSM7NoObservationsForConstellation(t *testing.T) {
+	obs := []RawxObservation{gpsObs(5, 20000000, 105000000, -1000, 40)}
+	frame, err := EncodeMSM7(1, GnssGalileo, 100000, obs) // ask for Galileo
+	require.NoError(t, err)
+	require.Nil(t, frame, "no frame when the constellation has no observations")
+}
+
+func TestEncodeMSM7ExcludesGhostCells(t *testing.T) {
+	obs := []RawxObservation{
+		gpsObs(4, 20960834.6, 110135576.123, -3722.4, 43),
+		ghostObs(1),
+		gpsObs(8, 18864369.0, 99121456.789, -1825.4, 49),
+		ghostObs(14),
+		gpsObs(9, 19008414.2, 99878123.456, -2474.4, 45),
+		// Nonzero pseudorange but flagged invalid — also a ghost.
+		{PrMes: 21000000, GnssID: GnssGPS, SvID: 30, SigID: 0, PrValid: false},
+	}
+	frame, err := EncodeMSM7(1, GnssGPS, 288093000, obs)
+	require.NoError(t, err)
+
+	d := decodeMSM7(t, frame)
+	require.Equal(t, []int{4, 8, 9}, d.sats)
+	require.Len(t, d.cells, 3)
+	for _, c := range d.cells {
+		require.True(t, c, "single-signal frame has a cell for every satellite")
+	}
+	// No emitted cell may carry an "untracked" value.
+	for i, ri := range d.roughInt {
+		require.NotEqual(t, uint32(0), ri, "sat %d rough range is real", i)
+		require.NotEqual(t, uint32(255), ri, "sat %d rough range not the invalid marker", i)
+	}
+	for i, cnr := range d.cnr {
+		require.NotEqual(t, uint32(0), cnr, "cell %d carries real signal strength", i)
+	}
+}
+
+func TestEncodeMSM7AllGhostsYieldNilFrame(t *testing.T) {
+	obs := []RawxObservation{ghostObs(1), ghostObs(14)}
+	frame, err := EncodeMSM7(1, GnssGPS, 288093000, obs)
+	require.NoError(t, err)
+	require.Nil(t, frame)
+}
+
+func TestEncodeMSM7PhaseRangeRate(t *testing.T) {
+	// DF399 must carry the satellite range rate in m/s (-Doppler*wavelength),
+	// not the raw Doppler in Hz. Encode a known Doppler and reconstruct it from
+	// the rough (DF399) + fine (DF404) phase range rate.
+	const doppler float32 = -519.0 // Hz, satellite receding
+	obs := []RawxObservation{gpsObs(5, 20000000, 105000000, doppler, 45)}
+
+	frame, err := EncodeMSM7(1, GnssGPS, 100000, obs)
+	require.NoError(t, err)
+	d := decodeMSM7(t, frame)
+	require.Len(t, d.roughRate, 1)
+	require.Len(t, d.fineRate, 1)
+
+	wavelength := speedOfLight / 1575.42e6
+	totalRate := float64(d.roughRate[0]) + float64(d.fineRate[0])*0.0001 // m/s
+	gotDoppler := -totalRate / wavelength
+	require.InDelta(t, float64(doppler), gotDoppler, 1.0)
+	require.Positive(t, d.roughRate[0], "receding satellite has a positive range rate")
+}
+
+func TestEncodeMSM7HalfCycleInverted(t *testing.T) {
+	// DF420 (half-cycle ambiguity) is the inverse of the u-blox "half cycle
+	// valid" flag: resolved -> 0, unresolved -> 1.
+	resolved := gpsObs(5, 20000000, 105000000, -100, 45)
+	resolved.HalfCyc = true
+	d := decodeMSM7(t, mustEncode(t, resolved))
+	require.Equal(t, uint32(0), d.half[0], "resolved half cycle -> DF420 0")
+
+	unresolved := gpsObs(6, 20000000, 105000000, -100, 45)
+	unresolved.HalfCyc = false
+	d = decodeMSM7(t, mustEncode(t, unresolved))
+	require.Equal(t, uint32(1), d.half[0], "unresolved half cycle -> DF420 1")
+}
+
+func TestEncodeMSM7GLONASS(t *testing.T) {
+	// GLONASS is FDMA: the wavelength depends on the frequency channel. The
+	// encoder must still produce a valid frame with real measurements.
+	obs := []RawxObservation{
+		{PrMes: 19500000, CpMes: 104000000, DoMes: 1500, GnssID: GnssGLONASS, SvID: 3, SigID: 0, FreqID: 5, CNO: 44, PrValid: true, CpValid: true},
+		{PrMes: 21000000, CpMes: 112000000, DoMes: -2000, GnssID: GnssGLONASS, SvID: 7, SigID: 0, FreqID: 1, CNO: 41, PrValid: true, CpValid: true},
+	}
+	frame, err := EncodeMSM7(1, GnssGLONASS, 100000, obs)
+	require.NoError(t, err)
+	d := decodeMSM7(t, frame)
+	require.Equal(t, TypeGLONASSMSM7, d.msgType)
+	require.Equal(t, []int{3, 7}, d.sats)
+	for _, cnr := range d.cnr {
+		require.NotZero(t, cnr)
+	}
+}
+
+func TestEncodeMSM7FiltersByConstellation(t *testing.T) {
+	obs := []RawxObservation{
+		gpsObs(4, 20000000, 105000000, -100, 45),
+		{PrMes: 22000000, CpMes: 115000000, DoMes: -200, GnssID: GnssGalileo, SvID: 11, SigID: 0, CNO: 40, PrValid: true, CpValid: true},
+		gpsObs(9, 21000000, 110000000, -300, 43),
+	}
+	d := decodeMSM7(t, mustEncodeAll(t, obs))
+	require.Equal(t, []int{4, 9}, d.sats, "only GPS satellites encoded")
+}
+
+func TestEncodeMSM7Deterministic(t *testing.T) {
+	obs := []RawxObservation{
+		gpsObs(10, 22000000, 115600000, -2000, 45),
+		gpsObs(15, 24000000, 126100000, -1500, 42),
+	}
+	a, err := EncodeMSM7(1, GnssGPS, 200000000, obs)
+	require.NoError(t, err)
+	b, err := EncodeMSM7(1, GnssGPS, 200000000, obs)
+	require.NoError(t, err)
+	require.Equal(t, a, b, "encoding is deterministic")
+}
+
+func mustEncode(t *testing.T, obs RawxObservation) []byte {
+	t.Helper()
+	frame, err := EncodeMSM7(1, GnssGPS, 100000, []RawxObservation{obs})
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+	return frame
+}
+
+func mustEncodeAll(t *testing.T, obs []RawxObservation) []byte {
+	t.Helper()
+	frame, err := EncodeMSM7(1, GnssGPS, 100000, obs)
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+	return frame
+}

--- a/rtcm/rtcm.go
+++ b/rtcm/rtcm.go
@@ -58,12 +58,12 @@ var (
 
 // Frame represents a parsed RTCM3 frame.
 type Frame struct {
-	// MessageType is the 12-bit RTCM3 message type ID.
-	MessageType uint16
 	// Payload is the frame payload (without header and CRC).
 	Payload []byte
 	// Raw is the complete frame bytes including header, payload, and CRC.
 	Raw []byte
+	// MessageType is the 12-bit RTCM3 message type ID.
+	MessageType uint16
 }
 
 // PayloadLen extracts the 10-bit payload length from a 3-byte RTCM3 header.
@@ -151,4 +151,51 @@ func CRC24Q(data []byte) uint32 {
 		crc = (crc << 8) ^ crc24qTable[((crc>>16)^uint32(b))&0xFF]
 	}
 	return crc & 0xFFFFFF
+}
+
+// putCRC computes the CRC-24Q over all but the last three bytes of frame and
+// writes the checksum into them.
+func putCRC(frame []byte) {
+	crc := CRC24Q(frame[:len(frame)-CRCSize])
+	frame[len(frame)-3] = byte((crc >> 16) & 0xFF)
+	frame[len(frame)-2] = byte((crc >> 8) & 0xFF)
+	frame[len(frame)-1] = byte(crc & 0xFF)
+}
+
+// PatchStationID sets the 12-bit Reference Station ID (DF003, bits 12-23
+// of the payload) in any RTCM3 frame and recomputes the CRC.
+func PatchStationID(frame []byte, id uint16) []byte {
+	if len(frame) < 6 {
+		return frame
+	}
+	patched := make([]byte, len(frame))
+	copy(patched, frame)
+
+	// DF003 is bits 12-23 of payload. Payload starts at frame[3].
+	// Bits 12-15 are the lower 4 bits of payload byte 1 (frame[4]).
+	// Bits 16-23 are all of payload byte 2 (frame[5]).
+	patched[4] = (patched[4] & 0xF0) | byte((id>>8)&0x0F)
+	patched[5] = byte(id & 0xFF)
+
+	putCRC(patched)
+	return patched
+}
+
+// Patch1005RefStation sets the Reference Station Indicator (DF141) to 1
+// in an RTCM 1005 frame and recomputes the CRC. DF141 is bit 33 of the
+// payload (0-indexed), which is byte 7 bit 6 of the raw frame.
+func Patch1005RefStation(frame []byte) []byte {
+	if len(frame) < 8 {
+		return frame
+	}
+	patched := make([]byte, len(frame))
+	copy(patched, frame)
+
+	// DF141 is at payload bit 33.
+	// Payload starts at frame byte 3.
+	// Bit 33 = byte 4 of payload = byte 7 of frame, bit position 6.
+	patched[7] |= 0x40
+
+	putCRC(patched)
+	return patched
 }

--- a/rtcm/ubx.go
+++ b/rtcm/ubx.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// UBX frame constants.
+const (
+	UBXSync1 byte = 0xB5
+	UBXSync2 byte = 0x62
+
+	UBXClassRXM byte = 0x02
+	UBXMsgRAWX  byte = 0x15
+	UBXMsgSFRBX byte = 0x13
+
+	UBXHeaderSize  = 6 // sync(2) + class(1) + id(1) + len(2)
+	UBXChecksumLen = 2
+)
+
+// GNSS system identifiers from UBX protocol.
+const (
+	GnssGPS     uint8 = 0
+	GnssSBAS    uint8 = 1
+	GnssGalileo uint8 = 2
+	GnssBeiDou  uint8 = 3
+	GnssQZSS    uint8 = 5
+	GnssGLONASS uint8 = 6
+)
+
+// RawxObservation holds one satellite/signal measurement from UBX-RXM-RAWX.
+type RawxObservation struct {
+	PrMes    float64 // Pseudorange measurement [m]
+	CpMes    float64 // Carrier phase measurement [cycles]
+	DoMes    float32 // Doppler measurement [Hz]
+	GnssID   uint8   // GNSS identifier
+	SvID     uint8   // Satellite identifier
+	SigID    uint8   // Signal identifier
+	FreqID   uint8   // GLONASS frequency slot
+	Locktime uint16  // Carrier phase lock time [ms]
+	CNO      uint8   // Carrier-to-noise ratio [dB-Hz]
+	PrValid  bool    // Pseudorange valid
+	CpValid  bool    // Carrier phase valid
+	HalfCyc  bool    // Half cycle resolved
+}
+
+// RawxEpoch holds all observations from one UBX-RXM-RAWX message.
+type RawxEpoch struct {
+	Observations []RawxObservation // Per-satellite measurements
+	RcvTow       float64           // Receiver time of week [s]
+	Week         uint16            // GPS week number
+	LeapS        int8              // GPS-UTC leap seconds
+}
+
+// ParseUBXFrame validates a UBX frame starting at data[0] and returns the
+// payload and total frame length consumed. Returns an error if the frame
+// is incomplete or checksum fails.
+func ParseUBXFrame(data []byte) (payload []byte, frameLen int, err error) {
+	if len(data) < UBXHeaderSize+UBXChecksumLen {
+		return nil, 0, fmt.Errorf("UBX frame too short: %d bytes", len(data))
+	}
+	if data[0] != UBXSync1 || data[1] != UBXSync2 {
+		return nil, 0, fmt.Errorf("invalid UBX sync bytes")
+	}
+
+	payloadLen := int(binary.LittleEndian.Uint16(data[4:6]))
+	frameLen = UBXHeaderSize + payloadLen + UBXChecksumLen
+	if len(data) < frameLen {
+		return nil, 0, fmt.Errorf("UBX frame incomplete: need %d, have %d", frameLen, len(data))
+	}
+
+	// Verify Fletcher-8 checksum over class+id+len+payload.
+	var ckA, ckB uint8
+	for i := 2; i < UBXHeaderSize+payloadLen; i++ {
+		ckA += data[i]
+		ckB += ckA
+	}
+	if ckA != data[frameLen-2] || ckB != data[frameLen-1] {
+		return nil, 0, fmt.Errorf("UBX checksum mismatch")
+	}
+
+	return data[UBXHeaderSize : UBXHeaderSize+payloadLen], frameLen, nil
+}
+
+// ParseRawx decodes a UBX-RXM-RAWX payload into an epoch with observations.
+func ParseRawx(payload []byte) (RawxEpoch, error) {
+	if len(payload) < 16 {
+		return RawxEpoch{}, fmt.Errorf("RAWX payload too short: %d", len(payload))
+	}
+
+	var epoch RawxEpoch
+	epoch.RcvTow = math.Float64frombits(binary.LittleEndian.Uint64(payload[0:8]))
+	epoch.Week = binary.LittleEndian.Uint16(payload[8:10])
+	epoch.LeapS = int8(payload[10] & 0x7F) // GPS leap seconds are small and non-negative
+	numMeas := int(payload[11])
+
+	if len(payload) < 16+numMeas*32 {
+		return RawxEpoch{}, fmt.Errorf("RAWX payload truncated: need %d, have %d",
+			16+numMeas*32, len(payload))
+	}
+
+	epoch.Observations = make([]RawxObservation, 0, numMeas)
+	for i := range numMeas {
+		off := 16 + i*32
+		obs := RawxObservation{
+			PrMes:    math.Float64frombits(binary.LittleEndian.Uint64(payload[off : off+8])),
+			CpMes:    math.Float64frombits(binary.LittleEndian.Uint64(payload[off+8 : off+16])),
+			DoMes:    math.Float32frombits(binary.LittleEndian.Uint32(payload[off+16 : off+20])),
+			GnssID:   payload[off+20],
+			SvID:     payload[off+21],
+			SigID:    payload[off+22],
+			FreqID:   payload[off+23],
+			Locktime: binary.LittleEndian.Uint16(payload[off+24 : off+26]),
+			CNO:      payload[off+26],
+		}
+		trkStat := payload[off+30]
+		obs.PrValid = trkStat&0x01 != 0
+		obs.CpValid = trkStat&0x02 != 0
+		obs.HalfCyc = trkStat&0x04 != 0
+
+		// Only include observations with valid, nonzero pseudorange and signal.
+		if obs.PrValid && obs.PrMes > 0 && obs.CNO > 0 {
+			epoch.Observations = append(epoch.Observations, obs)
+		}
+	}
+
+	return epoch, nil
+}

--- a/rtcm/ubx_test.go
+++ b/rtcm/ubx_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rtcm
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildRawxPayload assembles a synthetic UBX-RXM-RAWX message payload from a
+// set of observations, mirroring the u-blox wire layout. The header uses a
+// fixed GPS week (2360) and leap-second count (18).
+func buildRawxPayload(tow float64, obs []RawxObservation) []byte {
+	p := make([]byte, 16+len(obs)*32)
+	binary.LittleEndian.PutUint64(p[0:8], math.Float64bits(tow))
+	binary.LittleEndian.PutUint16(p[8:10], 2360)
+	p[10] = 18
+	p[11] = byte(len(obs))
+	for i, o := range obs {
+		off := 16 + i*32
+		binary.LittleEndian.PutUint64(p[off:off+8], math.Float64bits(o.PrMes))
+		binary.LittleEndian.PutUint64(p[off+8:off+16], math.Float64bits(o.CpMes))
+		binary.LittleEndian.PutUint32(p[off+16:off+20], math.Float32bits(o.DoMes))
+		p[off+20] = o.GnssID
+		p[off+21] = o.SvID
+		p[off+22] = o.SigID
+		p[off+23] = o.FreqID
+		binary.LittleEndian.PutUint16(p[off+24:off+26], o.Locktime)
+		p[off+26] = o.CNO
+		var trkStat byte
+		if o.PrValid {
+			trkStat |= 0x01
+		}
+		if o.CpValid {
+			trkStat |= 0x02
+		}
+		if o.HalfCyc {
+			trkStat |= 0x04
+		}
+		p[off+30] = trkStat
+	}
+	return p
+}
+
+// buildUBXFrame wraps a payload in a UBX frame (sync, class, id, length,
+// payload, Fletcher-8 checksum).
+func buildUBXFrame(msg byte, payload []byte) []byte {
+	frame := make([]byte, UBXHeaderSize+len(payload)+UBXChecksumLen)
+	frame[0] = UBXSync1
+	frame[1] = UBXSync2
+	frame[2] = UBXClassRXM
+	frame[3] = msg
+	binary.LittleEndian.PutUint16(frame[4:6], uint16(len(payload)))
+	copy(frame[UBXHeaderSize:], payload)
+	var ckA, ckB uint8
+	for i := 2; i < UBXHeaderSize+len(payload); i++ {
+		ckA += frame[i]
+		ckB += ckA
+	}
+	frame[len(frame)-2] = ckA
+	frame[len(frame)-1] = ckB
+	return frame
+}
+
+func TestParseRawxFields(t *testing.T) {
+	in := []RawxObservation{
+		{
+			PrMes: 20000000.5, CpMes: 105000000.25, DoMes: -1234.5,
+			GnssID: GnssGPS, SvID: 7, SigID: 0, FreqID: 0,
+			Locktime: 12000, CNO: 45, PrValid: true, CpValid: true, HalfCyc: true,
+		},
+	}
+	epoch, err := ParseRawx(buildRawxPayload(296966.995, in))
+	require.NoError(t, err)
+	require.InDelta(t, 296966.995, epoch.RcvTow, 1e-6)
+	require.Equal(t, uint16(2360), epoch.Week)
+	require.Equal(t, int8(18), epoch.LeapS)
+	require.Len(t, epoch.Observations, 1)
+
+	got := epoch.Observations[0]
+	require.InDelta(t, 20000000.5, got.PrMes, 1e-6)
+	require.InDelta(t, 105000000.25, got.CpMes, 1e-6)
+	require.InDelta(t, -1234.5, float64(got.DoMes), 1e-3)
+	require.Equal(t, GnssGPS, got.GnssID)
+	require.Equal(t, uint8(7), got.SvID)
+	require.Equal(t, uint16(12000), got.Locktime)
+	require.Equal(t, uint8(45), got.CNO)
+	require.True(t, got.PrValid)
+	require.True(t, got.CpValid)
+	require.True(t, got.HalfCyc)
+}
+
+func TestParseRawxFiltersGhosts(t *testing.T) {
+	in := []RawxObservation{
+		// Good observation — kept.
+		{PrMes: 21000000, CpMes: 1, DoMes: 1, GnssID: GnssGPS, SvID: 1, CNO: 40, PrValid: true},
+		// Pseudorange not valid — dropped.
+		{PrMes: 21000000, GnssID: GnssGPS, SvID: 2, CNO: 40, PrValid: false},
+		// Zero pseudorange — dropped (timing-only "ghost").
+		{PrMes: 0, GnssID: GnssGPS, SvID: 3, CNO: 40, PrValid: true},
+		// Zero CNR — dropped.
+		{PrMes: 21000000, GnssID: GnssGPS, SvID: 4, CNO: 0, PrValid: true},
+		// Another good one — kept.
+		{PrMes: 22000000, GnssID: GnssGalileo, SvID: 5, CNO: 38, PrValid: true},
+	}
+	epoch, err := ParseRawx(buildRawxPayload(100.0, in))
+	require.NoError(t, err)
+	require.Len(t, epoch.Observations, 2, "only valid, nonzero observations survive")
+	require.Equal(t, uint8(1), epoch.Observations[0].SvID)
+	require.Equal(t, uint8(5), epoch.Observations[1].SvID)
+}
+
+func TestParseRawxTooShort(t *testing.T) {
+	_, err := ParseRawx(make([]byte, 8))
+	require.Error(t, err)
+}
+
+func TestParseRawxTruncated(t *testing.T) {
+	// Header claims 3 measurements but the buffer only holds one.
+	p := buildRawxPayload(100, []RawxObservation{
+		{PrMes: 1, GnssID: GnssGPS, SvID: 1, CNO: 40, PrValid: true},
+	})
+	p[11] = 3 // lie about the measurement count
+	_, err := ParseRawx(p)
+	require.Error(t, err)
+}
+
+func TestParseUBXFrameRoundTrip(t *testing.T) {
+	payload := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	frame := buildUBXFrame(UBXMsgRAWX, payload)
+
+	got, frameLen, err := ParseUBXFrame(frame)
+	require.NoError(t, err)
+	require.Equal(t, len(frame), frameLen)
+	require.Equal(t, payload, got)
+}
+
+func TestParseUBXFrameBadChecksum(t *testing.T) {
+	frame := buildUBXFrame(UBXMsgRAWX, []byte{0xDE, 0xAD})
+	frame[len(frame)-1] ^= 0xFF // corrupt checksum
+	_, _, err := ParseUBXFrame(frame)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Summary:
ntripper turns a u-blox ZED-F9 series GNSS receiver into an NTRIP base
station. It reads RTCM3, UBX-RXM-RAWX (raw observations) and UBX-RXM-SFRBX
(navigation subframes) from an oscillatord Unix socket and pushes RTCM
corrections to an NTRIP caster over NTRIP v1 (SOURCE) or v2 (HTTP POST),
optionally through an HTTP CONNECT proxy.

- Generates MSM7 observation messages (1077/1087/1097/1127) for GPS,
  GLONASS, Galileo and BeiDou from the raw measurements.
- Decodes GPS broadcast ephemeris (RTCM 1019) from navigation subframes,
  which casters need to position the satellites.
- Forwards the station ARP (1005), GLONASS code-phase biases (1230) and an
  antenna descriptor (1033).

Adds a self-contained rtcm package (RTCM3 framing and CRC-24Q, a bit
reader/writer, UBX RAWX/SFRBX parsing, MSM7/1033/1019 encoders, GPS
ephemeris assembly, and a mixed UBX/RTCM3 scanner), the ntripper command
and an ntrip client. Diagnostic modes: -dry-run, -dump, -parse, -rawx-stats.

Differential Revision: D106543636


