### PR TITLE
Harden build flags so fbclock-bin passes Fedora annocheck

### DIFF
--- a/cmd/fbclock-bin/Makefile
+++ b/cmd/fbclock-bin/Makefile
@@ -1,13 +1,23 @@
-CC=gcc
-CFLAGS+=-g -lrt
+CC ?= gcc
+CFLAGS += -g
+
+# Security hardening so the binary passes annocheck/Fedora hardened-build checks
+# (bind-now, pie, cf-protection, property-note). $(CFLAGS)/$(LDFLAGS) are honored
+# so a distro spec (e.g. Fedora %set_build_flags) can still extend/override them.
+CFLAGS += -fPIE -fstack-protector-strong
+LDFLAGS += -pie -Wl,-z,now -Wl,-z,relro
+LDLIBS += -lrt
 
 arch := $(shell arch)
 ifeq ($(arch),x86_64)
-	CFLAGS += -msse4.2
+	CFLAGS += -msse4.2 -fcf-protection=full
+endif
+ifeq ($(arch),aarch64)
+	CFLAGS += -mbranch-protection=standard
 endif
 
 fbclock-bin:
-	$(CC) $(CFLAGS) -o fbclock-bin fbclock-bin.c ../../fbclock/fbclock.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o fbclock-bin fbclock-bin.c ../../fbclock/fbclock.c $(LDLIBS)
 
 .PHONY: clean
 

--- a/fbclock/Makefile
+++ b/fbclock/Makefile
@@ -1,9 +1,24 @@
-CC=gcc
-CFLAGS=-Wall -g -lrt -msse4.2 -std=gnu11
+CC ?= gcc
+CFLAGS += -Wall -g -std=gnu11
 CPP=g++
 CPPFLAGS=-fpermissive -lrt -lpthread -msse4.2 -lgtest -g
-AR=ar
+AR ?= ar
 ARFLAGS=rcs
+
+# Security hardening so the artifacts pass annocheck/Fedora hardened-build checks
+# (bind-now, cf-protection, property-note). $(CFLAGS)/$(LDFLAGS) are honored so a
+# distro spec (e.g. Fedora %set_build_flags) can still extend/override them.
+CFLAGS += -fstack-protector-strong
+LDFLAGS += -Wl,-z,now -Wl,-z,relro
+LDLIBS += -lrt
+
+arch := $(shell arch)
+ifeq ($(arch),x86_64)
+	CFLAGS += -msse4.2 -fcf-protection=full
+endif
+ifeq ($(arch),aarch64)
+	CFLAGS += -mbranch-protection=standard
+endif
 
 .PHONY: clean test
 
@@ -11,7 +26,7 @@ BUILDDIR ?= .
 
 fbclock:
 	mkdir -p $(BUILDDIR)
-	$(CC) $(CFLAGS) -shared -o $(BUILDDIR)/fbclock.so -fPIC fbclock.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -fPIC -o $(BUILDDIR)/fbclock.so fbclock.c $(LDLIBS)
 
 fbclock-static:
 	mkdir -p $(BUILDDIR)


### PR DESCRIPTION
Summary:
The Fedora package build (golang-github-facebook-time, mirrored from fbcode/time
via ShipIt to github.com/facebook/time) runs annocheck on /usr/bin/fbclock-bin
and fails the "hardened" profile on ALL four built arches (x86_64, aarch64,
ppc64le, s390x):

  bind-now                       FAIL on all 4 arches  (not linked -Wl,-z,now)
  pie                            FAIL on all 4 arches  (not linked -Wl,-pie)
  cf-protection / property-note  FAIL on x86_64 and aarch64 (no .note.gnu.property)

The spec builds the C binary via `cd cmd/fbclock-bin && %make_build`, so the
hand-written cmd/fbclock-bin/Makefile is the only thing that controls the binary's
flags. It had two independent problems:

- The link recipe never referenced $(LDFLAGS), so -pie / -Wl,-z,now never reached
  the link -> bind-now + pie fail on every arch. (The x86_64 annocheck confirms
  this: `pic` PASSes -- -fPIE was seen at compile -- while `pie` FAILs because
  -pie was absent at link.)
- Its own CFLAGS carried no control-flow hardening, so the objects emitted no
  CET/BTI GNU-property note -> cf-protection / property-note fail on x86_64 and
  aarch64. ppc64le/s390x have no ISA control-flow test in annocheck (those checks
  are skipped), so only bind-now + pie were failing there.

Fix: bake the hardening into the Makefile and honor $(CFLAGS)/$(LDFLAGS):
- all arches: -fPIE -fstack-protector-strong (compile); -pie -Wl,-z,now
  -Wl,-z,relro (link)
- x86_64: -fcf-protection=full (CET IBT+SHSTK)
- aarch64: -mbranch-protection=standard (BTI+PAC)
- ppc64le/s390x: no ISA control-flow flag needed; they pass on the base flags
CC/AR -> ?= and CFLAGS -> += so the distro spec (Fedora %set_build_flags) can
still extend or override. ISA flags are arch-guarded so no arch sees an
unsupported flag. fbclock.c already provides a portable CRC fallback for
non-x86/non-aarch64, so ppc64le/s390x need no source change.

The same hardening is applied to time/fbclock/Makefile (shared lib) for
consistency; that Makefile is not built by the Fedora spec.

No spec change is required -- once this lands and mirrors to
github.com/facebook/time, the Fedora package only needs its %commit bump.

Reviewed By: ESoapW

Differential Revision: D107654325


