### PR TITLE
Add Licence to `ntske/records.go` and `ntske/records_test.go`

### DIFF
--- a/ntp/ntske/records.go
+++ b/ntp/ntske/records.go
@@ -1,3 +1,19 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ntske
 
 import (


### PR DESCRIPTION
Summary: I added licence comment header at records.go and records_test.go

Reviewed By: leoleovich

Differential Revision: D110483543


