### PR TITLE
add a gradual warm-up window to stop API errors after restart

### DIFF
--- a/cmd/fbclock-daemon/main.go
+++ b/cmd/fbclock-daemon/main.go
@@ -62,6 +62,7 @@ func main() {
 	flag.DurationVar(&cfg.LinearizabilityTestInterval, "I", time.Minute, "Interval at which we run linearizability tests. 0 means disabled")
 	flag.DurationVar(&cfg.LinearizabilityTestMaxGMOffset, "o", 10*time.Microsecond, "Max offset between GMs before linearizability test considered failed")
 	flag.DurationVar(&cfg.BootDelay, "b", 0, "Postpone startup by this time after boot")
+	flag.BoolVar(&cfg.GradualWindow, "gradualwindow", false, "Publish a widened window from the first sample after a restart (default off)")
 	flag.StringVar(&cfgPath, "cfg", "", "Path to config")
 	flag.BoolVar(&manageDevice, "manage", true, fmt.Sprintf("Manage device. This will setup %q as a copy of PHC device associated with given network interface", daemon.ManagedPTPDevicePath))
 	flag.BoolVar(&csvLog, "csvlog", true, "Log all the metrics as CSV to log")

--- a/fbclock/daemon/config.go
+++ b/fbclock/daemon/config.go
@@ -19,6 +19,7 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/facebook/time/phc/unix"
@@ -38,6 +39,9 @@ type Config struct {
 	LinearizabilityTestMaxGMOffset time.Duration // max offset between GMs before linearizability test considered failed
 	BootDelay                      time.Duration // postpone startup by this time after boot
 	EnableDataV2                   bool          // enable fbclock data v2
+	GradualWindow                  bool          // publish a widened window from the first sample after restart (default off)
+	// kFactors is the precomputed warm-up tolerance-factor table k[2..RingSize], looked up per tick.
+	kFactors []float64
 }
 
 // EvalAndValidate makes sure config is valid and evaluates expressions for further use.
@@ -59,7 +63,27 @@ func (c *Config) EvalAndValidate() error {
 	if c.LinearizabilityTestMaxGMOffset < 0 {
 		return fmt.Errorf("bad config: 'offset' must be positive")
 	}
-	return c.Math.Prepare()
+	if err := c.Math.Prepare(); err != nil {
+		return err
+	}
+	// Fail closed: -gradualwindow relaxes the publish gate to n=2, so a custom -w without k would apply a
+	// flat 4.0 to a 2-sample stddev. Require k in the W expression.
+	if c.GradualWindow && !slices.Contains(c.Math.wExpr.Vars(), "k") {
+		return fmt.Errorf("bad config: 'gradualwindow' requires the W expression to reference 'k' (got %q)", c.Math.W)
+	}
+	// Precompute the data-independent factor table once at parse; only used when GradualWindow is on.
+	c.kFactors = precomputeGradualWindowFactors(c.RingSize, warmupConfidence)
+	return nil
+}
+
+// gradualFactor returns the precomputed warm-up factor for n samples, falling back to coverageZP (4.0)
+// when the table is absent (tests calling Math.Prepare directly) or n is outside [2, RingSize]. The
+// flag-off path only ever hits n == RingSize, where the factor is 4.0, so it stays byte-identical.
+func (c *Config) gradualFactor(n int) float64 {
+	if n >= 2 && n < len(c.kFactors) {
+		return c.kFactors[n]
+	}
+	return coverageZP
 }
 
 // PostponeStart postpones startup by BootDelay

--- a/fbclock/daemon/config_test.go
+++ b/fbclock/daemon/config_test.go
@@ -65,3 +65,45 @@ func TestPostponeStart(t *testing.T) {
 	require.True(t, time.Since(start) >= delay)
 	require.NoError(t, err)
 }
+
+// TestConfigBuildsKFactors checks EvalAndValidate precomputes the warm-up tolerance-factor table
+// (k[2..RingSize]) at parse time, so the per-tick hot path is just a lookup. gamma is no longer a config
+// field -- the warm-up confidence is hardcoded (warmupConfidence), so there is nothing to validate.
+func TestConfigBuildsKFactors(t *testing.T) {
+	cfg := &Config{
+		PTPClientAddress: "/tmp/fbclock-test",
+		RingSize:         30,
+		Interval:         time.Second,
+		Math: Math{
+			M:     MathDefaultM,
+			W:     MathDefaultW,
+			Drift: MathDefaultDrift,
+		},
+	}
+	require.NoError(t, cfg.EvalAndValidate())
+	require.Len(t, cfg.kFactors, cfg.RingSize+1)
+}
+
+// TestConfigGradualWindowRequiresK locks the fail-closed guard: with GradualWindow on, a W formula that
+// never references k is rejected at parse (it would apply a flat 4.0 to a 2-sample stddev); the default W
+// (which uses k) is accepted; and with the flag off the same k-less formula is fine.
+func TestConfigGradualWindowRequiresK(t *testing.T) {
+	const wNoK = "mean(m, 100) + 4.0 * stddev(m, 100)"
+	makeCfg := func(gradual bool, w string) *Config {
+		return &Config{
+			PTPClientAddress: "/tmp/fbclock-test",
+			RingSize:         30,
+			Interval:         time.Second,
+			GradualWindow:    gradual,
+			Math: Math{
+				M:     MathDefaultM,
+				W:     w,
+				Drift: MathDefaultDrift,
+			},
+		}
+	}
+
+	require.Error(t, makeCfg(true, wNoK).EvalAndValidate(), "gradualwindow + W without k must fail closed")
+	require.NoError(t, makeCfg(true, MathDefaultW).EvalAndValidate(), "gradualwindow + default W (has k) must pass")
+	require.NoError(t, makeCfg(false, wNoK).EvalAndValidate(), "flag off + W without k must pass")
+}

--- a/fbclock/daemon/daemon.go
+++ b/fbclock/daemon/daemon.go
@@ -283,7 +283,7 @@ func (s *Daemon) calcW() (float64, error) {
 		FreqAdjustmentPPB:       params["freq"][0],
 		FreqAdjustmentMeanPPB:   mean(params["freq"]),
 		FreqAdjustmentStddevPPB: stddev(params["freq"]),
-		ClockAccuracyMean:       mean(params["clockaccuracie"]),
+		ClockAccuracyMean:       mean(params["clockaccuracy"]),
 	}
 	mRaw, err := s.cfg.Math.mExpr.Evaluate(mapOfInterface(params))
 	if err != nil {
@@ -297,12 +297,23 @@ func (s *Daemon) calcW() (float64, error) {
 	s.state.pushM(m)
 
 	ms := s.state.takeM(s.cfg.RingSize)
-	if len(ms) != s.cfg.RingSize {
-		return 0, fmt.Errorf("%w getting W: want %d, got %d", errNotEnoughData, s.cfg.RingSize, len(ms))
+	minN := s.cfg.RingSize
+	if s.cfg.GradualWindow {
+		// Publish from n=2 (skip n=1: stddev is 0). len(ms) <= RingSize, so flag-off keeps today's gate.
+		minN = 2
+	}
+	if len(ms) < minN {
+		return 0, fmt.Errorf("%w getting W: want >= %d, got %d", errNotEnoughData, minN, len(ms))
 	}
 
+	n := len(ms)
+	// k is the precomputed factor for this sample count: coverageZP (4.0) at the full ring, so steady
+	// state and the flag-off path stay byte-identical. n and k are always injected; govaluate ignores
+	// vars a formula does not reference.
 	parameters := map[string]any{
 		"m": ms,
+		"n": float64(n),
+		"k": s.cfg.gradualFactor(n),
 	}
 	logSample.MeasurementMeanNS = mean(ms)
 	logSample.MeasurementStddevNS = stddev(ms)
@@ -322,8 +333,14 @@ func (s *Daemon) calcW() (float64, error) {
 
 func (s *Daemon) calcDriftPPB() (float64, error) {
 	lastN := s.state.takeDataPoint(s.cfg.RingSize)
-	if len(lastN) != s.cfg.RingSize {
-		return 0, fmt.Errorf("%w calculating drift: want %d, got %d", errNotEnoughData, s.cfg.RingSize, len(lastN))
+	minN := s.cfg.RingSize
+	if s.cfg.GradualWindow {
+		// Relax with the W gate: drift has no factor, but if it still required a full ring doWork would
+		// swallow the error and publish nothing. At n=2 freqchangeabs has one value.
+		minN = 2
+	}
+	if len(lastN) < minN {
+		return 0, fmt.Errorf("%w calculating drift: want >= %d, got %d", errNotEnoughData, minN, len(lastN))
 	}
 	params := prepareMathParameters(lastN)
 	driftRaw, err := s.cfg.Math.driftExpr.Evaluate(mapOfInterface(params))

--- a/fbclock/daemon/daemon_test.go
+++ b/fbclock/daemon/daemon_test.go
@@ -18,6 +18,7 @@ package daemon
 
 import (
 	"context"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -744,4 +745,125 @@ func TestCoeffV2(t *testing.T) {
 	c, err = calcCoeffPPB(&prevDataV2, &curDataV2)
 	require.Equal(t, int64(-493), c)
 	require.NoError(t, err)
+}
+
+// TestDaemonGradualWindowFromN2 verifies that with GradualWindow on the daemon skips n=1 and publishes
+// from n=2 (with the precomputed tolerance factor), and that with the flag off the same formula keeps
+// today's "nothing until the ring is full" behavior.
+func TestDaemonGradualWindowFromN2(t *testing.T) {
+	makeCfg := func(gradual bool) *Config {
+		cfg := &Config{
+			PTPClientAddress: "/tmp/fbclock-test",
+			RingSize:         30,
+			GradualWindow:    gradual,
+			Interval:         time.Second,
+			Math: Math{
+				M:     MathDefaultM,
+				W:     MathDefaultW,
+				Drift: MathDefaultDrift,
+			},
+		}
+		// EvalAndValidate (not Math.Prepare) so the warm-up factor table is precomputed.
+		require.NoError(t, cfg.EvalAndValidate())
+		return cfg
+	}
+	leaps := []leapsectz.LeapSecond{
+		{Tleap: 1435708825, Nleap: 26},
+		{Tleap: 1483228826, Nleap: 27},
+	}
+	startTime := time.Duration(1647359186979431900)
+	// Varying offset so stddev(m) > 0 and the warm-up factor actually widens the window.
+	sample := func(i int) *DataPoint {
+		return &DataPoint{
+			IngressTimeNS:     int64(startTime + time.Duration(i)*time.Second),
+			MasterOffsetNS:    float64(20 + (i%5)*3),
+			PathDelayNS:       213.0,
+			FreqAdjustmentPPB: float64(212131 + i),
+			ClockAccuracyNS:   100.0,
+			ServoState:        2,
+		}
+	}
+
+	// Flag ON: n=1 is skipped; publishes from n=2; window stays under the uint32 sentinel.
+	dOn := newTestDaemon(makeCfg(true), stats.NewStats())
+	for i := range 30 {
+		shmData, err := dOn.calculateSHMData(sample(i), leaps)
+		if i == 0 {
+			require.Error(t, err, "n=1 must be skipped (stddev=0, no margin)")
+			require.Nil(t, shmData)
+			continue
+		}
+		require.NoErrorf(t, err, "gradual window should publish from n=2 (i=%d)", i)
+		require.NotNil(t, shmData)
+		require.Greater(t, shmData.ErrorBoundNS, uint64(0))
+		require.Less(t, shmData.ErrorBoundNS, uint64(math.MaxUint32), "window must never reach the uint32 WOU sentinel")
+	}
+
+	// Flag OFF (same gradual formula): unchanged behavior, nothing until the ring is full.
+	dOff := newTestDaemon(makeCfg(false), stats.NewStats())
+	for i := range 30 {
+		shmData, err := dOff.calculateSHMData(sample(i), leaps)
+		if i < 29 {
+			require.Error(t, err, "flag off must not publish before the ring is full")
+			require.Nil(t, shmData)
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, shmData)
+		}
+	}
+}
+
+// TestDaemonGradualWindowSteadyStateIdentical locks the core invariant: once the ring is full the
+// GradualWindow flag changes nothing. It drives a flag-on and a flag-off daemon through the SAME ring
+// size and SAME sample sequence, and asserts the published ErrorBoundNS is identical at n == RingSize.
+func TestDaemonGradualWindowSteadyStateIdentical(t *testing.T) {
+	const ringSize = 30
+	makeCfg := func(gradual bool) *Config {
+		cfg := &Config{
+			PTPClientAddress: "/tmp/fbclock-test",
+			RingSize:         ringSize,
+			GradualWindow:    gradual,
+			Interval:         time.Second,
+			Math: Math{
+				M:     MathDefaultM,
+				W:     MathDefaultW,
+				Drift: MathDefaultDrift,
+			},
+		}
+		// EvalAndValidate (not Math.Prepare) so the warm-up factor table is precomputed.
+		require.NoError(t, cfg.EvalAndValidate())
+		return cfg
+	}
+	leaps := []leapsectz.LeapSecond{
+		{Tleap: 1435708825, Nleap: 26},
+		{Tleap: 1483228826, Nleap: 27},
+	}
+	startTime := time.Duration(1647359186979431900)
+	sample := func(i int) *DataPoint {
+		return &DataPoint{
+			IngressTimeNS:     int64(startTime + time.Duration(i)*time.Second),
+			MasterOffsetNS:    float64(20 + (i%5)*3),
+			PathDelayNS:       213.0,
+			FreqAdjustmentPPB: float64(212131 + i),
+			ClockAccuracyNS:   100.0,
+			ServoState:        2,
+		}
+	}
+
+	dOn := newTestDaemon(makeCfg(true), stats.NewStats())
+	dOff := newTestDaemon(makeCfg(false), stats.NewStats())
+	var onFull, offFull *fbclock.Data
+	for i := range ringSize {
+		onData, onErr := dOn.calculateSHMData(sample(i), leaps)
+		offData, offErr := dOff.calculateSHMData(sample(i), leaps)
+		if i == ringSize-1 {
+			require.NoError(t, onErr)
+			require.NoError(t, offErr)
+			onFull, offFull = onData, offData
+		}
+	}
+	require.NotNil(t, onFull)
+	require.NotNil(t, offFull)
+	require.Equal(t, offFull.ErrorBoundNS, onFull.ErrorBoundNS,
+		"with the ring full, GradualWindow must not change the published window")
 }

--- a/fbclock/daemon/gradualwindow.go
+++ b/fbclock/daemon/gradualwindow.go
@@ -1,0 +1,334 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+// Warm-up tolerance factor for the GradualWindow feature (T274511655).
+//
+// The published window is W = mean(m) + k*stddev(m). In steady state k is the constant 4. Right after a
+// restart the ring is nearly empty, so stddev is estimated from very few samples and is unreliable
+// (biased low, 0 at n=1), and a naive window could be too narrow exactly when we are least sure.
+// GradualWindow replaces the constant 4 with a sample-count factor k(n): wide at small n, converging to
+// exactly 4 at the full ring.
+//
+// Two parameters drive k(n):
+//   - z_p (coverageZP) is how wide: the sigma count, fixed at 4 (the steady-state coverage clients rely on).
+//   - gamma (warmupConfidence) is how conservative we are estimating that width from few samples. Higher
+//     gamma widens warm-up only; it vanishes at the full ring, where k is anchored to 4 for any gamma.
+//
+// k(n) is the one-sided normal tolerance factor, the noncentral-t quantile
+//
+//	k(n) = Q_noncentral_t(gamma; df = n-1, noncentrality = sqrt(n)*z_p) / sqrt(n)
+//
+// finite for every n >= 2 (n=1 is skipped: no spread from a single point). It depends only on n, so the
+// table k[2..RingSize] is precomputed once in EvalAndValidate and the hot path is a slice lookup.
+//
+// That quantile has no closed form, and no single numerical method is accurate over our whole n range, so
+// exactFactor uses two that agree where they overlap: the AS 243 noncentral-t series (Lenth 1989, Applied
+// Statistics), accurate at small n but underflowing its exp(-delta^2/2) term at the full-ring noncentrality
+// (delta=40); and a numerical integral over the sample-stddev (chi) distribution, stable there but weaker
+// at the smallest n. Both are cross-checked in tests against published tolerance tables and each other.
+
+import "math"
+
+// The operating point: the two parameters that define the window. Both hardcoded, not configurable.
+const (
+	// coverageZP is z_p, the steady multiplier k converges to (the 4 in MathDefaultW, where the 4-sigma SLA
+	// is explained). The warm-up tolerance table is anchored to it.
+	coverageZP = 4.0
+
+	// warmupConfidence is gamma: how conservative the warm-up factor k(n) is while the ring has few
+	// samples. Higher = wider early window; anchored away at the full ring (k(RingSize) == coverageZP for
+	// any value). Hardcoded like coverageZP; 0.9999 is deliberately conservative and stays finite below 1.
+	warmupConfidence = 0.9999
+)
+
+// Numerical-method constants for computing k(n) (see exactFactor); tuning only, not the operating point.
+const (
+	// ncTSwitchDelta is the crossover, in units of noncentrality delta=sqrt(n)*z_p, between exactFactor's
+	// two routines: below it the AS 243 series is accurate; at/above it that series underflows its
+	// exp(-delta^2/2) term (delta=40 at the n=100 anchor), so exactFactor switches to the chi integral.
+	ncTSwitchDelta = 36.0
+
+	// chiIntegralPanels is the Simpson's-rule resolution (even panel count) of exactFactor's chi integral
+	// (its large-noncentrality routine): higher is more accurate but slower. 4000 over-resolves the smooth
+	// integrand; computed once at config parse.
+	chiIntegralPanels = 4000
+
+	// Each solver below (continued fraction, series, bisection) loops until its convergence tolerance is
+	// met, bounded by a max iteration count as a safety cap. These name those per-routine caps and tolerances.
+	betacfMaxIter       = 500   // betacf continued-fraction iterations
+	betacfTol           = 1e-15 // betacf convergence
+	nctCDFMaxIter       = 1000  // nctCDF (AS 243) series terms
+	nctCDFTol           = 1e-14 // nctCDF convergence
+	nctPPFMaxIter       = 200   // nctPPF bisection iterations
+	nctPPFTol           = 1e-10 // nctPPF bisection convergence (relative)
+	factorBisectMaxIter = 100   // exactFactorIntegral k-bisection iterations
+	factorBisectTol     = 1e-12 // exactFactorIntegral k-bisection convergence (relative)
+)
+
+// lgamma returns log|Gamma(x)| (the sign is always + for the positive arguments used here).
+func lgamma(x float64) float64 {
+	v, _ := math.Lgamma(x)
+	return v
+}
+
+// normCDF is the standard-normal CDF Phi(z).
+func normCDF(z float64) float64 {
+	return 0.5 * math.Erfc(-z/math.Sqrt2)
+}
+
+// betacf is the continued fraction used by regIncBeta (Numerical Recipes "betacf", Lentz's method).
+func betacf(a, b, x float64) float64 {
+	const tiny = 1e-300
+	qab := a + b
+	qap := a + 1.0
+	qam := a - 1.0
+	c := 1.0
+	d := 1.0 - qab*x/qap
+	if math.Abs(d) < tiny {
+		d = tiny
+	}
+	d = 1.0 / d
+	h := d
+	for m := 1; m < betacfMaxIter; m++ {
+		mf := float64(m)
+		m2 := 2.0 * mf
+		aa := mf * (b - mf) * x / ((qam + m2) * (a + m2))
+		d = 1.0 + aa*d
+		if math.Abs(d) < tiny {
+			d = tiny
+		}
+		c = 1.0 + aa/c
+		if math.Abs(c) < tiny {
+			c = tiny
+		}
+		d = 1.0 / d
+		h *= d * c
+		aa = -(a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+		d = 1.0 + aa*d
+		if math.Abs(d) < tiny {
+			d = tiny
+		}
+		c = 1.0 + aa/c
+		if math.Abs(c) < tiny {
+			c = tiny
+		}
+		d = 1.0 / d
+		de := d * c
+		h *= de
+		if math.Abs(de-1.0) < betacfTol {
+			break
+		}
+	}
+	return h
+}
+
+// regIncBeta is the regularized incomplete beta function I_x(a,b). Used by the AS243 noncentral-t CDF.
+func regIncBeta(a, b, x float64) float64 {
+	if x <= 0 {
+		return 0.0
+	}
+	if x >= 1 {
+		return 1.0
+	}
+	lbeta := lgamma(a+b) - lgamma(a) - lgamma(b)
+	front := math.Exp(lbeta + a*math.Log(x) + b*math.Log(1.0-x))
+	if x < (a+1.0)/(a+b+2.0) {
+		return front * betacf(a, b, x) / a
+	}
+	return 1.0 - front*betacf(b, a, 1.0-x)/b
+}
+
+// nctCDF is the noncentral-t CDF P(T' <= t) for df=nu, noncentrality=delta (Lenth 1989, AS 243).
+// Accurate for small nu; its leading exp(-delta^2/2) term underflows once delta >~ ncTSwitchDelta,
+// which is exactly why exactFactor switches to the integral above that threshold.
+func nctCDF(t, nu, delta float64) float64 {
+	if t < 0 {
+		return 1.0 - nctCDF(-t, nu, -delta)
+	}
+	x := t * t / (t*t + nu)
+	if x <= 0 {
+		return normCDF(-delta)
+	}
+	en := 1.0
+	p := 0.5 * math.Exp(-0.5*delta*delta)
+	q := math.Sqrt(2.0/math.Pi) * p * delta
+	s := 0.5 - p
+	a := 0.5
+	b := 0.5 * nu
+	rxb := math.Pow(1.0-x, b)
+	lbeta := lgamma(a) + lgamma(b) - lgamma(a+b)
+	xodd := regIncBeta(a, b, x)
+	godd := 2.0 * rxb * math.Exp(a*math.Log(x)-lbeta)
+	xeven := 1.0 - rxb
+	geven := b * x * rxb
+	tnc := p*xodd + q*xeven
+	for range nctCDFMaxIter {
+		a += 1.0
+		xodd -= godd
+		xeven -= geven
+		godd *= x * (a + b - 1.0) / a
+		geven *= x * (a + b - 0.5) / (a + 0.5)
+		p *= delta * delta / (2.0 * en)
+		q *= delta * delta / (2.0*en + 1.0)
+		s -= p
+		en += 1.0
+		tnc += p*xodd + q*xeven
+		if 2.0*s*(xodd-godd) < nctCDFTol {
+			break
+		}
+	}
+	return tnc + normCDF(-delta)
+}
+
+// nctPPF is the gamma-quantile of the noncentral-t distribution (root-find on nctCDF). Used for the
+// delta < ncTSwitchDelta branch of exactFactor.
+func nctPPF(gamma, nu, delta float64) float64 {
+	// Phase 1: grow hi until it brackets the quantile (CDF(hi) >= gamma); give up (Inf) if it never does.
+	lo, hi := -10.0, 100.0
+	for nctCDF(hi, nu, delta) < gamma {
+		hi *= 2.0
+		if hi > 1e12 {
+			return math.Inf(1)
+		}
+	}
+	// Phase 2: bisection on the monotone CDF.
+	for range nctPPFMaxIter {
+		mid := 0.5 * (lo + hi)
+		if nctCDF(mid, nu, delta) < gamma {
+			lo = mid
+		} else {
+			hi = mid
+		}
+		if hi-lo < nctPPFTol*math.Max(1.0, hi) {
+			break
+		}
+	}
+	return 0.5 * (lo + hi)
+}
+
+// chiLogPDF is the log density of the chi distribution with nu degrees of freedom.
+func chiLogPDF(w, nu float64) float64 {
+	return (nu-1.0)*math.Log(w) - 0.5*w*w - ((nu/2.0-1.0)*math.Log(2.0) + lgamma(nu/2.0))
+}
+
+// exactFactorIntegral computes the same tolerance factor as the noncentral-t quantile, but by integrating
+// over the chi distribution of the sample stddev. For a candidate k the integral gives the achieved
+// confidence, then it bisects on k to hit gamma:
+//
+//	gamma = E_W[ Phi( sqrt(n)*(k*W/sqrt(nu) - zp) ) ],  W ~ chi_nu.
+//
+// It has no exp(-delta^2/2) term, so it is stable where AS 243 underflows (large delta, e.g. the
+// RingSize=100 anchor at delta=40).
+func exactFactorIntegral(n, zp, gamma float64) float64 {
+	nu := n - 1.0
+	sn := math.Sqrt(n)
+	isnu := 1.0 / math.Sqrt(nu)
+
+	lo := 0.0
+	hi := math.Sqrt(nu) + 16.0 // chi_nu concentrates near sqrt(nu); +16 is many sd of headroom
+	panels := chiIntegralPanels
+	h := (hi - lo) / float64(panels)
+	nodes := make([]float64, panels+1)
+	weights := make([]float64, panels+1)
+	for i := range nodes {
+		w := lo + float64(i)*h
+		var sc float64
+		switch {
+		case i == 0 || i == panels:
+			sc = 1.0
+		case i%2 == 1:
+			sc = 4.0
+		default:
+			sc = 2.0
+		}
+		var pdf float64
+		if w > 0.0 {
+			pdf = math.Exp(chiLogPDF(w, nu))
+		}
+		nodes[i] = w
+		weights[i] = sc * (h / 3.0) * pdf
+	}
+
+	g := func(k float64) float64 {
+		s := 0.0
+		for i := range nodes {
+			s += weights[i] * normCDF(sn*(k*nodes[i]*isnu-zp))
+		}
+		return s
+	}
+
+	klo, khi := 0.0, 4.0*(zp+1.0)
+	for g(khi) < gamma {
+		khi *= 2.0
+		if khi > 1e6 {
+			return math.Inf(1)
+		}
+	}
+	for range factorBisectMaxIter {
+		mid := 0.5 * (klo + khi)
+		if g(mid) < gamma {
+			klo = mid
+		} else {
+			khi = mid
+		}
+		if khi-klo < factorBisectTol*math.Max(1.0, khi) {
+			break
+		}
+	}
+	return 0.5 * (klo + khi)
+}
+
+// exactFactor numerically computes the one-sided normal tolerance factor t'_{n-1, sqrt(n)*zp}(gamma)/sqrt(n)
+// for n >= 2 (NaN for n < 2, the genuine boundary). It is hybrid for numerical stability across the whole
+// domain: the AS 243 noncentral-t quantile for delta < ncTSwitchDelta (accurate at tiny nu), and the
+// chi-density integral for delta >= ncTSwitchDelta (where AS 243 underflows). The two methods agree to
+// ~1e-3 or better in their overlap (see TestExactFactorMethodsAgree).
+func exactFactor(n, zp, gamma float64) float64 {
+	if n < 2 {
+		return math.NaN()
+	}
+	delta := math.Sqrt(n) * zp
+	if delta < ncTSwitchDelta {
+		return nctPPF(gamma, n-1.0, delta) / math.Sqrt(n)
+	}
+	return exactFactorIntegral(n, zp, gamma)
+}
+
+// precomputeGradualWindowFactors builds the data-independent warm-up factor table k[2..ringSize], used
+// as W = mean(m,n) + k(n)*stddev(m,n) during warm-up. k(n) is the one-sided noncentral-t tolerance
+// factor (z_p = coverageZP) scaled so k(ringSize) is exactly coverageZP (4.0), so the full-ring window
+// is the exact same number as the legacy "mean(m,N) + 4*stddev(m,N)". Indices 0 and 1 are left zero
+// (n=1 is skipped: its stddev is 0 so there is no margin to scale). Built once at config-parse; the hot
+// path only does a slice lookup.
+func precomputeGradualWindowFactors(ringSize int, gamma float64) []float64 {
+	out := make([]float64, ringSize+1)
+	if ringSize < 2 {
+		return out
+	}
+	fN := exactFactor(float64(ringSize), coverageZP, gamma)
+	for n := 2; n <= ringSize; n++ {
+		if n == ringSize {
+			// Anchor: pin to exactly coverageZP so the full-ring window is the exact same number as
+			// today, independent of any floating-point error in fN.
+			out[n] = coverageZP
+			continue
+		}
+		out[n] = coverageZP * exactFactor(float64(n), coverageZP, gamma) / fN
+	}
+	return out
+}

--- a/fbclock/daemon/gradualwindow_test.go
+++ b/fbclock/daemon/gradualwindow_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExactFactorPublishedTable validates the exact one-sided noncentral-t tolerance factor against an
+// EXTERNAL published tolerance table (p=0.90, gamma=0.95). These are standard one-sided normal
+// tolerance factors (NIST e-Handbook 7.2.6.3 / Krishnamoorthy & Mathew); matching them confirms the
+// whole betainc -> nctCDF -> nctPPF chain is correct, independent of the daemon's z_p=4 anchoring.
+func TestExactFactorPublishedTable(t *testing.T) {
+	const zp90 = 1.2815515594908223 // Phi^-1(0.90)
+	want := map[float64]float64{
+		3:  6.158,
+		4:  4.163,
+		5:  3.407,
+		7:  2.755,
+		10: 2.355,
+		15: 2.068,
+	}
+	for n, w := range want {
+		require.InDeltaf(t, w, exactFactor(n, zp90, 0.95), 0.01, "exactFactor(n=%v, p=0.90, gamma=0.95)", n)
+	}
+}
+
+// TestExactFactorMethodsAgree cross-checks the two exact methods in their overlap, at the shipped
+// warmupConfidence: the AS243 noncentral-t quantile and the chi-density integral. They must agree where
+// both are valid (delta<36), which is what validates the integral branch used at the RingSize=100 anchor
+// (delta=40) where AS243 underflows. Run at the high operating gamma -- that is the deep-tail path.
+func TestExactFactorMethodsAgree(t *testing.T) {
+	for _, n := range []float64{40, 60, 80} {
+		delta := math.Sqrt(n) * coverageZP
+		as243 := nctPPF(warmupConfidence, n-1, delta) / math.Sqrt(n)
+		integral := exactFactorIntegral(n, coverageZP, warmupConfidence)
+		require.InEpsilonf(t, as243, integral, 1e-3, "n=%v: AS243=%v integral=%v", n, as243, integral)
+	}
+}
+
+// TestNormCDF validates the Erfc-based standard-normal CDF against textbook Phi(z) values -- the one
+// special function every other routine here (noncentral-t, the tolerance integral) is built on.
+func TestNormCDF(t *testing.T) {
+	cases := []struct{ z, want float64 }{
+		{0.0, 0.5},
+		{1.0, 0.8413447460685429},
+		{-1.0, 0.15865525393145707},
+		{2.0, 0.9772498680518208},
+		{4.0, 0.9999683287581669},
+	}
+	for _, c := range cases {
+		require.InDeltaf(t, c.want, normCDF(c.z), 1e-9, "normCDF(%v)", c.z)
+	}
+}
+
+// TestExactFactorZP4 spot-checks the factor at the operating point (z_p=4, gamma=0.9999) against
+// independently computed reference values: F(100)=5.437 (integral branch, delta=40), raw k(4)=97.41
+// (AS243 branch), anchored K(4)=4*k(4)/F(100)=71.67. This is the z_p=4 path the daemon ships, which the
+// published p=0.90 table never reaches (its delta stays < 36).
+func TestExactFactorZP4(t *testing.T) {
+	require.InDelta(t, 5.437, exactFactor(100, coverageZP, warmupConfidence), 0.05) // F(100), integral branch
+	require.InDelta(t, 97.41, exactFactor(4, coverageZP, warmupConfidence), 0.5)    // raw k(4), AS243 branch
+	k := precomputeGradualWindowFactors(100, warmupConfidence)
+	require.InDelta(t, 71.67, k[4], 0.5) // anchored K(4) the daemon publishes at n=4
+}
+
+// TestGradualWindowProductionSafetyInvariant guards the precomputed k(n) factor table at the shipped
+// gamma=0.9999: every factor is finite, >= 4, strictly decreasing, and exactly 4 at the full ring, so a
+// warm-up factor is never tighter than steady. Runs RingSize=100 (anchor fN via the integral routine) and
+// a smaller ring (anchor fN via AS243). Tests the table, not runtime W.
+func TestGradualWindowProductionSafetyInvariant(t *testing.T) {
+	// anchor fN (delta=40, the integral routine); it scales every k(n) at RingSize=100.
+	require.InDelta(t, 5.437, exactFactorIntegral(100, coverageZP, warmupConfidence), 0.05)
+
+	// RingSize=100 anchors fN via the integral routine; a smaller ring anchors it via AS243. Check both.
+	for _, ringSize := range []int{30, 100} {
+		k := precomputeGradualWindowFactors(ringSize, warmupConfidence)
+		require.Lenf(t, k, ringSize+1, "ringSize=%d table length", ringSize)
+		require.Equalf(t, coverageZP, k[ringSize], "ringSize=%d anchor k(RingSize) must equal coverageZP", ringSize)
+		for n := 2; n <= ringSize; n++ {
+			require.Falsef(t, math.IsNaN(k[n]) || math.IsInf(k[n], 0), "ringSize=%d k(%d) must be finite", ringSize, n)
+			require.GreaterOrEqualf(t, k[n], coverageZP, "ringSize=%d k(%d) must stay >= coverageZP", ringSize, n)
+			if n > 2 {
+				require.Lessf(t, k[n], k[n-1], "ringSize=%d k(%d) must be < k(%d)", ringSize, n, n-1)
+			}
+		}
+		require.Greaterf(t, k[2], 10.0, "ringSize=%d k(2) should be large", ringSize)
+	}
+}

--- a/fbclock/daemon/math.go
+++ b/fbclock/daemon/math.go
@@ -19,6 +19,7 @@ package daemon
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/Knetic/govaluate"
 	"github.com/eclesh/welford"
@@ -35,6 +36,8 @@ supported variables:
   clockaccuracy (list of clock accuracy values received from GM)
   freqchange (list of last changes in frequency)
   freqchangeabs (list of last changes in frequency, abs values)
+  n (number of samples currently available; used for warm-up window widening)
+  k (precomputed warm-up tolerance factor for the current n; equals 4.0 at the full ring)
 supported functions:
   abs(value) - absolute value of single float64, for example abs(-1) = 1
   mean(values, number) - mean of list of 'number' values, for example mean(offset, 10) will take 10 elements from array 'offset' and return mean for those values
@@ -44,10 +47,16 @@ supported functions:
 const (
 	// MathDefaultHistory is a default number of samples to keep
 	MathDefaultHistory = 100
-	// MathDefaultM is a default formula to calculate M
+	// MathDefaultM is the default M formula, left unchanged by GradualWindow: the literal 100 is a sample
+	// count, but mean/stddev clamp to "all available", so warm-up uses whatever samples exist (no n wiring
+	// needed) and at the full ring (prod runs RingSize=100) M uses the whole ring.
 	MathDefaultM = "mean(clockaccuracy, 100) + abs(mean(offset, 100)) + 1.0 * stddev(offset, 100)"
-	// MathDefaultW is a default formula to calculate W
-	MathDefaultW = "mean(m, 100) + 4.0 * stddev(m, 100)"
+	// MathDefaultW is the default W formula, the window the daemon publishes. k is the warm-up tolerance
+	// factor for the current sample count n (precomputed by precomputeGradualWindowFactors, injected by
+	// calcW): larger at small n so the window is wide right after a restart, shrinking to 4.0 once the ring
+	// is full. That steady 4 (coverageZP) is our design SLA: a 4-sigma bound, so the window covers
+	// ~99.997% of the clock error (one-sided, Phi(4)).
+	MathDefaultW = "mean(m, n) + k * stddev(m, n)"
 	// MathDefaultDrift is a default formula to calculate default drift
 	MathDefaultDrift = "1.5 * mean(freqchangeabs, 99)"
 )
@@ -139,27 +148,24 @@ var supportedVariables = []string{
 	"clockaccuracy",
 	"freqchange",
 	"freqchangeabs",
+	"n",
+	"k",
 }
 
 func isSupportedVar(varName string) bool {
-	for _, v := range supportedVariables {
-		if v == varName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(supportedVariables, varName)
 }
 
 // all the functions we support in expressions
 var functions = map[string]govaluate.ExpressionFunction{
-	"abs": func(args ...interface{}) (interface{}, error) {
+	"abs": func(args ...any) (any, error) {
 		if len(args) != 1 {
 			return nil, fmt.Errorf("abs: wrong number of arguments: want 1, got %d", len(args))
 		}
 		val := args[0].(float64)
 		return math.Abs(val), nil
 	},
-	"mean": func(args ...interface{}) (interface{}, error) {
+	"mean": func(args ...any) (any, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("mean: wrong number of arguments: want 2, got %d", len(args))
 		}
@@ -170,7 +176,7 @@ var functions = map[string]govaluate.ExpressionFunction{
 		}
 		return mean(vals[:nSamples]), nil
 	},
-	"variance": func(args ...interface{}) (interface{}, error) {
+	"variance": func(args ...any) (any, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("variance: wrong number of arguments: want 2, got %d", len(args))
 		}
@@ -181,7 +187,7 @@ var functions = map[string]govaluate.ExpressionFunction{
 		}
 		return variance(vals[:nSamples]), nil
 	},
-	"stddev": func(args ...interface{}) (interface{}, error) {
+	"stddev": func(args ...any) (any, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("stddev: wrong number of arguments: want 2, got %d", len(args))
 		}
@@ -215,6 +221,19 @@ func prepareExpression(exprStr string) (expr *govaluate.EvaluableExpression, err
 
 func prepareMathParameters(lastN []*DataPoint) map[string][]float64 {
 	size := len(lastN)
+	if size == 0 {
+		// Defensive: no live path calls this with an empty slice (calcW runs after pushDataPoint;
+		// calcDriftPPB runs after its gate). The guard prevents a latent negative-length make below
+		// and a lastN[0] panic.
+		return map[string][]float64{
+			"offset":        {},
+			"delay":         {},
+			"freq":          {},
+			"clockaccuracy": {},
+			"freqchange":    {},
+			"freqchangeabs": {},
+		}
+	}
 	offsets := make([]float64, size)
 	delays := make([]float64, size)
 	freqs := make([]float64, size)
@@ -243,8 +262,8 @@ func prepareMathParameters(lastN []*DataPoint) map[string][]float64 {
 	}
 }
 
-func mapOfInterface(m map[string][]float64) map[string]interface{} {
-	mm := make(map[string]interface{}, len(m))
+func mapOfInterface(m map[string][]float64) map[string]any {
+	mm := make(map[string]any, len(m))
 	for k, v := range m {
 		mm[k] = v
 	}

--- a/fbclock/daemon/math_test.go
+++ b/fbclock/daemon/math_test.go
@@ -149,3 +149,36 @@ func FuzzPrepareExpression(f *testing.F) {
 		_, _ = prepareExpression(input)
 	})
 }
+
+// TestGradualWindowByteIdentityAtFullRing locks the invariant that the new k(n) W expression reduces
+// bit-for-bit to the legacy "mean(m, N) + 4.0 * stddev(m, N)" once the ring is full (n == N).
+func TestGradualWindowByteIdentityAtFullRing(t *testing.T) {
+	cases := []struct {
+		n      int
+		legacy string
+	}{
+		{30, "mean(m, 30) + 4.0 * stddev(m, 30)"},
+		{100, "mean(m, 100) + 4.0 * stddev(m, 100)"},
+	}
+	for _, tc := range cases {
+		ms := make([]float64, tc.n)
+		for i := range ms {
+			ms[i] = 100 + float64(i%7) // varied so stddev(m) > 0
+		}
+		newExpr, err := prepareExpression(MathDefaultW)
+		require.NoError(t, err)
+		legacyExpr, err := prepareExpression(tc.legacy)
+		require.NoError(t, err)
+		// At the full ring the precomputed factor is exactly 4.0 (coverageZP), so the new scalar-k
+		// expression must reduce bit-for-bit to the legacy "mean(m,N) + 4.0*stddev(m,N)".
+		gotNew, err := newExpr.Evaluate(map[string]interface{}{
+			"m": ms,
+			"n": float64(tc.n),
+			"k": coverageZP,
+		})
+		require.NoError(t, err)
+		gotLegacy, err := legacyExpr.Evaluate(map[string]interface{}{"m": ms})
+		require.NoError(t, err)
+		require.Equal(t, gotLegacy, gotNew)
+	}
+}


### PR DESCRIPTION
Summary:
**What**

When fbclock-sidecar restarts, fbclock returns `FBCLOCK_E_DATA_STALE` to clients for ~100s afterward. That spikes ptp.fbclock[_synthetic].api.errors, trips monitoring/alerts, and blocks conveyors (which gate on those errors). Customers have hit this.

**Why**

Currently fbclock publishes a one-sided window `W = mean(m) + 4 * stddev(m)`, the formula-driven part of the client-visible window of uncertainty (WOU), where m is the in-process ring of the last RingSize (=100) per-second measurement samples. It only publishes once that ring is full, since a window built from 1–2 samples has no meaningful stddev and would be garbage/too tight, so the daemon waits until it has a trustworthy estimate.

As a result, on any restart the ring starts empty and there's a ~RingSize-second (~100s) silent gap where it publishes nothing and v2 clients get `DATA_STALE`. (There's also a -b boot delay that waits for sptp/PHC/servo to come up after a host reboot, that's a separate, boot-only wait. The restart gap is the ring refill, and we're keeping RingSize as-is.)


**How**

Publish a valid window from the 2nd sample instead of waiting for the full ring, but make it appropriately wider while we only have a few samples. We replace the constant 4 with a sample-count factor k(n):


`W = mean(m, n) + k(n) * stddev(m, n)`


k(n) is the one-sided normal tolerance factor (the noncentral-t quantile `t'_{n-1, sqrt(n)*z_p}(gamma) / sqrt(n)`), anchored so k(RingSize) = 4 exactly.

Intuition: with few samples the stddev is unreliable (biased low), so we widen to stay safe. As the ring fills, k(n) shrinks back to 4 and the window is byte-identical to today's on the same samples. It's a sample-count-driven widening of the existing operating point, not a new coverage guarantee.

Two separate parameters, both hardcoded, kept distinct on purpose:
- z_p = 4 is the coverage/SLA: the fixed 4-sigma steady-state width that k(n) converges back to at the full ring (k(RingSize) = 4).
- gamma = 0.9999 is the warm-up confidence: how sure we are we actually hit that 4-sigma coverage when we've only got a few samples to estimate the spread from (99.99% confident of the fixed 4-sigma/~99.997%(one-sided, Phi(4)) coverage). It's hardcoded like the steady 4, vanishes as the ring fills (k goes back to 4 for any gamma) so it never touches steady state, and a higher value just widens the first sample or two.

Design decisions / tradeoffs:

- Skip n=1 (stddev is 0 → no margin); publish from n=2.
- k(n) depends only on n, not the data, so the whole table is precomputed once at config parse - the per-tick path is just a lookup.
- We deliberately do not force a uniformly wide window from the start. A servo-locked clock is genuinely accurate from the first sample (the window is dominated by GM clock accuracy), so the honest early window is data-driven (k*stddev), not a hand-picked number. Tradeoff: on a very calm host the warm-up window stays modest (the factor can't inflate a near-zero stddev), which is fine, the goal is to restore a valid window and kill the error gap, and the window stays safe and converges to today's value.
- Behind a new -gradualwindow flag, default off, so this diff is a no-op in prod. Landing flag-off first, then I'll canary -gradualwindow=true and enable it gradually via chef.

 test_plan_yes_description_no

Differential Revision: D108339317


