### PR TITLE
Add chrony's compliant AES-128-GCM-SIV export record

### DIFF
--- a/ntp/ntske/records.go
+++ b/ntp/ntske/records.go
@@ -60,6 +60,9 @@ const (
 	RecordNewCookie         uint16 = 5
 	RecordServerNegotiation uint16 = 6
 	RecordPortNegotiation   uint16 = 7
+	// RecordCompliant128GCMExport  negotiates AES-128-GCM-SIV compliant export. It
+	// is a non-standard (IANA-unassigned) type; non-critical, with an empty body.
+	RecordCompliant128GCMExport uint16 = 1024
 )
 
 const (
@@ -213,6 +216,12 @@ func NewServerNegotiation(server string) Record {
 // port number (RFC 8915 §4.1.8).
 func NewPortNegotiation(port uint16) Record {
 	return Record{Type: RecordPortNegotiation, Body: MarshalUint16s([]uint16{port})}
+}
+
+// NewCompliant128GCMExport returns an AES-128-GCM-SIV compliant-export record.
+// The Critical Bit is not set and the body is empty.
+func NewCompliant128GCMExport() Record {
+	return Record{Type: RecordCompliant128GCMExport, Body: []byte{}}
 }
 
 // MarshalUint16s encodes a sequence of 16-bit integers in network byte order.

--- a/ntp/ntske/records_test.go
+++ b/ntp/ntske/records_test.go
@@ -170,7 +170,7 @@ func TestParseZeroLengthBodyMidStream(t *testing.T) {
 	require.Equal(t, rec.Body, got[1].Body)
 }
 
-// TestConstructors covers all eight defined record-type constructor helpers,
+// TestConstructors covers the defined record-type constructor helpers,
 // checking the record type, critical bit, and body encoding of each.
 func TestConstructors(t *testing.T) {
 	cases := []struct {
@@ -188,6 +188,7 @@ func TestConstructors(t *testing.T) {
 		{"new cookie", NewCookie([]byte{0xab, 0xcd}), RecordNewCookie, false, []byte{0xab, 0xcd}},
 		{"server negotiation", NewServerNegotiation("ntp.example"), RecordServerNegotiation, false, []byte("ntp.example")},
 		{"port negotiation", NewPortNegotiation(123), RecordPortNegotiation, false, []byte{0x00, 0x7b}},
+		{"compliant 128 gcm export", NewCompliant128GCMExport(), RecordCompliant128GCMExport, false, []byte{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/ntp/ntske/server.go
+++ b/ntp/ntske/server.go
@@ -204,7 +204,7 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 	}
 	// (5) Validate the request and choose the AEAD algorithm. A protocol-level
 	// failure carries an error code we relay to the client; anything else drops.
-	aeadID, err := s.validateRequest(records)
+	aeadID, compliantExport, err := s.validateRequest(records)
 	if err != nil {
 		var ce *cookieError
 		if errors.As(err, &ce) { //nolint:modernize // Go 1.25 compatibility: avoid errors.AsType which requires Go 1.26
@@ -215,7 +215,7 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 		return
 	}
 	// (6) Derive C2S/S2C keys from the TLS session and seal the cookies.
-	response, err := s.buildResponse(cs, aeadID)
+	response, err := s.buildResponse(cs, aeadID, compliantExport)
 	if err != nil {
 		s.writeError(tlsConn, errorInternalServerError)
 		slog.Error("ntske: building response", "remote", conn.RemoteAddr(), "err", err)
@@ -236,14 +236,13 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 // 0. The chosen algorithm is the client's first preference the server supports.
 // Duplicate Next Protocol or AEAD Algorithm records are rejected with BadRequest
 // to avoid silent overwrite and to signal the error back to the client.
-func (s *Server) validateRequest(records []Record) (uint16, error) {
+func (s *Server) validateRequest(records []Record) (aeadID uint16, compliantExport bool, err error) {
 	var (
 		sawNextProto bool
 		sawEOM       bool
 		sawAEAD      bool
 		clientAEAD   []uint16
 		ntpv4        bool
-		err          error
 	)
 	for _, r := range records {
 		switch r.Type {
@@ -251,14 +250,14 @@ func (s *Server) validateRequest(records []Record) (uint16, error) {
 			sawEOM = true
 		case RecordNextProtocol:
 			if sawNextProto {
-				return 0, protocolError(errorBadRequest,
+				return 0, false, protocolError(errorBadRequest,
 					"duplicate Next Protocol Negotiation record")
 			}
 			sawNextProto = true
 			var ids []uint16
 			ids, err = ParseUint16s(r.Body)
 			if err != nil {
-				return 0, protocolError(errorBadRequest, "malformed Next Protocol body: %v", err)
+				return 0, false, protocolError(errorBadRequest, "malformed Next Protocol body: %v", err)
 			}
 			for _, id := range ids {
 				if id == NextProtocolNTPv4 {
@@ -267,34 +266,36 @@ func (s *Server) validateRequest(records []Record) (uint16, error) {
 			}
 		case RecordAEADAlgorithm:
 			if sawAEAD {
-				return 0, protocolError(errorBadRequest,
+				return 0, false, protocolError(errorBadRequest,
 					"duplicate AEAD Algorithm Negotiation record")
 			}
 			sawAEAD = true
 			clientAEAD, err = ParseUint16s(r.Body)
 			if err != nil {
-				return 0, protocolError(errorBadRequest, "malformed AEAD body: %v", err)
+				return 0, false, protocolError(errorBadRequest, "malformed AEAD body: %v", err)
 			}
+		case RecordCompliant128GCMExport:
+			compliantExport = true
 		case RecordError, RecordWarning, RecordNewCookie,
 			RecordServerNegotiation, RecordPortNegotiation:
 			// Records a client may legally send or we simply ignore server-side.
 		default:
 			// Unknown record: only fatal if the Critical Bit is set (RFC 8915 §4).
 			if r.Critical {
-				return 0, protocolError(errorUnrecognizedCriticalRecord,
+				return 0, false, protocolError(errorUnrecognizedCriticalRecord,
 					"unknown critical record type %d", r.Type)
 			}
 		}
 	}
 	switch {
 	case !sawEOM:
-		return 0, protocolError(errorBadRequest, "missing End of Message record")
+		return 0, false, protocolError(errorBadRequest, "missing End of Message record")
 	case !sawNextProto || !ntpv4:
-		return 0, protocolError(errorBadRequest, "no NTPv4 in Next Protocol Negotiation")
+		return 0, false, protocolError(errorBadRequest, "no NTPv4 in Next Protocol Negotiation")
 	case !sawAEAD:
-		return 0, protocolError(errorBadRequest, "missing AEAD Algorithm Negotiation")
+		return 0, false, protocolError(errorBadRequest, "missing AEAD Algorithm Negotiation")
 	case len(clientAEAD) == 0:
-		return 0, protocolError(errorBadRequest, "empty AEAD Algorithm Negotiation body")
+		return 0, false, protocolError(errorBadRequest, "empty AEAD Algorithm Negotiation body")
 	}
 	// Pick the client's first preference that we support. Client order wins, and
 	// we only offer an algorithm we can actually derive keys for (aeadIDToKeyLen
@@ -307,15 +308,17 @@ func (s *Server) validateRequest(records []Record) (uint16, error) {
 		if _, err := aeadIDToKeyLen(protocol.AEADAlgorithm(id)); err != nil {
 			continue
 		}
-		return id, nil
+		return id, compliantExport, nil
 	}
-	return 0, protocolError(errorBadRequest, "no mutually supported AEAD algorithm")
+	return 0, false, protocolError(errorBadRequest, "no mutually supported AEAD algorithm")
 }
 
 // buildResponse derives the directional keys for the negotiated algorithm and
-// assembles the NTS-KE response: Next Protocol, AEAD, optional NTP server/port
-// hints, N cookies, and End of Message.
-func (s *Server) buildResponse(cs tls.ConnectionState, aeadID uint16) ([]Record, error) {
+// assembles the NTS-KE response: Next Protocol, AEAD, an optional
+// Compliant128GCMExport echo, optional NTP server/port hints, N cookies, and
+// End of Message. The compliant-export record is echoed only when the client
+// offered it and the negotiated algorithm is AES-128-GCM-SIV.
+func (s *Server) buildResponse(cs tls.ConnectionState, aeadID uint16, compliantExport bool) ([]Record, error) {
 	// aeadIDToKeyLen lives in keystore.go (same package) — reuse it instead of
 	// a duplicate lookup. It takes protocol.AEADAlgorithm, so convert the wire
 	// uint16 at the boundary.
@@ -323,7 +326,6 @@ func (s *Server) buildResponse(cs tls.ConnectionState, aeadID uint16) ([]Record,
 	if err != nil {
 		return nil, err
 	}
-
 	c2s, err := exportKey(cs, aeadID, directionC2S, keyLen)
 	if err != nil {
 		return nil, err
@@ -336,6 +338,14 @@ func (s *Server) buildResponse(cs tls.ConnectionState, aeadID uint16) ([]Record,
 	records := []Record{
 		NewNextProtocol(NextProtocolNTPv4),
 		NewAEADAlgorithm(aeadID),
+	}
+	// Echo the compliant-export record back so the client knows the server agreed:
+	// the record is a negotiation, not a one-way announcement. Both sides must
+	// independently derive the compliant AES-128-GCM-SIV export context, so the
+	// client only switches to it after seeing our echo. Without the echo the client
+	// falls back to the default context and the two ends disagree on key material.
+	if compliantExport && aeadID == uint16(protocol.AEADAES128GCMSIV) {
+		records = append(records, NewCompliant128GCMExport())
 	}
 	if s.NTPv4Server != "" {
 		records = append(records, NewServerNegotiation(s.NTPv4Server))

--- a/ntp/ntske/server_test.go
+++ b/ntp/ntske/server_test.go
@@ -238,6 +238,66 @@ func TestServerAEADPreferenceOrder(t *testing.T) {
 	require.Equal(t, []uint16{sivCMAC}, parseUint16s(aead[0].Body), "client's first preference wins")
 }
 
+// TestServerCompliant128GCMExport verifies the compliant-export negotiation:
+// the server echoes a Compliant128GCMExport record only when the client offers
+// it AND the negotiated AEAD is AES-128-GCM-SIV. If the client omits the record,
+// or a non-GCM-SIV algorithm is chosen, no such record appears in the response.
+func TestServerCompliant128GCMExport(t *testing.T) {
+	cases := []struct {
+		name    string
+		request []Record
+		want    bool
+	}{
+		{
+			name: "offered and GCM-SIV chosen: echoed",
+			request: []Record{
+				NewNextProtocol(NextProtocolNTPv4),
+				NewAEADAlgorithm(gcmSIV),
+				NewCompliant128GCMExport(),
+				NewEndOfMessage(),
+			},
+			want: true,
+		},
+		{
+			name: "offered but SIV-CMAC chosen: not echoed",
+			request: []Record{
+				NewNextProtocol(NextProtocolNTPv4),
+				NewAEADAlgorithm(sivCMAC),
+				NewCompliant128GCMExport(),
+				NewEndOfMessage(),
+			},
+			want: false,
+		},
+		{
+			name: "not offered, GCM-SIV chosen: not echoed",
+			request: []Record{
+				NewNextProtocol(NextProtocolNTPv4),
+				NewAEADAlgorithm(gcmSIV),
+				NewEndOfMessage(),
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			serverTLS, clientTLS := newTestTLSConfigs(t)
+			ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+			require.NoError(t, err)
+			srv := &Server{TLSConfig: serverTLS, Keystore: ks, Cookies: 1}
+
+			_, resp := runExchange(t, srv, clientTLS, tc.request)
+			echoed := recordsByType(resp)[RecordCompliant128GCMExport]
+			if tc.want {
+				require.Len(t, echoed, 1)
+				require.False(t, echoed[0].Critical)
+				require.Empty(t, echoed[0].Body)
+			} else {
+				require.Empty(t, echoed)
+			}
+		})
+	}
+}
+
 // TestServerRejectsWrongALPN checks that a client which completes TLS 1.3 but
 // does not select "ntske/1" is dropped without a response and counted as an
 // error, and that no handshake is credited.
@@ -415,7 +475,7 @@ func TestValidateRequest(t *testing.T) {
 	srv := &Server{} // uses default SupportedAEAD [30, 17]
 
 	t.Run("happy path returns chosen AEAD", func(t *testing.T) {
-		id, err := srv.validateRequest([]Record{
+		id, _, err := srv.validateRequest([]Record{
 			NewNextProtocol(NextProtocolNTPv4),
 			NewAEADAlgorithm(sivCMAC, gcmSIV),
 			NewEndOfMessage(),
@@ -425,13 +485,34 @@ func TestValidateRequest(t *testing.T) {
 	})
 
 	t.Run("unknown non-critical record is ignored", func(t *testing.T) {
-		_, err := srv.validateRequest([]Record{
+		_, _, err := srv.validateRequest([]Record{
 			NewNextProtocol(NextProtocolNTPv4),
 			NewAEADAlgorithm(gcmSIV),
 			{Critical: false, Type: 999},
 			NewEndOfMessage(),
 		})
 		require.NoError(t, err)
+	})
+
+	t.Run("reports compliant-export offer", func(t *testing.T) {
+		_, offered, err := srv.validateRequest([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(gcmSIV),
+			NewCompliant128GCMExport(),
+			NewEndOfMessage(),
+		})
+		require.NoError(t, err)
+		require.True(t, offered)
+	})
+
+	t.Run("no compliant-export offer when absent", func(t *testing.T) {
+		_, offered, err := srv.validateRequest([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(gcmSIV),
+			NewEndOfMessage(),
+		})
+		require.NoError(t, err)
+		require.False(t, offered)
 	})
 
 	errCases := []struct {
@@ -467,7 +548,7 @@ func TestValidateRequest(t *testing.T) {
 	}
 	for _, tc := range errCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := srv.validateRequest(tc.records)
+			_, _, err := srv.validateRequest(tc.records)
 			var ce *cookieError
 			require.ErrorAs(t, err, &ce)
 			require.Equal(t, tc.code, ce.code)


### PR DESCRIPTION
Summary: Adds support for chrony's private, non-critical NTS-KE record used to negotiate the "compliant" key export for AES-128-GCM-SIV (chrony's `NTS_KE_RECORD_COMPLIANT_128GCM_EXPORT`, record type `1024`, outside the RFC 8915 IANA registry)

Reviewed By: leoleovich

Differential Revision: D111257783


