### PR TITLE
Add server NTS-KE

### DIFF
--- a/ntp/ntske/records.go
+++ b/ntp/ntske/records.go
@@ -75,6 +75,7 @@ var (
 	ErrBodyTruncated   = errors.New("ntske: record body truncated")
 	ErrBodyTooLarge    = errors.New("ntske: record body exceeds 16-bit length field")
 	ErrTypeTooLarge    = errors.New("ntske: record type exceeds 15-bit field")
+	ErrOddLengthBody   = errors.New("ntske: odd-length uint16 body")
 )
 
 // Marshal encodes a single record into its wire format (RFC 8915 §4).
@@ -173,26 +174,26 @@ func NewEndOfMessage() Record {
 // NewNextProtocol returns a Next Protocol Negotiation record carrying the given
 // protocol IDs. The Critical Bit MUST be set.
 func NewNextProtocol(protocolIDs ...uint16) Record {
-	return Record{Critical: true, Type: RecordNextProtocol, Body: marshalUint16s(protocolIDs)}
+	return Record{Critical: true, Type: RecordNextProtocol, Body: MarshalUint16s(protocolIDs)}
 }
 
 // NewError returns an Error record carrying the given error code
 // The Critical Bit MUST be set.
 func NewError(code uint16) Record {
-	return Record{Critical: true, Type: RecordError, Body: marshalUint16s([]uint16{code})}
+	return Record{Critical: true, Type: RecordError, Body: MarshalUint16s([]uint16{code})}
 }
 
 // NewWarning returns a Warning record carrying the given warning code
 // The Critical Bit MUST be set.
 func NewWarning(code uint16) Record {
-	return Record{Critical: true, Type: RecordWarning, Body: marshalUint16s([]uint16{code})}
+	return Record{Critical: true, Type: RecordWarning, Body: MarshalUint16s([]uint16{code})}
 }
 
 // NewAEADAlgorithm returns an AEAD Algorithm Negotiation record carrying the
 // given algorithm IDs. The Critical Bit MAY be set; it is
 // left unset here.
 func NewAEADAlgorithm(algorithmIDs ...uint16) Record {
-	return Record{Type: RecordAEADAlgorithm, Body: marshalUint16s(algorithmIDs)}
+	return Record{Type: RecordAEADAlgorithm, Body: MarshalUint16s(algorithmIDs)}
 }
 
 // NewCookie returns a New Cookie for NTPv4 record carrying the opaque cookie
@@ -211,14 +212,27 @@ func NewServerNegotiation(server string) Record {
 // NewPortNegotiation returns an NTPv4 Port Negotiation record carrying the UDP
 // port number (RFC 8915 §4.1.8).
 func NewPortNegotiation(port uint16) Record {
-	return Record{Type: RecordPortNegotiation, Body: marshalUint16s([]uint16{port})}
+	return Record{Type: RecordPortNegotiation, Body: MarshalUint16s([]uint16{port})}
 }
 
-// marshalUint16s encodes a sequence of 16-bit integers in network byte order.
-func marshalUint16s(values []uint16) []byte {
+// MarshalUint16s encodes a sequence of 16-bit integers in network byte order.
+func MarshalUint16s(values []uint16) []byte {
 	out := make([]byte, 2*len(values))
 	for i, v := range values {
-		binary.BigEndian.PutUint16(out[2*i:2*i+2], v)
+		binary.BigEndian.PutUint16(out[2*i:], v)
 	}
 	return out
+}
+
+// ParseUint16s decodes a body of packed 16-bit network-order integers.
+// Returns ErrOddLengthBody if len is odd — faulty NTS-KE body per RFC 8915.
+func ParseUint16s(b []byte) ([]uint16, error) {
+	if len(b)%2 != 0 {
+		return nil, ErrOddLengthBody
+	}
+	out := make([]uint16, len(b)/2)
+	for i := 0; i < len(b); i += 2 {
+		out[i/2] = binary.BigEndian.Uint16(b[i:])
+	}
+	return out, nil
 }

--- a/ntp/ntske/records_test.go
+++ b/ntp/ntske/records_test.go
@@ -206,3 +206,29 @@ func TestConstructors(t *testing.T) {
 		})
 	}
 }
+
+// TestParseUint16s verifies round-trip encoding and odd-length rejection.
+func TestParseUint16s(t *testing.T) {
+	vals, err := ParseUint16s([]byte{0x00, 0x01, 0x00, 0x1e})
+	require.NoError(t, err)
+	require.Equal(t, []uint16{1, 30}, vals)
+
+	vals, err = ParseUint16s([]byte{0x00})
+	require.ErrorIs(t, err, ErrOddLengthBody)
+	require.Nil(t, vals)
+
+	vals, err = ParseUint16s([]byte{0x00, 0x01, 0xFF})
+	require.ErrorIs(t, err, ErrOddLengthBody)
+	require.Nil(t, vals)
+
+	vals, err = ParseUint16s(nil)
+	require.NoError(t, err)
+	require.Empty(t, vals)
+
+	// Round-trip via MarshalUint16s
+	orig := []uint16{0, 1, 30, 65535}
+	wire := MarshalUint16s(orig)
+	decoded, err := ParseUint16s(wire)
+	require.NoError(t, err)
+	require.Equal(t, orig, decoded)
+}

--- a/ntp/ntske/server.go
+++ b/ntp/ntske/server.go
@@ -1,0 +1,446 @@
+package ntske
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"slices"
+	"time"
+
+	"github.com/facebook/time/ntp/protocol"
+)
+
+// NTS-KE protocol constants
+const (
+	// ALPNProtocol is the ALPN protocol ID negotiated over TLS.
+	ALPNProtocol = "ntske/1"
+	// exporterLabel is the RFC 8915 TLS exporter label used for key extraction.
+	exporterLabel = "EXPORTER-network-time-security"
+	// NextProtocolNTPv4 is the Next Protocol ID for NTPv4.
+	NextProtocolNTPv4 uint16 = 0
+	// maxMessageSize is the upper bound on a single NTS-KE message.
+	maxMessageSize = 64 * 1024
+)
+
+// server default
+const (
+	// defaultCookies is the number of cookies issued per handshake when Server.Cookies is unset.
+	defaultCookies = 8
+	// maxCookies is the hard upper bound on cookies issued per handshake,
+	// regardless of Server.Cookies. It bounds the per-connection cookie-sealing
+	// cost and the response size so a large or misconfigured Cookies value
+	// cannot be turned into a CPU/bandwidth amplification vector.
+	maxCookies = 32
+	// defaultHandshakeTimeout is the per-connection deadline applied to the entire
+	// NTS-KE exchange when Server.HandshakeTimeout is unset. It bounds TLS handshake,
+	// request read, validation, cookie sealing, and response write — not just the
+	// TLS handshake.
+	defaultHandshakeTimeout = 10 * time.Second
+)
+
+// exporter constants direction RFC 8915 5.1
+const (
+	// directionC2S labels the client-to-server key direction.
+	directionC2S byte = 0
+	// directionS2C labels the server-to-client key direction.
+	directionS2C byte = 1
+)
+
+// NTS-KE error codes RFC 8915 7.8
+const (
+	// errorUnrecognizedCriticalRecord means a critical record had an unrecognized type.
+	errorUnrecognizedCriticalRecord uint16 = 0
+	// errorBadRequest means the request was malformed.
+	errorBadRequest uint16 = 1
+	// errorInternalServerError means the server failed to process a valid request.
+	errorInternalServerError uint16 = 2
+)
+
+// Stats receives per-connection counters emitted by a Server.
+type Stats interface {
+	IncHandshakes() // a TLS handshake completed with ALPN "ntske/1"
+	IncErrors()     // a connection ended in an NTS-KE Error response or failure
+}
+
+// Server holds the configuration for an NTS-KE server. The zero value is not
+// usable; TLSConfig and Keystore must be set before serving.
+type Server struct {
+	// TLSConfig is cloned per listener; MinVersion is pinned to TLS 1.3 and
+	// NextProtos to "ntske/1".
+	TLSConfig *tls.Config
+	// Keystore seals NTS cookies returned to clients.
+	Keystore Keystore
+	// Cookies is the number of NewCookie records to issue per exchange.
+	// Defaults to 8 when unset and is capped at maxCookies (32); larger values
+	// are clamped to bound per-connection cost.
+	Cookies uint16
+	// SupportedAEAD is the list of AEAD algorithm IDs the server will negotiate.
+	// Defaults to AES-128-GCM-SIV (30) and AES-SIV-CMAC-512 (17) when unset.
+	SupportedAEAD []uint16
+	// HandshakeTimeout is the per-connection deadline for the entire NTS-KE
+	// exchange, not just the TLS handshake. It bounds TLS handshake,
+	// request record read, request validation, cookie sealing via Keystore,
+	// and response write. Defaults to 10s when unset. Size this to accommodate
+	// slow keystore or network paths; TLS-only sizing will cause premature
+	// timeouts.
+	HandshakeTimeout time.Duration
+	// NTPv4Server, if set, is advertised in Server Negotiation records.
+	NTPv4Server string
+	// NTPv4Port, if non-zero, is advertised in Port Negotiation records.
+	NTPv4Port uint16
+	// Stats, if non-nil, receives per-connection counters.
+	Stats Stats
+}
+
+// cookieError wraps an NTS-KE error code so the handler can distinguish a
+// protocol rejection (respond with an Error record, code carried here) from a
+// transport failure (just drop the connection).
+type cookieError struct {
+	code uint16
+	err  error
+}
+
+func (e *cookieError) Error() string { return fmt.Sprintf("ntske: error code %d: %v", e.code, e.err) }
+func (e *cookieError) Unwrap() error { return e.err }
+func protocolError(code uint16, format string, args ...any) *cookieError {
+	return &cookieError{code: code, err: fmt.Errorf(format, args...)}
+}
+
+// ListenAndServe listens on the TCP address addr and serves NTS-KE connections
+// until ctx is cancelled. It returns the error that stopped the accept loop; a
+// clean shutdown via ctx cancellation returns nil.
+func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
+	if s.TLSConfig == nil {
+		return errors.New("ntske: TLSConfig is required")
+	}
+	if s.Keystore == nil {
+		return errors.New("ntske: Keystore is required")
+	}
+	// Clone so we never mutate the caller's config, then pin the two invariants
+	// the protocol requires: TLS 1.3 and ALPN "ntske/1".
+	tlsConf := s.TLSConfig.Clone()
+	tlsConf.MinVersion = tls.VersionTLS13
+	tlsConf.NextProtos = []string{ALPNProtocol}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("ntske: listen %q: %w", addr, err)
+	}
+	tlsLn := tls.NewListener(ln, tlsConf)
+	// Cancelling ctx unblocks Accept by closing the listener; the resulting
+	// net.ErrClosed is treated as a clean stop below.
+	context.AfterFunc(ctx, func() { _ = tlsLn.Close() })
+	for {
+		conn, err := tlsLn.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				//nolint:nilerr // ctx cancellation/ErrClosed is a clean shutdown, not a failure
+				return nil
+			}
+			return fmt.Errorf("ntske: accept: %w", err)
+		}
+		go s.handleConnection(ctx, conn)
+	}
+}
+
+// handleConnection runs the full NTS-KE exchange for one client. It is the main
+// per-connection routine and never returns an error to the caller: every exit
+// path either sends the client an Error record or closes the connection, and
+// records the outcome in Stats.
+func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	// (1) Bound the whole exchange with one deadline derived from the timeout.
+	deadline := time.Now().Add(s.handshakeTimeout())
+	_ = conn.SetDeadline(deadline)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	// (2) The listener produced a *tls.Conn; the handshake is lazy, so drive it
+	// explicitly to fail fast and to expose ConnectionState before any I/O.
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		slog.Error("ntske: connection is not TLS", "remote", conn.RemoteAddr())
+		s.incErrors()
+		return
+	}
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		slog.Warn("ntske: TLS handshake failed", "remote", conn.RemoteAddr(), "err", err)
+		s.incErrors()
+		return
+	}
+	// (3) Enforce ALPN: a client that did not select "ntske/1" is not speaking
+	// this protocol, so there is no meaningful Error record to send — just drop.
+	cs := tlsConn.ConnectionState()
+	if cs.NegotiatedProtocol != ALPNProtocol {
+		slog.Warn("ntske: wrong ALPN", "remote", conn.RemoteAddr(), "alpn", cs.NegotiatedProtocol)
+		s.incErrors()
+		return
+	}
+	s.incHandshakes()
+	// (4) Read the request records up to End of Message, maxCapped at 64 KiB.
+	records, err := readMessage(tlsConn, maxMessageSize)
+	if err != nil {
+		slog.Warn("ntske: reading request", "remote", conn.RemoteAddr(), "err", err)
+		s.incErrors()
+		return
+	}
+	// (5) Validate the request and choose the AEAD algorithm. A protocol-level
+	// failure carries an error code we relay to the client; anything else drops.
+	aeadID, err := s.validateRequest(records)
+	if err != nil {
+		var ce *cookieError
+		if errors.As(err, &ce) { //nolint:modernize // Go 1.25 compatibility: avoid errors.AsType which requires Go 1.26
+			s.writeError(tlsConn, ce.code)
+		}
+		slog.Warn("ntske: invalid request", "remote", conn.RemoteAddr(), "err", err)
+		s.incErrors()
+		return
+	}
+	// (6) Derive C2S/S2C keys from the TLS session and seal the cookies.
+	response, err := s.buildResponse(cs, aeadID)
+	if err != nil {
+		s.writeError(tlsConn, errorInternalServerError)
+		slog.Error("ntske: building response", "remote", conn.RemoteAddr(), "err", err)
+		s.incErrors()
+		return
+	}
+	// (7) Marshal and write the response records back to the client.
+	if err := s.writeRecords(tlsConn, response); err != nil {
+		slog.Warn("ntske: writing response", "remote", conn.RemoteAddr(), "err", err)
+		s.incErrors()
+	}
+}
+
+// validateRequest checks the client's records against RFC 8915 §4.1 and returns
+// the negotiated AEAD algorithm ID. It requires a Next Protocol record naming
+// NTPv4, an AEAD record whose list intersects SupportedAEAD, and a terminating
+// End of Message; any unrecognized critical record is rejected with error code
+// 0. The chosen algorithm is the client's first preference the server supports.
+// Duplicate Next Protocol or AEAD Algorithm records are rejected with BadRequest
+// to avoid silent overwrite and to signal the error back to the client.
+func (s *Server) validateRequest(records []Record) (uint16, error) {
+	var (
+		sawNextProto bool
+		sawEOM       bool
+		sawAEAD      bool
+		clientAEAD   []uint16
+		ntpv4        bool
+		err          error
+	)
+	for _, r := range records {
+		switch r.Type {
+		case RecordEndOfMessage:
+			sawEOM = true
+		case RecordNextProtocol:
+			if sawNextProto {
+				return 0, protocolError(errorBadRequest,
+					"duplicate Next Protocol Negotiation record")
+			}
+			sawNextProto = true
+			var ids []uint16
+			ids, err = ParseUint16s(r.Body)
+			if err != nil {
+				return 0, protocolError(errorBadRequest, "malformed Next Protocol body: %v", err)
+			}
+			for _, id := range ids {
+				if id == NextProtocolNTPv4 {
+					ntpv4 = true
+				}
+			}
+		case RecordAEADAlgorithm:
+			if sawAEAD {
+				return 0, protocolError(errorBadRequest,
+					"duplicate AEAD Algorithm Negotiation record")
+			}
+			sawAEAD = true
+			clientAEAD, err = ParseUint16s(r.Body)
+			if err != nil {
+				return 0, protocolError(errorBadRequest, "malformed AEAD body: %v", err)
+			}
+		case RecordError, RecordWarning, RecordNewCookie,
+			RecordServerNegotiation, RecordPortNegotiation:
+			// Records a client may legally send or we simply ignore server-side.
+		default:
+			// Unknown record: only fatal if the Critical Bit is set (RFC 8915 §4).
+			if r.Critical {
+				return 0, protocolError(errorUnrecognizedCriticalRecord,
+					"unknown critical record type %d", r.Type)
+			}
+		}
+	}
+	switch {
+	case !sawEOM:
+		return 0, protocolError(errorBadRequest, "missing End of Message record")
+	case !sawNextProto || !ntpv4:
+		return 0, protocolError(errorBadRequest, "no NTPv4 in Next Protocol Negotiation")
+	case !sawAEAD:
+		return 0, protocolError(errorBadRequest, "missing AEAD Algorithm Negotiation")
+	case len(clientAEAD) == 0:
+		return 0, protocolError(errorBadRequest, "empty AEAD Algorithm Negotiation body")
+	}
+	// Pick the client's first preference that we support. Client order wins, and
+	// we only offer an algorithm we can actually derive keys for (aeadIDToKeyLen
+	// is the source of truth), so a misconfigured SupportedAEAD yields a clean
+	// rejection here instead of an internal error later in buildResponse.
+	for _, id := range clientAEAD {
+		if !slices.Contains(s.supportedAEAD(), id) {
+			continue
+		}
+		if _, err := aeadIDToKeyLen(protocol.AEADAlgorithm(id)); err != nil {
+			continue
+		}
+		return id, nil
+	}
+	return 0, protocolError(errorBadRequest, "no mutually supported AEAD algorithm")
+}
+
+// buildResponse derives the directional keys for the negotiated algorithm and
+// assembles the NTS-KE response: Next Protocol, AEAD, optional NTP server/port
+// hints, N cookies, and End of Message.
+func (s *Server) buildResponse(cs tls.ConnectionState, aeadID uint16) ([]Record, error) {
+	// aeadIDToKeyLen lives in keystore.go (same package) — reuse it instead of
+	// a duplicate lookup. It takes protocol.AEADAlgorithm, so convert the wire
+	// uint16 at the boundary.
+	keyLen, err := aeadIDToKeyLen(protocol.AEADAlgorithm(aeadID))
+	if err != nil {
+		return nil, err
+	}
+
+	c2s, err := exportKey(cs, aeadID, directionC2S, keyLen)
+	if err != nil {
+		return nil, err
+	}
+	s2c, err := exportKey(cs, aeadID, directionS2C, keyLen)
+	if err != nil {
+		return nil, err
+	}
+
+	records := []Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(aeadID),
+	}
+	if s.NTPv4Server != "" {
+		records = append(records, NewServerNegotiation(s.NTPv4Server))
+	}
+	if s.NTPv4Port != 0 {
+		records = append(records, NewPortNegotiation(s.NTPv4Port))
+	}
+	for range s.cookieCount() {
+		cookie, err := s.Keystore.SealCookie(protocol.AEADAlgorithm(aeadID), c2s, s2c)
+		if err != nil {
+			return nil, fmt.Errorf("sealing cookie: %w", err)
+		}
+		records = append(records, NewCookie(cookie))
+	}
+	return append(records, NewEndOfMessage()), nil
+}
+
+// writeError sends a critical Error record followed by End of Message (best effort).
+func (s *Server) writeError(w io.Writer, code uint16) {
+	_ = s.writeRecords(w, []Record{NewError(code), NewEndOfMessage()})
+}
+
+// writeRecords marshals records to the NTS-KE wire format and writes them.
+func (s *Server) writeRecords(w io.Writer, records []Record) error {
+	b, err := MarshalRecords(records)
+	if err != nil {
+		return fmt.Errorf("ntske: marshal response: %w", err)
+	}
+	if _, err := w.Write(b); err != nil {
+		return fmt.Errorf("ntske: write response: %w", err)
+	}
+	return nil
+}
+
+// readMessage reads NTS-KE records from r until an End of Message record, never
+// consuming more than maxCap octets in total.
+func readMessage(r io.Reader, maxCap int) ([]Record, error) {
+	// buf grows on demand as records are read; total bounds it by maxCap.
+	var buf []byte
+	header := make([]byte, recordHeaderLen)
+	total := 0
+	for {
+		if _, err := io.ReadFull(r, header); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrHeaderTruncated, err)
+		}
+		bodyLen := int(binary.BigEndian.Uint16(header[2:4]))
+		total += recordHeaderLen + bodyLen
+		// Check cap immediately after computing total and reject before growing
+		// buf so the bound is tight and obvious.
+		if total > maxCap {
+			return nil, fmt.Errorf("%w: message exceeds %d octets", ErrBodyTooLarge, maxCap)
+		}
+		buf = append(buf, header...)
+		body := make([]byte, bodyLen)
+		if _, err := io.ReadFull(r, body); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrBodyTruncated, err)
+		}
+		buf = append(buf, body...)
+
+		typeWord := binary.BigEndian.Uint16(header[0:2])
+		if typeWord&typeMask == RecordEndOfMessage {
+			return Parse(buf)
+		}
+	}
+}
+
+// exporterContext builds the 5-octet RFC 8915 §4.3 exporter context:
+// [Next Protocol:2 BE][AEAD Algorithm:2 BE][direction:1].
+func exporterContext(aeadID uint16, direction byte) []byte {
+	ctx := make([]byte, 5)
+	binary.BigEndian.PutUint16(ctx[0:2], NextProtocolNTPv4)
+	binary.BigEndian.PutUint16(ctx[2:4], aeadID)
+	ctx[4] = direction
+	return ctx
+}
+
+// exportKey derives one directional NTS-KE key from the TLS session using the
+// RFC 8915 exporter label and the 5-octet context for the given direction.
+func exportKey(cs tls.ConnectionState, aeadID uint16, direction byte, keyLen int) ([]byte, error) {
+	key, err := cs.ExportKeyingMaterial(exporterLabel, exporterContext(aeadID, direction), keyLen)
+	if err != nil {
+		return nil, fmt.Errorf("exporting key (direction %d): %w", direction, err)
+	}
+	return key, nil
+}
+
+// --- default accessors ---
+func (s *Server) cookieCount() uint16 {
+	n := s.Cookies
+	if n == 0 {
+		n = defaultCookies
+	}
+	return min(n, maxCookies)
+}
+func (s *Server) supportedAEAD() []uint16 {
+	if len(s.SupportedAEAD) > 0 {
+		return s.SupportedAEAD
+	}
+	return []uint16{
+		uint16(protocol.AEADAES128GCMSIV),  // 30
+		uint16(protocol.AEADAESSIVCMAC512), // 17
+	}
+}
+
+// handshakeTimeout returns the effective per-connection deadline duration.
+// Despite the historical name, this bounds the entire NTS-KE exchange:
+// TLS handshake, record read, validation, cookie sealing, and response write.
+func (s *Server) handshakeTimeout() time.Duration {
+	if s.HandshakeTimeout > 0 {
+		return s.HandshakeTimeout
+	}
+	return defaultHandshakeTimeout
+}
+func (s *Server) incHandshakes() {
+	if s.Stats != nil {
+		s.Stats.IncHandshakes()
+	}
+}
+func (s *Server) incErrors() {
+	if s.Stats != nil {
+		s.Stats.IncErrors()
+	}
+}

--- a/ntp/ntske/server_test.go
+++ b/ntp/ntske/server_test.go
@@ -1,0 +1,535 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ntske
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/facebook/time/ntp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// gcmSIV and sivCMAC are the two AEAD IDs as they travel on the wire (uint16),
+// spelled out here so the tests read against the negotiation, not the crypto.
+const (
+	gcmSIV  = uint16(protocol.AEADAES128GCMSIV)  // 30
+	sivCMAC = uint16(protocol.AEADAESSIVCMAC512) // 17
+)
+
+// countingStats is a Stats implementation that tallies calls. Uses atomics so
+// the -race detector stays quiet when the server calls it from its own
+// goroutine while the test reads the counters.
+type countingStats struct {
+	handshakes atomic.Int64
+	errors     atomic.Int64
+}
+
+func (s *countingStats) IncHandshakes() { s.handshakes.Add(1) }
+func (s *countingStats) IncErrors()     { s.errors.Add(1) }
+
+// newTestTLSConfigs returns a matched server/client pair backed by a throwaway
+// self-signed Ed25519 certificate, both pinned to TLS 1.3 and ALPN "ntske/1".
+func newTestTLSConfigs(t *testing.T) (server, client *tls.Config) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "ntske-test"},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Unix(1<<31-1, 0),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	require.NoError(t, err)
+
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}
+	server = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{ALPNProtocol},
+	}
+	client = &tls.Config{
+		InsecureSkipVerify: true, // #nosec G402 -- test-only self-signed cert
+		MinVersion:         tls.VersionTLS13,
+		NextProtos:         []string{ALPNProtocol},
+	}
+	return server, client
+}
+
+// runExchange spins up srv.handleConnection over an in-memory net.Pipe, drives
+// the client-side TLS handshake with clientTLS, sends request, and returns the
+// client tls.Conn plus the records the server wrote back. The server goroutine
+// has finished by the time this returns.
+func runExchange(t *testing.T, srv *Server, clientTLS *tls.Config, request []Record) (*tls.Conn, []Record) {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	tlsServer := tls.Server(serverConn, srv.TLSConfig)
+	tlsClient := tls.Client(clientConn, clientTLS)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleConnection(context.Background(), tlsServer)
+	}()
+
+	require.NoError(t, tlsClient.HandshakeContext(context.Background()))
+
+	if len(request) > 0 {
+		req, err := MarshalRecords(request)
+		require.NoError(t, err)
+		_, err = tlsClient.Write(req)
+		require.NoError(t, err)
+	}
+
+	// Read the server's reply before waiting on the goroutine: net.Pipe writes
+	// block until read, so the server cannot finish until we drain the response.
+	resp, err := readMessage(tlsClient, maxMessageSize)
+	require.NoError(t, err)
+	<-done
+	return tlsClient, resp
+}
+
+// recordsByType groups a record slice by type for convenient assertions.
+func recordsByType(records []Record) map[uint16][]Record {
+	out := make(map[uint16][]Record)
+	for _, r := range records {
+		out[r.Type] = append(out[r.Type], r)
+	}
+	return out
+}
+
+// parseUint16s is a test helper that decodes a uint16 body, panicking on error
+// because test fixtures are expected to be well-formed. It wraps ParseUint16s
+// which returns ErrOddLengthBody for malformed odd-length bodies.
+func parseUint16s(b []byte) []uint16 {
+	v, err := ParseUint16s(b)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// TestServerIssuesCookies is the end-to-end happy path:
+// TLS 1.3 handshake, negotiates AES-128-GCM-SIV, and the server returns the
+// requested number of cookies. Each cookie must open under the keystore and
+// yield exactly the C2S/S2C keys the client derives independently from the TLS
+// session — proving the exporter label and context match on both sides.
+func TestServerIssuesCookies(t *testing.T) {
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	stats := &countingStats{}
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks, Cookies: 4, Stats: stats}
+
+	tlsClient, resp := runExchange(t, srv, clientTLS, []Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(gcmSIV),
+		NewEndOfMessage(),
+	})
+
+	byType := recordsByType(resp)
+	require.Len(t, byType[RecordNextProtocol], 1)
+	require.Len(t, byType[RecordAEADAlgorithm], 1)
+	require.Len(t, byType[RecordEndOfMessage], 1)
+	require.Equal(t, []uint16{gcmSIV}, parseUint16s(byType[RecordAEADAlgorithm][0].Body))
+	require.Equal(t, RecordEndOfMessage, resp[len(resp)-1].Type, "EOM must be last")
+
+	cookies := byType[RecordNewCookie]
+	require.Len(t, cookies, 4)
+
+	// The client derives the same keys the server sealed into every cookie.
+	cs := tlsClient.ConnectionState()
+	wantC2S, err := cs.ExportKeyingMaterial(exporterLabel, exporterContext(gcmSIV, directionC2S), 16)
+	require.NoError(t, err)
+	wantS2C, err := cs.ExportKeyingMaterial(exporterLabel, exporterContext(gcmSIV, directionS2C), 16)
+	require.NoError(t, err)
+
+	for _, c := range cookies {
+		id, c2s, s2c, err := ks.OpenCookie(c.Body)
+		require.NoError(t, err)
+		require.Equal(t, protocol.AEADAES128GCMSIV, id)
+		require.Equal(t, wantC2S, c2s)
+		require.Equal(t, wantS2C, s2c)
+	}
+
+	require.Equal(t, int64(1), stats.handshakes.Load())
+	require.Equal(t, int64(0), stats.errors.Load())
+}
+
+// TestServerDefaultCookieCount checks that a Server with Cookies unset issues
+// the documented default of 8.
+func TestServerDefaultCookieCount(t *testing.T) {
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks}
+
+	_, resp := runExchange(t, srv, clientTLS, []Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(gcmSIV),
+		NewEndOfMessage(),
+	})
+	require.Len(t, recordsByType(resp)[RecordNewCookie], defaultCookies)
+}
+
+// TestServerClampsCookieCount checks that a Cookies value above the maxCookies
+// upper bound is clamped, so a large or misconfigured value cannot be turned
+// into a per-handshake cookie-sealing / response-size amplification vector.
+func TestServerClampsCookieCount(t *testing.T) {
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks, Cookies: 1000}
+
+	_, resp := runExchange(t, srv, clientTLS, []Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(gcmSIV),
+		NewEndOfMessage(),
+	})
+	require.Len(t, recordsByType(resp)[RecordNewCookie], maxCookies)
+}
+
+// TestServerAEADPreferenceOrder verifies that when the client lists several
+// algorithms the server supports, the server honours the client's first
+// preference rather than its own default order.
+func TestServerAEADPreferenceOrder(t *testing.T) {
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	// Default SupportedAEAD is [30, 17]; client prefers 17 first.
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks, Cookies: 1}
+
+	_, resp := runExchange(t, srv, clientTLS, []Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(sivCMAC, gcmSIV),
+		NewEndOfMessage(),
+	})
+	aead := recordsByType(resp)[RecordAEADAlgorithm]
+	require.Len(t, aead, 1)
+	require.Equal(t, []uint16{sivCMAC}, parseUint16s(aead[0].Body), "client's first preference wins")
+}
+
+// TestServerRejectsWrongALPN checks that a client which completes TLS 1.3 but
+// does not select "ntske/1" is dropped without a response and counted as an
+// error, and that no handshake is credited.
+func TestServerRejectsWrongALPN(t *testing.T) {
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+	clientTLS.NextProtos = nil // offer no ALPN, so negotiation yields ""
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	stats := &countingStats{}
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks, Stats: stats}
+
+	serverConn, clientConn := net.Pipe()
+	tlsServer := tls.Server(serverConn, serverTLS)
+	tlsClient := tls.Client(clientConn, clientTLS)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleConnection(context.Background(), tlsServer)
+	}()
+
+	require.NoError(t, tlsClient.HandshakeContext(context.Background()))
+	<-done
+
+	require.Equal(t, int64(0), stats.handshakes.Load(), "wrong ALPN must not credit a handshake")
+	require.Equal(t, int64(1), stats.errors.Load())
+}
+
+// TestServerErrorResponses exercises the two protocol rejections the client can
+// observe: an unrecognized critical record yields Error(0), and a request whose
+// AEAD list intersects nothing the server supports yields Error(1).
+func TestServerErrorResponses(t *testing.T) {
+	cases := []struct {
+		name    string
+		request []Record
+		want    uint16
+	}{
+		{
+			name: "unknown critical record",
+			request: []Record{
+				NewNextProtocol(NextProtocolNTPv4),
+				NewAEADAlgorithm(gcmSIV),
+				{Critical: true, Type: 999, Body: nil},
+				NewEndOfMessage(),
+			},
+			want: errorUnrecognizedCriticalRecord,
+		},
+		{
+			name: "no mutually supported AEAD",
+			request: []Record{
+				NewNextProtocol(NextProtocolNTPv4),
+				NewAEADAlgorithm(0xBEEF),
+				NewEndOfMessage(),
+			},
+			want: errorBadRequest,
+		},
+		{
+			name: "next protocol without NTPv4",
+			request: []Record{
+				NewNextProtocol(0x0007),
+				NewAEADAlgorithm(gcmSIV),
+				NewEndOfMessage(),
+			},
+			want: errorBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			serverTLS, clientTLS := newTestTLSConfigs(t)
+			ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+			require.NoError(t, err)
+			srv := &Server{TLSConfig: serverTLS, Keystore: ks}
+
+			_, resp := runExchange(t, srv, clientTLS, tc.request)
+			require.Len(t, resp, 2)
+			require.Equal(t, RecordError, resp[0].Type)
+			require.Equal(t, []uint16{tc.want}, parseUint16s(resp[0].Body))
+			require.Equal(t, RecordEndOfMessage, resp[1].Type)
+		})
+	}
+}
+
+// TestListenAndServeRequiresConfig checks the two guard clauses that reject an
+// unusable Server before any listener is created.
+func TestListenAndServeRequiresConfig(t *testing.T) {
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	serverTLS, _ := newTestTLSConfigs(t)
+
+	t.Run("missing TLSConfig", func(t *testing.T) {
+		srv := &Server{Keystore: ks}
+		err := srv.ListenAndServe(context.Background(), "127.0.0.1:0")
+		require.ErrorContains(t, err, "TLSConfig is required")
+	})
+
+	t.Run("missing Keystore", func(t *testing.T) {
+		srv := &Server{TLSConfig: serverTLS}
+		err := srv.ListenAndServe(context.Background(), "127.0.0.1:0")
+		require.ErrorContains(t, err, "Keystore is required")
+	})
+}
+
+// TestListenAndServeListenError checks that a listen failure (here, an
+// out-of-range port) is surfaced rather than swallowed.
+func TestListenAndServeListenError(t *testing.T) {
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	serverTLS, _ := newTestTLSConfigs(t)
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks}
+
+	err = srv.ListenAndServe(context.Background(), "127.0.0.1:99999999")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "listen")
+}
+
+// TestListenAndServe drives the real accept loop over a loopback listener:
+// a client completes the full NTS-KE exchange against the served port, and
+// cancelling the context cleanly stops the loop with a nil return.
+func TestListenAndServe(t *testing.T) {
+	// Grab a free loopback port, then release it for the server to rebind.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := probe.Addr().String()
+	require.NoError(t, probe.Close())
+
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	require.NoError(t, err)
+	stats := &countingStats{}
+	srv := &Server{TLSConfig: serverTLS, Keystore: ks, Cookies: 2, Stats: stats}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe(ctx, addr) }()
+
+	// The accept loop starts asynchronously; retry until the port is bound.
+	var conn *tls.Conn
+	require.Eventually(t, func() bool {
+		c, derr := tls.Dial("tcp", addr, clientTLS)
+		if derr != nil {
+			return false
+		}
+		conn = c
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+	defer func() { _ = conn.Close() }()
+
+	req, err := MarshalRecords([]Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(gcmSIV),
+		NewEndOfMessage(),
+	})
+	require.NoError(t, err)
+	_, err = conn.Write(req)
+	require.NoError(t, err)
+
+	resp, err := readMessage(conn, maxMessageSize)
+	require.NoError(t, err)
+	require.Len(t, recordsByType(resp)[RecordNewCookie], 2)
+	require.Equal(t, int64(1), stats.handshakes.Load())
+
+	// Cancelling the context closes the listener; the accept loop returns nil.
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "ctx cancellation is a clean shutdown")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServe did not return after context cancellation")
+	}
+}
+
+// TestValidateRequest unit-tests the pure negotiation logic, including the
+// missing-EOM branch that readMessage otherwise guarantees end-to-end.
+func TestValidateRequest(t *testing.T) {
+	srv := &Server{} // uses default SupportedAEAD [30, 17]
+
+	t.Run("happy path returns chosen AEAD", func(t *testing.T) {
+		id, err := srv.validateRequest([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(sivCMAC, gcmSIV),
+			NewEndOfMessage(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, sivCMAC, id)
+	})
+
+	t.Run("unknown non-critical record is ignored", func(t *testing.T) {
+		_, err := srv.validateRequest([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(gcmSIV),
+			{Critical: false, Type: 999},
+			NewEndOfMessage(),
+		})
+		require.NoError(t, err)
+	})
+
+	errCases := []struct {
+		name    string
+		records []Record
+		code    uint16
+	}{
+		{"missing EOM", []Record{NewNextProtocol(NextProtocolNTPv4), NewAEADAlgorithm(gcmSIV)}, errorBadRequest},
+		{"missing next protocol", []Record{NewAEADAlgorithm(gcmSIV), NewEndOfMessage()}, errorBadRequest},
+		{"missing AEAD", []Record{NewNextProtocol(NextProtocolNTPv4), NewEndOfMessage()}, errorBadRequest},
+		{"duplicate next protocol", []Record{
+			NewNextProtocol(NextProtocolNTPv4), NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(gcmSIV), NewEndOfMessage(),
+		}, errorBadRequest},
+		{"duplicate AEAD", []Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(gcmSIV), NewAEADAlgorithm(sivCMAC),
+			NewEndOfMessage(),
+		}, errorBadRequest},
+		{"unknown critical", []Record{
+			NewNextProtocol(NextProtocolNTPv4), NewAEADAlgorithm(gcmSIV),
+			{Critical: true, Type: 999}, NewEndOfMessage(),
+		}, errorUnrecognizedCriticalRecord},
+		{"odd length next protocol", []Record{
+			{Critical: true, Type: RecordNextProtocol, Body: []byte{0x00}},
+			NewAEADAlgorithm(gcmSIV), NewEndOfMessage(),
+		}, errorBadRequest},
+		{"odd length AEAD", []Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			{Type: RecordAEADAlgorithm, Body: []byte{0x00, 0x1e, 0xFF}},
+			NewEndOfMessage(),
+		}, errorBadRequest},
+	}
+	for _, tc := range errCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := srv.validateRequest(tc.records)
+			var ce *cookieError
+			require.ErrorAs(t, err, &ce)
+			require.Equal(t, tc.code, ce.code)
+		})
+	}
+}
+
+// TestExporterContext pins the exact 5-octet RFC 8915 §4.3 context bytes for
+// each direction: [NextProto:2][AEAD:2][direction:1].
+func TestExporterContext(t *testing.T) {
+	require.Equal(t, []byte{0x00, 0x00, 0x00, 0x1e, 0x00}, exporterContext(gcmSIV, directionC2S))
+	require.Equal(t, []byte{0x00, 0x00, 0x00, 0x1e, 0x01}, exporterContext(gcmSIV, directionS2C))
+}
+
+// TestParseUint16sRejectsOddLength checks the decoder round-trips MarshalUint16s and rejects
+// odd-length bodies with ErrOddLengthBody per RFC 8915.
+func TestParseUint16sRejectsOddLength(t *testing.T) {
+	vals, err := ParseUint16s([]byte{0, 1, 0, 30})
+	require.NoError(t, err)
+	require.Equal(t, []uint16{1, 30}, vals)
+
+	vals, err = ParseUint16s([]byte{0, 1, 0xFF})
+	require.ErrorIs(t, err, ErrOddLengthBody)
+	require.Nil(t, vals)
+
+	vals, err = ParseUint16s(nil)
+	require.NoError(t, err)
+	require.Empty(t, vals)
+}
+
+// TestReadMessage covers framing: records are read up to (and including) End of
+// Message, trailing bytes after EOM are left unread, the byte cap is enforced,
+// and truncated headers/bodies surface the records.go sentinels.
+func TestReadMessage(t *testing.T) {
+	valid, err := MarshalRecords([]Record{
+		NewNextProtocol(NextProtocolNTPv4),
+		NewAEADAlgorithm(gcmSIV),
+		NewEndOfMessage(),
+	})
+	require.NoError(t, err)
+
+	t.Run("reads to EOM and ignores trailing bytes", func(t *testing.T) {
+		buf := append(bytes.Clone(valid), 0xDE, 0xAD, 0xBE, 0xEF)
+		got, err := readMessage(bytes.NewReader(buf), maxMessageSize)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		require.Equal(t, RecordEndOfMessage, got[2].Type)
+	})
+
+	t.Run("enforces the byte cap", func(t *testing.T) {
+		_, err := readMessage(bytes.NewReader(valid), 4)
+		require.ErrorIs(t, err, ErrBodyTooLarge)
+	})
+
+	t.Run("truncated header", func(t *testing.T) {
+		_, err := readMessage(bytes.NewReader([]byte{0x00, 0x01}), maxMessageSize)
+		require.ErrorIs(t, err, ErrHeaderTruncated)
+	})
+
+	t.Run("truncated body", func(t *testing.T) {
+		// Header claims a 10-octet body but only 2 follow.
+		_, err := readMessage(bytes.NewReader([]byte{0x80, 0x01, 0x00, 0x0A, 0x00, 0x00}), maxMessageSize)
+		require.ErrorIs(t, err, ErrBodyTruncated)
+	})
+}


### PR DESCRIPTION
Summary:
Adds `ntske.Server`, the TLS 1.3 NTS-KE (Key Establishment) server from RFC 8915 

It negotiates an AEAD algorithm with each client, derives the C2S/S2C session keys from the TLS session, seals them into cookies via `Keystore`, and returns a batch of cookies.

`Server` requires `TLSConfig` and `Keystore`; optional knobs are `Cookies` (default 8), `SupportedAEAD` (default `[30, 17]` ), `HandshakeTimeout` (default 10s), `NTPv4Server`/`NTPv4Port` hints, and a `Stats` interface for counters. 

`ListenAndServe(ctx, addr)` runs the accept loop and shuts down when `ctx` is cancelled; each connection is handled in its own goroutine.
Per connection: run the TLS 1.3 handshake and reject unless ALPN is `ntske/1`; read records to End of Message, capped at 64 KiB; validate the request (`Next Protocol` must include NTPv4, the AEAD list must intersect `SupportedAEAD`, EOM must be present, any unknown critical record is rejected with `Error(0)`); pick the AEAD as the client's first preference the server supports; derive the directional keys via `ExportKeyingMaterial` with label `EXPORTER-network-time-security` and the 5-octet context `[NextProto:2][AEAD:2][direction:1]`; seal N cookies and write the response. Malformed requests get `Error(1)`; internal failures get `Error(2)`.
The cookie wire format stays chrony-compatible.

Reviewed By: vvfedorenko

Differential Revision: D111039664


