### PR TITLE
fix linter issue

### DIFF
--- a/cmd/ntripper/main.go
+++ b/cmd/ntripper/main.go
@@ -247,7 +247,7 @@ func runOnce(ctx context.Context, cfg config, logger *slog.Logger, st *stats.JSO
 		err = streamFrames(ctx, sockConn, client, logger, st, stationID, ephColl)
 		sockConn.Close()
 
-		if err == nil || ctx.Err() != nil {
+		if ctx.Err() != nil {
 			return err
 		}
 

--- a/cmd/ptpcheck/cmd/ptping.go
+++ b/cmd/ptpcheck/cmd/ptping.go
@@ -97,9 +97,8 @@ func (p *ptping) init() error {
 	timestamp.TimeoutTXTS = 100 * time.Millisecond
 	p.client, err = client.NewClient(p.target, ptp.PortEvent, p.clockID, p.eventConn, &client.Config{}, &client.JSONStats{})
 	go func() {
-		if err := p.runReader(); err != nil {
-			log.Error(err)
-		}
+		err := p.runReader()
+		log.Error(err)
 	}()
 
 	return err

--- a/cmd/ptpcheck/cmd/ts2phc.go
+++ b/cmd/ptpcheck/cmd/ts2phc.go
@@ -139,8 +139,7 @@ var ts2phcCmd = &cobra.Command{
 		go func() {
 			log.Fatalf("Metrics server error: %v", metrics.RunMetricsServer(monitoringPort, metricsHandler))
 		}()
-		if err := ts2phcRun(srcDeviceTS2PHCFlag, dstDeviceTS2PHCFlag, intervalTS2PHCFlag, firstStepTS2PHCFlag, stepThresholdTS2PHCFlag, srcPinTS2PHCFlag, metricsHandler); err != nil {
-			log.Fatal(err)
-		}
+		err := ts2phcRun(srcDeviceTS2PHCFlag, dstDeviceTS2PHCFlag, intervalTS2PHCFlag, firstStepTS2PHCFlag, stepThresholdTS2PHCFlag, srcPinTS2PHCFlag, metricsHandler)
+		log.Fatal(err)
 	},
 }


### PR DESCRIPTION
Summary: ts2phcRun always return error. remove redundant if statement

Reviewed By: pmazzini

Differential Revision: D111040017


