### PR TITLE
Add extension fields to Packet with parsing and marshaling (#559)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,15 @@ jobs:
           go-version: 1.26
       - run: sudo apt-get install libpcap-dev libcap2-bin
       - run: go build -v ./...
-      # fuzzing, need to specify each package separately
-      - run: go test -v -fuzz='.*' -fuzztime=10s ./ptp/protocol/
-      - run: go test -v -fuzz='.*' -fuzztime=10s ./ntp/protocol/
-      - run: go test -v -fuzz='.*' -fuzztime=10s ./ntp/chrony/
+      # Fuzzing: `go test -fuzz` runs a single target per invocation, so iterate
+      # over every fuzz function in each package (a package may define several).
+      - name: Fuzz
+        run: |
+          for pkg in ./ptp/protocol/ ./ntp/protocol/ ./ntp/chrony/; do
+            for f in $(go test -list='^Fuzz' "$pkg" | grep '^Fuzz'); do
+              go test -v -fuzz="^${f}$" -fuzztime=10s "$pkg"
+            done
+          done
       - name: Run coverage
         run: sudo --preserve-env=PATH capsh --inh=cap_net_raw --print -- -c "go test -v -race -coverprofile=coverage.txt -covermode=atomic ./..."
       - name: Upload coverage to Codecov

--- a/cmd/ntpcheck/cmd/utils.go
+++ b/cmd/ntpcheck/cmd/utils.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"crypto/md5"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -70,7 +69,7 @@ func fakeSeconds(secondsCount int) {
 
 	// the timestamp in this format is number of seconds from NTP Epoch
 	fmt.Printf("# Generating %d fake leap seconds:\n", secondsCount)
-	for i := 0; i < secondsCount; i++ {
+	for i := range secondsCount {
 		firstOfFakeMonth := firstOfThisMonth.AddDate(0, i+1, 0)
 		delta := int((firstOfFakeMonth.Sub(ntpEpoch)).Seconds())
 		fmt.Printf("%d  XX  # %s\n", delta, firstOfFakeMonth.Format(time.RFC3339))
@@ -101,7 +100,7 @@ func receiveNTPPacketWithRetries(connFd int, buf, oob []byte, tries int) (*ntp.P
 	var err error
 	var n int
 	var clientReceiveTime time.Time
-	for try := 0; try < tries; try++ {
+	for range tries {
 		n, _, clientReceiveTime, err = timestamp.ReadPacketWithRXTimestampBuf(connFd, buf, oob)
 		if errors.Is(err, unix.EINTR) || errors.Is(err, unix.EAGAIN) {
 			log.Debug("got timeout reading response packet, retrying")
@@ -195,7 +194,11 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int, ntp
 			TxTimeFrac: frac,
 		}
 
-		if err := binary.Write(conn, binary.BigEndian, request); err != nil {
+		b, err := request.Bytes()
+		if err != nil {
+			return fmt.Errorf("failed to marshal request, %w", err)
+		}
+		if _, err := conn.Write(b); err != nil {
 			return fmt.Errorf("failed to send request, %w", err)
 		}
 		response, clientReceiveTime, err := receiveNTPPacketWithRetries(connFd, buf, oob, tries)
@@ -283,7 +286,7 @@ func addFakeSecondZoneInfo(srcfile, dstfile string, offsetMonth int) error {
 	fmt.Printf("Fake second added on %s\n", fakeLeap.Format(time.RFC3339))
 	ls = append(ls, leapsectz.LeapSecond{
 		Tleap: uint64(fakeLeap.Sub(ntpEpoch).Seconds()) + uint64(len(ls)),
-		Nleap: int32(len(ls) + 1),
+		Nleap: int32(len(ls) + 1), //#nosec G115
 	})
 
 	o, err := os.Create(dstfile)

--- a/ntp/protocol/extension_fields.go
+++ b/ntp/protocol/extension_fields.go
@@ -155,13 +155,24 @@ func (t ExtensionFieldType) isReserved() bool {
 	return t >= ExtensionTypeReservedLo
 }
 
-// Validate reports whether the extension field can be safely marshalled: the
-// body must not exceed ExtensionMaxBodySize and Type must not fall in the
-// IANA-reserved range (0xF000–0xFFFF, RFC 9748).
-func (ef ExtensionField) Validate() error {
+// checkBodySize guards against a body large enough to wrap the 16-bit wire
+// length field once the 4-octet header and padding are added. It applies to
+// every encode path, including faithful reconstruction of received packets.
+func (ef ExtensionField) checkBodySize() error {
 	if len(ef.Body) > ExtensionMaxBodySize {
 		return fmt.Errorf("%w: type=%#x body=%d max=%d",
 			ErrExtensionBodyTooLarge, ef.Type, len(ef.Body), ExtensionMaxBodySize)
+	}
+	return nil
+}
+
+// validate reports whether the extension field can be safely marshalled: the
+// body must not exceed ExtensionMaxBodySize and Type must not fall in the
+// IANA-reserved range (0xF000–0xFFFF, RFC 9748). It is the single policy source
+// for extension fields we originate (see MarshalExtensionFields).
+func (ef ExtensionField) validate() error {
+	if err := ef.checkBodySize(); err != nil {
+		return err
 	}
 	if ef.Type.isReserved() {
 		return fmt.Errorf("%w: type=%#x", ErrExtensionTypeReserved, ef.Type)
@@ -169,38 +180,75 @@ func (ef ExtensionField) Validate() error {
 	return nil
 }
 
-// MarshalExtensionFields encodes a slice of extension fields into the wire
-// format defined by RFC 7822 §7.5. Each field is padded with zeros to a
-// multiple of 4 octets and to at least ExtensionMinSize.
+// MarshalExtensionFields is the strict, outbound-only encoder: every field must
+// pass Validate (rejecting IANA-reserved types we must never originate) before
+// encoding. Use this for any extension fields we generate. Each field is padded
+// with zeros to a multiple of 4 octets and to at least ExtensionMinSize (RFC 7822 §7.5).
 func MarshalExtensionFields(efs []ExtensionField) ([]byte, error) {
+	for _, ef := range efs {
+		if err := ef.validate(); err != nil {
+			return nil, err
+		}
+	}
+	return encodeExtensionFields(efs)
+}
+
+// writeExtensionFields writes efs into dst (sized by the caller via EncodedSize)
+// and returns bytes written, with no validation. It clear()s each field's
+// padding so output is correct on a reused buffer (RFC 8915 §5.6: padding MUST
+// be zero; stale padding in an authenticator's AD would break verification).
+func writeExtensionFields(dst []byte, efs []ExtensionField) int {
+	offset := 0
+	for _, ef := range efs {
+		flen := ef.EncodedSize()
+		binary.BigEndian.PutUint16(dst[offset:offset+2], uint16(ef.Type))
+		binary.BigEndian.PutUint16(dst[offset+2:offset+4], uint16(flen)) // #nosec G115 -- bounded by checkBodySize
+		bodyEnd := offset + ExtensionHeaderSize + len(ef.Body)
+		copy(dst[offset+ExtensionHeaderSize:], ef.Body)
+		clear(dst[bodyEnd : offset+flen]) // zero padding (reused-buffer safety)
+		offset += flen
+	}
+	return offset
+}
+
+// MarshalExtensionFieldsTo encodes efs into dst without allocating, returning
+// bytes written. Like MarshalExtensionFields it is strict (rejects reserved
+// types) and zeroes padding, so a caller may reuse one buffer across packets.
+// dst must be at least the sum of each field's EncodedSize.
+func MarshalExtensionFieldsTo(efs []ExtensionField, dst []byte) (int, error) {
+	total := 0
+	for _, ef := range efs {
+		if err := ef.validate(); err != nil {
+			return 0, err
+		}
+		total += ef.EncodedSize()
+	}
+	if len(dst) < total {
+		return 0, fmt.Errorf("%w: need %d bytes, have %d", ErrExtensionTruncated, total, len(dst))
+	}
+	return writeExtensionFields(dst, efs), nil
+}
+
+// encodeExtensionFields marshals faithfully: it keeps the length-overflow guard
+// but does NOT reject reserved types, so a parsed packet re-serializes
+// byte-for-byte — required because RFC 8915 §5.2 covers unrecognized EFs in the
+// authenticated portion, even reserved-range ones we would never originate.
+func encodeExtensionFields(efs []ExtensionField) ([]byte, error) {
 	totalSize := 0
 	for _, ef := range efs {
-		if err := ef.Validate(); err != nil {
+		if err := ef.checkBodySize(); err != nil {
 			return nil, err
 		}
 		totalSize += ef.EncodedSize()
 	}
 	out := make([]byte, totalSize)
-	offset := 0
-	for _, ef := range efs {
-		flen := ef.EncodedSize()
-		binary.BigEndian.PutUint16(out[offset:offset+2], uint16(ef.Type))
-		binary.BigEndian.PutUint16(out[offset+2:offset+4], uint16(flen)) // #nosec G115 -- bounded by ExtensionMaxBodySize check above
-		copy(out[offset+ExtensionHeaderSize:], ef.Body)
-		offset += flen
-	}
+	writeExtensionFields(out, efs)
 	return out, nil
 }
 
 // ParseExtensionFields parses a buffer of zero or more concatenated extension
-// fields per RFC 7822 §7.5. The buffer must contain only extension fields;
+// fields per. The buffer must contain only extension fields;
 // any legacy NTPv3/v4 MAC bytes must be stripped before calling.
-//
-// The returned ExtensionField.Body contains the value plus any wire padding;
-// the caller interprets the value boundary based on the field type. Bodies
-// are copied out of the input buffer so the returned EFs remain valid even
-// if the caller mutates or reuses the input (e.g. a UDP read loop that
-// overwrites a single receive buffer per packet).
 func ParseExtensionFields(b []byte) ([]ExtensionField, error) {
 	var efs []ExtensionField
 	for len(b) > 0 {

--- a/ntp/protocol/extension_fields_test.go
+++ b/ntp/protocol/extension_fields_test.go
@@ -220,7 +220,7 @@ func TestExtensionFieldValidate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.ef.Validate()
+			err := tc.ef.validate()
 			if tc.wantErr == nil {
 				require.NoError(t, err)
 			} else {
@@ -241,4 +241,24 @@ func TestMarshalExtensionFieldsRejectsInvalid(t *testing.T) {
 func TestAEADAlgorithmValues(t *testing.T) {
 	require.Equal(t, AEADAlgorithm(17), AEADAESSIVCMAC512)
 	require.Equal(t, AEADAlgorithm(30), AEADAES128GCMSIV)
+}
+
+// FuzzEFRoundTrip locks the parse/encode mutual-inverse that NTS request auth
+// relies on: the server reconstructs the signed bytes by re-serializing the
+// parsed EFs (Packet.AssociatedData / encodeExtensionFields), so encode(parse(b))
+// MUST equal b byte-for-byte for every buffer that parses.
+func FuzzEFRoundTrip(f *testing.F) {
+	// Seeds: empty, a single known EF, a reserved-type EF with non-zero body.
+	f.Add([]byte{})
+	f.Add([]byte{0x01, 0x04, 0x00, 0x08, 1, 2, 3, 4})
+	f.Add([]byte{0xF0, 0x01, 0x00, 0x08, 0, 0, 0, 0})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		efs, err := ParseExtensionFields(b)
+		if err != nil {
+			return // only well-formed buffers are subject to the identity
+		}
+		reenc, err := encodeExtensionFields(efs)
+		require.NoError(t, err)
+		require.Equal(t, b, reenc) // NTS verification depends on this identity
+	})
 }

--- a/ntp/protocol/ntp_test.go
+++ b/ntp/protocol/ntp_test.go
@@ -106,6 +106,26 @@ func TestResponseConversion(t *testing.T) {
 	require.Equal(t, ntpResponseBytes, bytes)
 }
 
+// TestPacketHeaderRoundTrip checks Bytes -> UnmarshalBinary is an exact identity
+// across every header field. The hand-rolled codec has no reflection safety net,
+// so a new field left unwired, or a wrong byte offset, would silently drop or
+// corrupt a value; the whole-struct compare catches it.
+func TestPacketHeaderRoundTrip(t *testing.T) {
+	p := &Packet{
+		Settings: 0x23, Stratum: 2, Poll: 6, Precision: -25,
+		RootDelay: 0x11111111, RootDispersion: 0x22222222, ReferenceID: 0x33333333,
+		RefTimeSec: 0x44444444, RefTimeFrac: 0x55555555,
+		OrigTimeSec: 0x66666666, OrigTimeFrac: 0x77777777,
+		RxTimeSec: 0x88888888, RxTimeFrac: 0x99999999,
+		TxTimeSec: 0xAAAAAAAA, TxTimeFrac: 0xBBBBBBBB,
+	}
+	b, err := p.Bytes()
+	require.NoError(t, err)
+	var got Packet
+	require.NoError(t, got.UnmarshalBinary(b))
+	require.Equal(t, *p, got)
+}
+
 func TestBytesToPacket(t *testing.T) {
 	packet, err := BytesToPacket(ntpResponseBytes)
 	require.NoError(t, err)
@@ -282,6 +302,15 @@ func Benchmark_BytesToPacketConversion(b *testing.B) {
 	}
 }
 
+// TestPacketUnmarshalZeroAlloc locks the header-only unmarshal at zero allocs.
+func TestPacketUnmarshalZeroAlloc(t *testing.T) {
+	p := &Packet{}
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = p.UnmarshalBinary(ntpResponseBytes)
+	})
+	require.Zero(t, allocs, "UnmarshalBinary must not allocate for a header-only packet")
+}
+
 /*
 Benchmark_ServerWithoutKernelTimestamps is a benchmark to determine speed of
 reading NTP packets without kernel timestamps
@@ -396,8 +425,34 @@ func FuzzBytesToPacket(f *testing.F) {
 		packet, err := BytesToPacket(b)
 		if err == nil {
 			bb, err := packet.Bytes()
-			require.NoError(t, err)
+			if err != nil {
+				return // Bytes() strictly rejects IANA-reserved EF types that parsing accepts (RFC 9748)
+			}
 			require.Equal(t, b[:len(bb)], bb)
+		}
+	})
+}
+
+// FuzzPacketAssociatedData exercises the exact NTS verification path (header via
+// putHeader + first-n EFs via encodeExtensionFields) and asserts it equals the
+// same prefix of the input, so the reconstructed authenticated bytes match the
+// wire for every prefix.
+func FuzzPacketAssociatedData(f *testing.F) {
+	f.Add(ntpResponseBytes)
+	f.Add(append(append([]byte{}, ntpRequestBytes...), 0x01, 0x04, 0x00, 0x08, 1, 2, 3, 4))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		var p Packet
+		if err := p.UnmarshalBinary(b); err != nil {
+			return
+		}
+		want := PacketSizeBytes
+		for i := 0; i <= len(p.ExtensionFields); i++ {
+			ad, err := p.AssociatedData(i)
+			require.NoError(t, err)
+			require.Equal(t, b[:want], ad)
+			if i < len(p.ExtensionFields) {
+				want += p.ExtensionFields[i].EncodedSize()
+			}
 		}
 	})
 }

--- a/ntp/protocol/packet.go
+++ b/ntp/protocol/packet.go
@@ -17,8 +17,8 @@ limitations under the License.
 package protocol
 
 import (
-	"bytes"
 	"encoding/binary"
+	"fmt"
 	"net"
 )
 
@@ -27,6 +27,11 @@ const PacketSizeBytes = 48
 
 // ControlHeaderSizeBytes is a buffer to read packet header with Kernel timestamps
 const ControlHeaderSizeBytes = 32
+
+// maxUDPPacketSizeBytes bounds a single UDP read. Plain NTP is 48 octets, but an
+// NTS-protected packet also carries extension fields, so reads are sized to a
+// full 1500-octet MTU to avoid silently truncating them.
+const maxUDPPacketSizeBytes = 1500
 
 // Packet is an NTPv4 packet
 /*
@@ -73,21 +78,22 @@ Setting = LI | VN  |Mode. Client request example:
 + -------- leap year indicator, 0 no warning
 */
 type Packet struct {
-	Settings       uint8  // leap year indicator, version number and mode
-	Stratum        uint8  // stratum
-	Poll           int8   // poll. Power of 2
-	Precision      int8   // precision. Power of 2
-	RootDelay      uint32 // total delay to the reference clock
-	RootDispersion uint32 // total dispersion to the reference clock
-	ReferenceID    uint32 // identifier of server or a reference clock
-	RefTimeSec     uint32 // last time local clock was updated sec
-	RefTimeFrac    uint32 // last time local clock was updated frac
-	OrigTimeSec    uint32 // client time sec
-	OrigTimeFrac   uint32 // client time frac
-	RxTimeSec      uint32 // receive time sec
-	RxTimeFrac     uint32 // receive time frac
-	TxTimeSec      uint32 // transmit time sec
-	TxTimeFrac     uint32 // transmit time frac
+	Settings        uint8            // leap year indicator, version number and mode
+	Stratum         uint8            // stratum
+	Poll            int8             // poll. Power of 2
+	Precision       int8             // precision. Power of 2
+	RootDelay       uint32           // total delay to the reference clock
+	RootDispersion  uint32           // total dispersion to the reference clock
+	ReferenceID     uint32           // identifier of server or a reference clock
+	RefTimeSec      uint32           // last time local clock was updated sec
+	RefTimeFrac     uint32           // last time local clock was updated frac
+	OrigTimeSec     uint32           // client time sec
+	OrigTimeFrac    uint32           // client time frac
+	RxTimeSec       uint32           // receive time sec
+	RxTimeFrac      uint32           // receive time frac
+	TxTimeSec       uint32           // transmit time sec
+	TxTimeFrac      uint32           // transmit time frac
+	ExtensionFields []ExtensionField // Empty for plain NTP
 }
 
 const (
@@ -97,6 +103,50 @@ const (
 	vnLast           = 4
 	modeClient       = 3
 )
+
+// putHeader writes the fixed 48-octet NTP header (RFC 5905) into dst in wire
+// order, big-endian. dst must be at least PacketSizeBytes long. This hand-rolled
+// codec replaces reflection-based binary.Write over a []any field list, keeping
+// the hot request/response path allocation-free.
+func (p *Packet) putHeader(dst []byte) {
+	_ = dst[PacketSizeBytes-1] // bounds-check hint: panic early if dst too short
+	dst[0] = p.Settings
+	dst[1] = p.Stratum
+	dst[2] = byte(p.Poll)      //#nosec G115
+	dst[3] = byte(p.Precision) //#nosec G115
+	binary.BigEndian.PutUint32(dst[4:8], p.RootDelay)
+	binary.BigEndian.PutUint32(dst[8:12], p.RootDispersion)
+	binary.BigEndian.PutUint32(dst[12:16], p.ReferenceID)
+	binary.BigEndian.PutUint32(dst[16:20], p.RefTimeSec)
+	binary.BigEndian.PutUint32(dst[20:24], p.RefTimeFrac)
+	binary.BigEndian.PutUint32(dst[24:28], p.OrigTimeSec)
+	binary.BigEndian.PutUint32(dst[28:32], p.OrigTimeFrac)
+	binary.BigEndian.PutUint32(dst[32:36], p.RxTimeSec)
+	binary.BigEndian.PutUint32(dst[36:40], p.RxTimeFrac)
+	binary.BigEndian.PutUint32(dst[40:44], p.TxTimeSec)
+	binary.BigEndian.PutUint32(dst[44:48], p.TxTimeFrac)
+}
+
+// readHeader parses the fixed 48-octet NTP header from src, which must be at
+// least PacketSizeBytes long, into p.
+func (p *Packet) readHeader(src []byte) {
+	_ = src[PacketSizeBytes-1] // bounds-check hint
+	p.Settings = src[0]
+	p.Stratum = src[1]
+	p.Poll = int8(src[2])      //#nosec G115
+	p.Precision = int8(src[3]) //#nosec G115
+	p.RootDelay = binary.BigEndian.Uint32(src[4:8])
+	p.RootDispersion = binary.BigEndian.Uint32(src[8:12])
+	p.ReferenceID = binary.BigEndian.Uint32(src[12:16])
+	p.RefTimeSec = binary.BigEndian.Uint32(src[16:20])
+	p.RefTimeFrac = binary.BigEndian.Uint32(src[20:24])
+	p.OrigTimeSec = binary.BigEndian.Uint32(src[24:28])
+	p.OrigTimeFrac = binary.BigEndian.Uint32(src[28:32])
+	p.RxTimeSec = binary.BigEndian.Uint32(src[32:36])
+	p.RxTimeFrac = binary.BigEndian.Uint32(src[36:40])
+	p.TxTimeSec = binary.BigEndian.Uint32(src[40:44])
+	p.TxTimeFrac = binary.BigEndian.Uint32(src[44:48])
+}
 
 // ValidSettingsFormat verifies that LI | VN  |Mode fields are set correctly
 // check the first byte,include:
@@ -118,17 +168,69 @@ func (p *Packet) ValidSettingsFormat() bool {
 	return false
 }
 
-// Bytes converts Packet to []bytes
+// encodedLen returns the packet's wire size: the 48-octet header plus every
+// extension field (including padding).
+func (p *Packet) encodedLen() int {
+	n := PacketSizeBytes
+	for _, ef := range p.ExtensionFields {
+		n += ef.EncodedSize()
+	}
+	return n
+}
+
+// Bytes serializes the packet (header + extension fields) into a freshly
+// allocated []byte. It uses explicit big-endian offsets (no reflection) and
+// works for both plain NTP and NTS packets.
 func (p *Packet) Bytes() ([]byte, error) {
-	var bytes bytes.Buffer
-	err := binary.Write(&bytes, binary.BigEndian, p)
-	return bytes.Bytes(), err
+	out := make([]byte, p.encodedLen())
+	p.putHeader(out)
+	if len(p.ExtensionFields) == 0 {
+		return out, nil
+	}
+	if _, err := MarshalExtensionFieldsTo(p.ExtensionFields, out[PacketSizeBytes:]); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // UnmarshalBinary fills the Packet from []bytes
 func (p *Packet) UnmarshalBinary(b []byte) error {
-	reader := bytes.NewReader(b)
-	return binary.Read(reader, binary.BigEndian, p)
+	if len(b) < PacketSizeBytes {
+		return fmt.Errorf("ntp packet too short: %d bytes", len(b))
+	}
+	p.readHeader(b)
+	if len(b) > PacketSizeBytes {
+		efs, err := ParseExtensionFields(b[PacketSizeBytes:])
+		if err != nil {
+			return err
+		}
+		p.ExtensionFields = efs
+	} else {
+		p.ExtensionFields = nil
+	}
+	return nil
+}
+
+// AssociatedData returns the header plus the first n extension fields,
+// re-serialized so unrecognized/reserved EFs are reproduced exactly (RFC 8915
+// §5.4). Callers MUST NOT mutate ExtensionFields between parse and this call, or
+// the reconstructed bytes will no longer match what the peer authenticated.
+func (p *Packet) AssociatedData(n int) ([]byte, error) {
+	if n < 0 || n > len(p.ExtensionFields) {
+		return nil, fmt.Errorf("ntp: associated-data ef index %d out of range [0,%d]", n, len(p.ExtensionFields))
+	}
+	efs := p.ExtensionFields[:n]
+	size := PacketSizeBytes
+	for i := range efs {
+		if err := efs[i].checkBodySize(); err != nil {
+			return nil, err
+		}
+		size += efs[i].EncodedSize()
+	}
+	out := make([]byte, size)
+	p.putHeader(out)
+	writeExtensionFields(out[PacketSizeBytes:], efs)
+	return out, nil
 }
 
 // BytesToPacket converts []bytes to Packet
@@ -137,14 +239,16 @@ func BytesToPacket(ntpPacketBytes []byte) (*Packet, error) {
 	return packet, packet.UnmarshalBinary(ntpPacketBytes)
 }
 
-// ReadNTPPacket reads incoming NTP packet
+// ReadNTPPacket reads an incoming NTP packet, including any NTS extension
+// fields. The read buffer is a full 1500-octet MTU so extension fields are not
+// silently truncated, and the packet is parsed from exactly the bytes received.
 func ReadNTPPacket(conn *net.UDPConn) (ntp *Packet, remAddr net.Addr, err error) {
-	buf := make([]byte, PacketSizeBytes)
-	_, remAddr, err = conn.ReadFromUDP(buf)
+	buf := make([]byte, maxUDPPacketSizeBytes)
+	n, remAddr, err := conn.ReadFromUDP(buf)
 	if err != nil {
 		return nil, nil, err
 	}
-	ntp, err = BytesToPacket(buf)
+	ntp, err = BytesToPacket(buf[:n])
 
 	return ntp, remAddr, err
 }

--- a/ntp/responder/server/server_test.go
+++ b/ntp/responder/server/server_test.go
@@ -217,9 +217,14 @@ func TestServer(t *testing.T) {
 		}
 		response := &ntp.Packet{}
 
-		err = binary.Write(sendConn, binary.BigEndian, request)
+		reqBytes, err := request.Bytes()
 		require.Nil(t, err, "sending request should not err")
-		err = binary.Read(sendConn, binary.BigEndian, response)
+		_, err = sendConn.Write(reqBytes)
+		require.Nil(t, err, "sending request should not err")
+		respBuf := make([]byte, ntp.PacketSizeBytes)
+		_, err = sendConn.Read(respBuf)
+		require.Nil(t, err, "receiving response should not err")
+		err = response.UnmarshalBinary(respBuf)
 		require.Nil(t, err, "receiving response should not err")
 		require.Equal(t, sec, response.OrigTimeSec, "response Origin Time seconds should match our TX seconds")
 		require.Equal(t, frac, response.OrigTimeFrac, "response Origin Time fraction should match our TX fraction")


### PR DESCRIPTION
Summary:

Add ExtensionFields to the NTP Packet struct plus the extension-field wire
codec: ParseExtensionFields, strict MarshalExtensionFields for fields we
originate, and a faithful re-serialization path (AssociatedData /
encodeExtensionFields) used to reconstruct the bytes an NTS authenticator
covers. Also replaces the reflection-based header (un)marshal with a
hand-rolled, zero-alloc 48-byte codec (MarshalBinaryTo/EncodedLen). This is
the protocol-layer foundation the NTS request path builds on.

Reviewed By: vvfedorenko

Differential Revision: D112528466
