### PR TITLE
Add AEAD logic in `nts/`

### DIFF
--- a/ntp/protocol/extension_fields.go
+++ b/ntp/protocol/extension_fields.go
@@ -91,6 +91,21 @@ const (
 	NTSAuthenticator     ExtensionFieldType = 0x0404
 )
 
+// AEADAlgorithm is a 16-bit IANA "AEAD Algorithms" registry identifier
+// negotiated via NTS-KE and used to select the AEAD for the Authenticator
+// extension field (RFC 8915 §5.1).
+type AEADAlgorithm uint16
+
+const (
+	// AEADAESSIVCMAC512 is AEAD_AES_SIV_CMAC_512 (RFC 5297), the RFC 8915 §5.7
+	// mandatory-to-implement algorithm. Deterministic: it carries no separate
+	// nonce and uses a 64-octet key.
+	AEADAESSIVCMAC512 AEADAlgorithm = 17
+	// AEADAES128GCMSIV is AEAD_AES_128_GCM_SIV (RFC 8452). It uses a 16-octet
+	// key and a 12-octet nonce.
+	AEADAES128GCMSIV AEADAlgorithm = 30
+)
+
 // Sentinel errors returned by extension-field parsing.
 var (
 	ErrExtensionTruncated     = errors.New("extension field truncated")

--- a/ntp/protocol/extension_fields_test.go
+++ b/ntp/protocol/extension_fields_test.go
@@ -234,3 +234,11 @@ func TestMarshalExtensionFieldsRejectsInvalid(t *testing.T) {
 	_, err := MarshalExtensionFields([]ExtensionField{{Type: 0xF000}})
 	require.ErrorIs(t, err, ErrExtensionTypeReserved)
 }
+
+// TestAEADAlgorithmValues pins the negotiated AEAD identifiers to their IANA
+// "AEAD Algorithms" registry values; drift here would silently break NTS-KE
+// interop with peers.
+func TestAEADAlgorithmValues(t *testing.T) {
+	require.Equal(t, AEADAlgorithm(17), AEADAESSIVCMAC512)
+	require.Equal(t, AEADAlgorithm(30), AEADAES128GCMSIV)
+}

--- a/ntp/protocol/nts/aead.go
+++ b/ntp/protocol/nts/aead.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nts
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/facebook/time/ntp/protocol"
+	aeadsubtle "github.com/tink-crypto/tink-go/v2/aead/subtle"
+	daeadsubtle "github.com/tink-crypto/tink-go/v2/daead/subtle"
+)
+
+// AEAD is the authenticated-encryption interface used to protect the encrypted
+// extension fields of an NTS-protected NTP packet (RFC 8915). Implementations
+// wrap a specific negotiated IANA AEAD algorithm; construct one with NewAEAD.
+type AEAD interface {
+	// Seal encrypts and authenticates plaintext, binding it to ad. It returns
+	// the nonce (possibly empty) and ciphertext to place in the Authenticator's
+	// Nonce and Ciphertext fields respectively.
+	Seal(ad, plaintext []byte) (nonce, ciphertext []byte, err error)
+	// Open verifies and decrypts ciphertext against ad and nonce. A nonce whose
+	// length is wrong for the algorithm is rejected with ErrAEADNonceSize; any
+	// authentication or decryption failure is returned as the underlying error.
+	Open(ad, nonce, ciphertext []byte) (plaintext []byte, err error)
+}
+
+var (
+	// ErrUnsupportedAlgorithm is returned by NewAEAD when the IANA AEAD ID is
+	// not one this package implements.
+	ErrUnsupportedAlgorithm = errors.New("nts: unsupported AEAD algorithm")
+	// ErrAEADKeySize is returned by NewAEAD when the key length does not match
+	// the one required by the negotiated algorithm.
+	ErrAEADKeySize = errors.New("nts: invalid AEAD key size")
+	// ErrAEADNonceSize is returned by Open when the nonce length is wrong for
+	// the algorithm (empty for SIV, fixed-length for GCM-SIV).
+	ErrAEADNonceSize = errors.New("nts: invalid AEAD nonce size")
+)
+
+const (
+	// aesSIVCMAC512KeySize is the AES-SIV-CMAC-512 key length in octets (RFC 5297).
+	aesSIVCMAC512KeySize = 64
+
+	// aes128GCMSIVKeySize is the AES-128-GCM-SIV key length in octets. tink's
+	// NewAESGCMSIV also accepts 32-octet keys (AES-256), but IANA AEAD ID 30 is
+	// specifically AES-128, so NewAEAD pins the key length.
+	aes128GCMSIVKeySize = 16
+
+	// aesGCMSIVTagSize is the AES-GCM-SIV authentication tag length in octets
+	// (RFC 8452, same as AES block size). Used to validate tink output structure
+	// nonce || ciphertext || tag.
+	aesGCMSIVTagSize = 16
+)
+
+// NewAEAD builds an AEAD for the negotiated IANA AEAD algorithm ID. Supported
+// IDs: AEADAESSIVCMAC512 (17) and AEADAES128GCMSIV (30).
+func NewAEAD(algorithm protocol.AEADAlgorithm, key []byte) (AEAD, error) {
+	switch algorithm {
+	case protocol.AEADAESSIVCMAC512:
+		if len(key) != aesSIVCMAC512KeySize {
+			return nil, fmt.Errorf("%w: AES-SIV-CMAC-512 requires %d bytes, got %d",
+				ErrAEADKeySize, aesSIVCMAC512KeySize, len(key))
+		}
+		siv, err := daeadsubtle.NewAESSIV(key)
+		if err != nil {
+			return nil, fmt.Errorf("nts: AES-SIV-CMAC: %w", err)
+		}
+		return &aesSIVCMAC{siv: siv}, nil
+	case protocol.AEADAES128GCMSIV:
+		// key_len check
+		if len(key) != aes128GCMSIVKeySize {
+			return nil, fmt.Errorf("%w: AES-128-GCM-SIV requires %d bytes, got %d",
+				ErrAEADKeySize, aes128GCMSIVKeySize, len(key))
+		}
+		gcm, err := aeadsubtle.NewAESGCMSIV(key)
+		if err != nil {
+			return nil, fmt.Errorf("nts: AES-128-GCM-SIV: %w", err)
+		}
+		return &aesGCMSIV{aead: gcm}, nil
+	default:
+		return nil, fmt.Errorf("%w: %#x", ErrUnsupportedAlgorithm, algorithm)
+	}
+}
+
+// aesSIVCMAC wraps tink's deterministic AES-SIV-CMAC (RFC 5297, 64-octet key).
+type aesSIVCMAC struct {
+	siv *daeadsubtle.AESSIV
+}
+
+// encrypt-and-authenticate
+func (a *aesSIVCMAC) Seal(ad, plaintext []byte) ([]byte, []byte, error) {
+	ct, err := a.siv.EncryptDeterministically(plaintext, ad)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nts: SIV encrypt: %w", err)
+	}
+	// Deterministic AEAD: no nonce on the wire (RFC 8915 §5.7); the synthetic
+	// IV is the first 16 octets of the ciphertext.
+	return nil, ct, nil
+}
+
+// verify-and-decrypt
+func (a *aesSIVCMAC) Open(ad, nonce, ciphertext []byte) ([]byte, error) {
+	if len(nonce) != 0 {
+		return nil, fmt.Errorf("%w: empty nonce required for SIV, got %d bytes",
+			ErrAEADNonceSize, len(nonce))
+	}
+	pt, err := a.siv.DecryptDeterministically(ciphertext, ad)
+	if err != nil {
+		return nil, fmt.Errorf("nts: SIV decrypt: %w", err)
+	}
+	return pt, nil
+}
+
+// aesGCMSIV wraps tink's AES-GCM-SIV (RFC 8452, 16-octet key, 12-octet nonce).
+type aesGCMSIV struct {
+	aead *aeadsubtle.AESGCMSIV
+}
+
+func (a *aesGCMSIV) Seal(ad, plaintext []byte) ([]byte, []byte, error) {
+	// tink returns (nonce || ciphertext || tag) as one blob; split the random
+	// 12-octet nonce off the front so it lands in the Authenticator Nonce field.
+	sealed, err := a.aead.Encrypt(plaintext, ad)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nts: GCM-SIV encrypt: %w", err)
+	}
+	minSealedLen := aeadsubtle.AESGCMSIVNonceSize + aesGCMSIVTagSize
+	if len(sealed) < minSealedLen {
+		return nil, nil, fmt.Errorf("nts: GCM-SIV output %d bytes shorter than minimum %d (nonce+tag)", len(sealed), minSealedLen)
+	}
+	// Return independent copies to avoid slice aliasing hazard:
+	// sealed[:n] has cap=len(sealed), so append to nonce would overwrite ciphertext.
+	// bytes.Clone makes the copy intent explicit (Go 1.20+, Meta targets 1.26).
+	nonce := bytes.Clone(sealed[:aeadsubtle.AESGCMSIVNonceSize])
+	ciphertext := bytes.Clone(sealed[aeadsubtle.AESGCMSIVNonceSize:])
+	return nonce, ciphertext, nil
+}
+func (a *aesGCMSIV) Open(ad, nonce, ciphertext []byte) ([]byte, error) {
+	// validate nonce len
+	if len(nonce) != aeadsubtle.AESGCMSIVNonceSize {
+		return nil, fmt.Errorf("%w: GCM-SIV requires %d-byte nonce, got %d",
+			ErrAEADNonceSize, aeadsubtle.AESGCMSIVNonceSize, len(nonce))
+	}
+	// Rejoin (nonce || ciphertext || tag) into the blob layout tink expects.
+	// slices.Concat is Go 1.22+ modern idiom for concatenating slices.
+	sealed := slices.Concat(nonce, ciphertext)
+	pt, err := a.aead.Decrypt(sealed, ad)
+	if err != nil {
+		return nil, fmt.Errorf("nts: GCM-SIV decrypt: %w", err)
+	}
+	return pt, nil
+}

--- a/ntp/protocol/nts/aead_test.go
+++ b/ntp/protocol/nts/aead_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nts
+
+import (
+	"testing"
+
+	"github.com/facebook/time/ntp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// aeadFor builds an AEAD for the given algorithm using a deterministic,
+// correctly-sized key so tests can seal and open without external key material.
+func aeadFor(t *testing.T, alg protocol.AEADAlgorithm) AEAD {
+	t.Helper()
+	var keyLen int
+	switch alg {
+	case protocol.AEADAESSIVCMAC512:
+		keyLen = 64
+	case protocol.AEADAES128GCMSIV:
+		keyLen = 16
+	default:
+		t.Fatal("unsupported algorithm")
+	}
+	key := make([]byte, keyLen)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	a, err := NewAEAD(alg, key)
+	require.NoError(t, err)
+	return a
+}
+
+// TestAEADRoundTrip checks that both supported algorithms decrypt back to the
+// original plaintext when sealing and opening with matching associated data.
+func TestAEADRoundTrip(t *testing.T) {
+	for _, alg := range []protocol.AEADAlgorithm{protocol.AEADAESSIVCMAC512, protocol.AEADAES128GCMSIV} {
+		a := aeadFor(t, alg)
+		ad := []byte("associated-data")
+		pt := []byte("secret-extension-fields")
+		nonce, ct, err := a.Seal(ad, pt)
+		require.NoError(t, err)
+		got, err := a.Open(ad, nonce, ct)
+		require.NoError(t, err)
+		require.Equal(t, pt, got)
+	}
+}
+
+// TestAEADADTamper checks that opening fails for both algorithms when the
+// associated data differs from what was bound at seal time.
+func TestAEADADTamper(t *testing.T) {
+	for _, alg := range []protocol.AEADAlgorithm{protocol.AEADAESSIVCMAC512, protocol.AEADAES128GCMSIV} {
+		a := aeadFor(t, alg)
+		pt := []byte("secret-extension-fields")
+		nonce, ct, err := a.Seal([]byte("associated-data"), pt)
+		require.NoError(t, err)
+		_, err = a.Open([]byte("tampered-data"), nonce, ct)
+		require.Error(t, err)
+	}
+}
+
+// TestAEADCiphertextTamper checks that opening fails for both algorithms when a
+// single ciphertext byte is flipped after sealing.
+func TestAEADCiphertextTamper(t *testing.T) {
+	for _, alg := range []protocol.AEADAlgorithm{protocol.AEADAESSIVCMAC512, protocol.AEADAES128GCMSIV} {
+		a := aeadFor(t, alg)
+		ad := []byte("associated-data")
+		pt := []byte("secret-extension-fields")
+		nonce, ct, err := a.Seal(ad, pt)
+		require.NoError(t, err)
+		require.NotEmpty(t, ct)
+		ct[len(ct)-1] ^= 0xFF
+		_, err = a.Open(ad, nonce, ct)
+		require.Error(t, err)
+	}
+}
+
+// TestAEADWrongLengthNonce checks that opening rejects a nonce of the wrong
+// length with ErrAEADNonceSize: SIV requires an empty nonce, while GCM-SIV
+// requires a fixed-length nonce.
+func TestAEADWrongLengthNonce(t *testing.T) {
+	for _, alg := range []protocol.AEADAlgorithm{protocol.AEADAESSIVCMAC512, protocol.AEADAES128GCMSIV} {
+		a := aeadFor(t, alg)
+		ad := []byte("associated-data")
+		pt := []byte("secret-extension-fields")
+		nonce, ct, err := a.Seal(ad, pt)
+		require.NoError(t, err)
+		badNonce := append(append([]byte{}, nonce...), 0x00)
+		_, err = a.Open(ad, badNonce, ct)
+		require.ErrorIs(t, err, ErrAEADNonceSize)
+	}
+}
+
+// TestNewAEADUnsupportedAlgorithm checks that an IANA AEAD ID that the package
+// does not implement is rejected with ErrUnsupportedAlgorithm.
+func TestNewAEADUnsupportedAlgorithm(t *testing.T) {
+	_, err := NewAEAD(protocol.AEADAlgorithm(0xFFFF), make([]byte, 64))
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}
+
+// TestNewAEADInvalidKeySize checks that each supported algorithm rejects a
+// wrong-length key with ErrAEADKeySize.
+func TestNewAEADInvalidKeySize(t *testing.T) {
+	cases := []struct {
+		name string
+		alg  protocol.AEADAlgorithm
+		key  []byte
+	}{
+		{"SIV short key", protocol.AEADAESSIVCMAC512, make([]byte, 32)},
+		{"GCM-SIV short key", protocol.AEADAES128GCMSIV, make([]byte, 15)},
+		{"GCM-SIV long key", protocol.AEADAES128GCMSIV, make([]byte, 32)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAEAD(tc.alg, tc.key)
+			require.ErrorIs(t, err, ErrAEADKeySize)
+		})
+	}
+}

--- a/ntp/protocol/nts/authenticator.go
+++ b/ntp/protocol/nts/authenticator.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/facebook/time/ntp/protocol"
-	"github.com/tink-crypto/tink-go/v2/daead/subtle"
 )
 
 /*
@@ -142,37 +141,30 @@ func ParseAuthenticatorBody(body []byte) (AuthenticatorBody, error) {
 	return ab, nil
 }
 
-// SealAuthenticator builds an NTS Authenticator extension field over the
-// supplied associated data. The plaintext (typically empty for the common
-// case of no encrypted EFs) is encrypted and authenticated using AES-SIV.
-// The returned extension field is appended after the AD on the wire.
-//
-// Per RFC 8915 §5.6.1, the caller MUST pass `ad` as the NTP packet header
-// (48 octets) followed by every extension field preceding this Authenticator,
-// exactly as those bytes appear on the wire (including any wire padding).
-// This package has no NTP-packet awareness, so it cannot validate the AD
-// shape — that responsibility lives one layer up (the responder request
-// path or the KE-side smoke client). If the caller constructs the wrong AD,
-// the receiver's OpenAuthenticator will fail verification with
-// ErrAuthenticatorVerify; bugs of this kind manifest as "every NTS request
-// rejected" with no other signal, so AD-construction code should be reviewed
-// carefully.
-func SealAuthenticator(siv *subtle.AESSIV, ad, plaintext []byte) (protocol.ExtensionField, error) {
-	ct, err := siv.EncryptDeterministically(plaintext, ad)
+// SealAuthenticator encrypts plaintext under the given AEAD, authenticating ad
+// as associated data, and returns the result as an NTS Authenticator extension
+// field (RFC 8915 §5.6). The AEAD-produced nonce and ciphertext are packed into
+// the EF body via MarshalAuthenticatorBody. A nil or empty plaintext yields an
+// authenticator that protects ad only.
+func SealAuthenticator(aead AEAD, ad, plaintext []byte) (protocol.ExtensionField, error) {
+	nonce, ct, err := aead.Seal(ad, plaintext)
 	if err != nil {
-		return protocol.ExtensionField{}, fmt.Errorf("nts: SIV encrypt: %w", err)
+		return protocol.ExtensionField{}, err
 	}
-	body, err := MarshalAuthenticatorBody(nil, ct)
+	body, err := MarshalAuthenticatorBody(nonce, ct)
 	if err != nil {
 		return protocol.ExtensionField{}, err
 	}
 	return protocol.ExtensionField{Type: protocol.NTSAuthenticator, Body: body}, nil
 }
 
-// OpenAuthenticator verifies and decrypts an NTS Authenticator extension
-// field. Returns the encrypted plaintext (zero or more encrypted EFs as a
-// concatenated byte slice) on success.
-func OpenAuthenticator(siv *subtle.AESSIV, ad []byte, ef protocol.ExtensionField) ([]byte, error) {
+// OpenAuthenticator verifies and decrypts an NTS Authenticator extension field
+// (RFC 8915 §5.6), authenticating ad as associated data, and returns the
+// recovered plaintext. It returns ErrAuthenticatorMalformed if ef is not an
+// authenticator EF, if its body is structurally invalid, or if the nonce length
+// is rejected by the AEAD; it returns ErrAuthenticatorVerify if AEAD
+// verification fails.
+func OpenAuthenticator(aead AEAD, ad []byte, ef protocol.ExtensionField) ([]byte, error) {
 	if ef.Type != protocol.NTSAuthenticator {
 		return nil, fmt.Errorf("%w: expected type %#x got %#x",
 			ErrAuthenticatorMalformed, protocol.NTSAuthenticator, ef.Type)
@@ -181,23 +173,15 @@ func OpenAuthenticator(siv *subtle.AESSIV, ad []byte, ef protocol.ExtensionField
 	if err != nil {
 		return nil, err
 	}
-	if len(body.Nonce) != 0 {
-		// SIV-protected packets carry Nonce Length = 0 on the wire — see the
-		// file-level comment above. Peers that send a non-empty Nonce would
-		// require the bytes to be folded into the SIV S2V input list as a
-		// trailing entry; tink's single-AD EncryptDeterministically/
-		// DecryptDeterministically API doesn't expose that, and chrony (our
-		// primary interop target) sets the Nonce to empty for SIV anyway.
-		return nil, fmt.Errorf("%w: empty Nonce required for SIV, got %d bytes",
-			ErrAuthenticatorMalformed, len(body.Nonce))
-	}
-	pt, err := siv.DecryptDeterministically(body.Ciphertext, ad)
+	pt, err := aead.Open(ad, body.Nonce, body.Ciphertext)
 	if err != nil {
-		// Wrap ErrAuthenticatorVerify (not the tink error) so the tink err
-		// stays out of the errors.Is chain — see the sentinel's godoc.
-		// Pass err.Error() rather than err so errorlint doesn't "helpfully"
-		// rewrite the %s back to %w, which would put the tink err in the
-		// chain and silently break the contract.
+		// A wrong-length nonce is a structural (malformed) fault, not an
+		// authentication failure — surface it as ErrAuthenticatorMalformed.
+		if errors.Is(err, ErrAEADNonceSize) {
+			return nil, fmt.Errorf("%w: %s", ErrAuthenticatorMalformed, err.Error())
+		}
+		// Keep the AEAD err text but not in the errors.Is chain — see the
+		// ErrAuthenticatorVerify godoc. %s (not %w) is deliberate.
 		return nil, fmt.Errorf("%w: %s", ErrAuthenticatorVerify, err.Error())
 	}
 	return pt, nil

--- a/ntp/protocol/nts/authenticator_test.go
+++ b/ntp/protocol/nts/authenticator_test.go
@@ -28,17 +28,20 @@ import (
 	"github.com/tink-crypto/tink-go/v2/daead/subtle"
 )
 
-// newTestSIV returns an AES-SIV-CMAC instance with a deterministic 64-byte key.
-// Tink requires a 64-byte key (CMAC-512 variant).
-func newTestSIV(t *testing.T) *subtle.AESSIV {
+// newTestAEAD returns an AEAD backed by AES-SIV-CMAC-512 for authenticator tests.
+// Delegates to aeadFor defined in aead_test.go to avoid duplicating test helper logic
+// across test files in package nts.
+func newTestAEAD(t *testing.T) AEAD {
 	t.Helper()
-	key := make([]byte, subtle.AESSIVKeySize)
-	for i := range key {
-		key[i] = byte(i + 1)
-	}
-	siv, err := subtle.NewAESSIV(key)
-	require.NoError(t, err)
-	return siv
+	return aeadFor(t, protocol.AEADAESSIVCMAC512)
+}
+
+// newTestAEADWithAlg builds an AEAD for the given algorithm using a deterministic key.
+// Consolidated to use the single aeadFor helper from aead_test.go to keep algorithm
+// support in sync across test files.
+func newTestAEADWithAlg(t *testing.T, alg protocol.AEADAlgorithm) AEAD {
+	t.Helper()
+	return aeadFor(t, alg)
 }
 
 func TestMarshalAuthenticatorBodyEmptyNonce(t *testing.T) {
@@ -85,7 +88,7 @@ func TestParseAuthenticatorBodyRejectsLengthExceedingBuffer(t *testing.T) {
 }
 
 func TestSealOpenAuthenticatorEmptyPlaintext(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	ad := []byte("some-associated-data-from-the-ntp-packet")
 
 	ef, err := SealAuthenticator(siv, ad, nil)
@@ -98,7 +101,7 @@ func TestSealOpenAuthenticatorEmptyPlaintext(t *testing.T) {
 }
 
 func TestSealOpenAuthenticatorWithPlaintext(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	ad := []byte("ntp-header-and-leading-extension-fields")
 	plaintext := []byte("encrypted-extension-field-payload")
 
@@ -111,7 +114,7 @@ func TestSealOpenAuthenticatorWithPlaintext(t *testing.T) {
 }
 
 func TestOpenAuthenticatorRejectsTamperedAD(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	ad := []byte("authentic-associated-data")
 
 	ef, err := SealAuthenticator(siv, ad, nil)
@@ -124,7 +127,7 @@ func TestOpenAuthenticatorRejectsTamperedAD(t *testing.T) {
 }
 
 func TestOpenAuthenticatorRejectsTamperedCiphertext(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	ad := []byte("ad")
 
 	ef, err := SealAuthenticator(siv, ad, []byte("plaintext"))
@@ -145,7 +148,7 @@ func TestOpenAuthenticatorRejectsTamperedCiphertext(t *testing.T) {
 // linter) changes the wrap from "%w: %s" to "%w: %w" and silently puts
 // tink's err back in the chain.
 func TestOpenAuthenticatorVerifyChainTerminatesAtSentinel(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	ad := []byte("ad")
 
 	ef, err := SealAuthenticator(siv, ad, []byte("plaintext"))
@@ -166,19 +169,51 @@ func TestOpenAuthenticatorVerifyChainTerminatesAtSentinel(t *testing.T) {
 }
 
 func TestOpenAuthenticatorRejectsWrongType(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	bogus := protocol.ExtensionField{Type: protocol.UniqueIdentifier, Body: make([]byte, 32)}
 	_, err := OpenAuthenticator(siv, []byte("ad"), bogus)
 	require.ErrorIs(t, err, ErrAuthenticatorMalformed)
 }
 
 func TestOpenAuthenticatorRejectsNonEmptyNonce(t *testing.T) {
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	body, err := MarshalAuthenticatorBody([]byte{1, 2, 3, 4}, []byte{5, 6, 7, 8})
 	require.NoError(t, err)
 	ef := protocol.ExtensionField{Type: protocol.NTSAuthenticator, Body: body}
 	_, err = OpenAuthenticator(siv, []byte("ad"), ef)
 	require.ErrorIs(t, err, ErrAuthenticatorMalformed)
+}
+
+// TestSealOpenAuthenticatorGCMSIV exercises the non-deterministic GCM-SIV path
+// through the authenticator: unlike SIV, GCM-SIV emits a non-empty nonce that
+// must survive marshalling into and parsing back out of the EF body.
+func TestSealOpenAuthenticatorGCMSIV(t *testing.T) {
+	aead := newTestAEADWithAlg(t, protocol.AEADAES128GCMSIV)
+	ad := []byte("ntp-header-and-leading-extension-fields")
+	plaintext := []byte("encrypted-extension-field-payload")
+
+	ef, err := SealAuthenticator(aead, ad, plaintext)
+	require.NoError(t, err)
+	require.Equal(t, protocol.NTSAuthenticator, ef.Type)
+
+	got, err := OpenAuthenticator(aead, ad, ef)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, got)
+}
+
+// TestOpenAuthenticatorGCMSIVRejectsTamperedAD checks that the GCM-SIV path
+// fails verification when the associated data is altered after sealing.
+func TestOpenAuthenticatorGCMSIVRejectsTamperedAD(t *testing.T) {
+	aead := newTestAEADWithAlg(t, protocol.AEADAES128GCMSIV)
+	ad := []byte("authentic-associated-data")
+
+	ef, err := SealAuthenticator(aead, ad, []byte("plaintext"))
+	require.NoError(t, err)
+
+	tampered := bytes.Clone(ad)
+	tampered[0] ^= 0xff
+	_, err = OpenAuthenticator(aead, tampered, ef)
+	require.ErrorIs(t, err, ErrAuthenticatorVerify)
 }
 
 // TestAESSIVKnownAnswerVectors pins tink's deterministic AES-SIV-CMAC-512
@@ -250,7 +285,7 @@ func TestAESSIVKnownAnswerVectors(t *testing.T) {
 func TestSealAuthenticatorThroughExtensionFramework(t *testing.T) {
 	// Verify the EF can be encoded with MarshalExtensionFields and round-trips
 	// through ParseExtensionFields cleanly.
-	siv := newTestSIV(t)
+	siv := newTestAEAD(t)
 	ad := []byte("packet-up-to-authenticator")
 	plaintext := make([]byte, 16)
 	_, err := rand.Read(plaintext)


### PR DESCRIPTION
Summary:
- `nts/aead.go`: Defined the AEAD interface with `Seal()` and `Open()`, which define the contract that both cipher implementations must satisfy; implemented aesSIVCMAC and aesGCMSIV as wrappers around the tink library. The `NewAEAD()` factory function, given an IANA AEAD algorithm ID and a raw key, returns a ready-to-use object that satisfies the AEAD interface without the caller needing to know which concrete cipher implementation backs it. Removed stray `// Seal encrypts` fragment from AEAD interface godoc so Seal method documentation reads cleanly. Fixed slice aliasing hazard in aesGCMSIV.Seal by returning independent copies via bytes.Clone instead of subslices sharing tink buffer. Made error wrapping consistent: Open now wraps tink errors with "nts: SIV decrypt" and "nts: GCM-SIV decrypt" prefixes matching Seal path.

- `nts/aead_test.go`: Tests round-trip for both algorithms, AD-tamper rejection, ciphertext-tamper rejection, and wrong-length-nonce rejection.

- `authenticator.go`: No longer knows about concrete ciphers; now depends on the AEAD interface. `SealAuthenticator()` and `OpenAuthenticator()` accept any algorithm.

- `authenticator_test.go`: `newTestSIV()` replaced with `newTestAEAD()`. Added a GCM-SIV round-trip (non-empty nonce path) and GCM-SIV AD-tamper → ErrAuthenticatorVerify.

- `extension_fields.go`: Added IANA AEAD IDs 17 and 30 for the AEAD_AES_SIV_CMAC_512 and AEAD_AES_128_GCM_SIV algorithms, respectively.

- `extension_fields_test.go`: Pins the new AEADAESSIVCMAC512 (17) and AEADAES128GCMSIV (30) constants to their IANA registry values.

Reviewed By: vvfedorenko

Differential Revision: D110591249


