### PR TITLE
Preallocate raw slice in TestDecodeClientAccessesByIndex3Empty

### DIFF
--- a/ntp/chrony/packet_test.go
+++ b/ntp/chrony/packet_test.go
@@ -827,7 +827,7 @@ func TestDecodeClientAccessesByIndex3(t *testing.T) {
 }
 
 func TestDecodeClientAccessesByIndex3Empty(t *testing.T) {
-	raw := []uint8{
+	head := []uint8{
 		// Reply head
 		0x06, 0x02, 0x00, 0x00, 0x00, 0x44, 0x00, 0x15, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef,
@@ -837,6 +837,8 @@ func TestDecodeClientAccessesByIndex3Empty(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00,
 	}
+	raw := make([]uint8, 0, len(head)+8*60)
+	raw = append(raw, head...)
 	raw = append(raw, make([]uint8, 8*60)...)
 
 	packet, err := decodePacket(raw)


### PR DESCRIPTION
Summary:
golangci-lint (prealloc) fails on the public github.com/facebook/time CI:

  ntp/chrony/packet_test.go: Consider preallocating raw (prealloc)
      raw := []uint8{

TestDecodeClientAccessesByIndex3Empty seeds raw as a literal and then grows
it with raw = append(raw, make([]uint8, 8*60)...), which prealloc flags.
Preallocate the backing array up front (len(head)+8*60) and append into it so
the capacity is known, satisfying the linter without changing the bytes
decoded.

Differential Revision: D107549224


