### PR TITLE
wire NTS request path into the UDP listener

### DIFF
--- a/ntp/responder/server/config.go
+++ b/ntp/responder/server/config.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/facebook/time/ntp/ntske"
 	"github.com/facebook/time/timestamp"
 )
 
@@ -41,6 +42,7 @@ type Config struct {
 	Stratum        int
 	TimestampType  timestamp.Timestamp
 	Workers        int
+	Keystore       ntske.Keystore // if non-nil enables NTS auth path.
 	phcOffset      time.Duration
 }
 

--- a/ntp/responder/server/nts.go
+++ b/ntp/responder/server/nts.go
@@ -28,7 +28,7 @@ import (
 // maxResponseCookies caps how many fresh cookies a single response carries. This
 // bounds the amplification factor regardless of how many placeholders a client
 // stuffs into its request.
-const maxResponseCookies = 32 //nolint:unused // used by the NTS request path
+const maxResponseCookies = 32
 
 // Failure classes for the NTS request path. Callers use errors.Is to branch on
 // them (e.g. for stats); the wrapped error carries the detail.
@@ -47,7 +47,7 @@ var (
 // response's extension fields (UniqueID echo + sealed authenticator). req is the
 // parsed request; resp is the response whose header is already set. The caller
 // marshals resp via Bytes(), so both the NTS and plain paths share one marshal.
-func processNTSRequest(ks ntske.Keystore, req, resp *ntp.Packet) error { //nolint:unused // used by the NTS request path
+func processNTSRequest(ks ntske.Keystore, req, resp *ntp.Packet) error {
 	if len(req.ExtensionFields) == 0 {
 		return ErrNoExtensionFields
 	}

--- a/ntp/responder/server/server.go
+++ b/ntp/responder/server/server.go
@@ -28,11 +28,17 @@ import (
 	"net"
 	"time"
 
+	"github.com/facebook/time/ntp/ntske"
 	ntp "github.com/facebook/time/ntp/protocol"
 	"github.com/facebook/time/timestamp"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
+
+// maxPacketSizeBytes bounds a single UDP read. Plain NTP is 48 octets; an NTS
+// request additionally carries a UniqueID, a cookie, optional placeholders and
+// an authenticator, so the buffer is grown to a full 1500-octet MTU to hold it.
+const maxPacketSizeBytes = 1500
 
 // task is a data structure with everything needed to work independently on NTP packet.
 type task struct {
@@ -40,6 +46,7 @@ type task struct {
 	addr     unix.Sockaddr
 	received time.Time
 	request  *ntp.Packet
+	keystore ntske.Keystore
 	stats    Stats
 }
 
@@ -175,7 +182,7 @@ func (s *Server) startListener(conn *net.UDPConn) {
 		log.Fatalf("Failed to set socket to blocking: %s", err)
 	}
 
-	buf := make([]byte, timestamp.PayloadSizeBytes)
+	buf := make([]byte, maxPacketSizeBytes)
 	oob := make([]byte, timestamp.ControlSizeBytes)
 
 	for {
@@ -197,13 +204,21 @@ func (s *Server) startListener(conn *net.UDPConn) {
 			rxTS = rxTS.Add(s.Config.phcOffset)
 		}
 
-		if err := request.UnmarshalBinary(buf[:bbuf]); err != nil {
+		// On a plain-NTP server (no keystore) ignore anything past the 48-octet
+		// header: With NTS enabled, let UnmarshalBinary parse the trailing
+		// bytes as extension fields.
+		parseLen := bbuf
+		if s.Config.Keystore == nil && bbuf > ntp.PacketSizeBytes {
+			parseLen = ntp.PacketSizeBytes
+		}
+
+		if err := request.UnmarshalBinary(buf[:parseLen]); err != nil {
 			log.Errorf("failed to parse ntp packet: %s", err)
 			s.Stats.IncReadError()
 			continue
 		}
 		s.Stats.IncRequests()
-		s.tasks <- task{connFd: connFd, addr: clisa, received: rxTS, request: request, stats: s.Stats}
+		s.tasks <- task{connFd: connFd, addr: clisa, received: rxTS, request: request, keystore: s.Config.Keystore, stats: s.Stats}
 	}
 }
 
@@ -233,13 +248,21 @@ func (t *task) serve(response *ntp.Packet, extraoffset time.Duration) {
 	}
 
 	generateResponse(time.Now().Add(extraoffset), t.received.Add(extraoffset), t.request, response)
+	response.ExtensionFields = nil
+	if t.keystore != nil && len(t.request.ExtensionFields) > 0 {
+		if err := processNTSRequest(t.keystore, t.request, response); err != nil {
+			log.Debugf("NTS request rejected: %v", err)
+			t.stats.IncInvalidFormat()
+			return
+		}
+	}
 	responseBytes, err := response.Bytes()
 	if err != nil {
-		log.Errorf("Failed to convert ntp.%v to bytes %v: %v", response, responseBytes, err)
+		log.Debugf("marshaling response failed: %v", err)
+		t.stats.IncInvalidFormat()
 		return
 	}
-
-	log.Debugf("Writing response: %+v", response)
+	log.Debugf("Writing %d-byte response", len(responseBytes))
 	if err := unix.Sendto(t.connFd, responseBytes, unix.MSG_DONTWAIT, t.addr); err != nil {
 		log.Debugf("Failed to respond to the request: %v", err)
 		return

--- a/ntp/responder/server/server_test.go
+++ b/ntp/responder/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	ntp "github.com/facebook/time/ntp/protocol"
+	"github.com/facebook/time/ntp/protocol/nts"
 	"github.com/facebook/time/ntp/responder/checker"
 	"github.com/facebook/time/ntp/responder/stats"
 	"github.com/facebook/time/timestamp"
@@ -247,4 +248,43 @@ func Benchmark_fillStaticHeaders(b *testing.B) {
 		response := &ntp.Packet{}
 		s.fillStaticHeaders(response)
 	}
+}
+
+func TestServerNTS(t *testing.T) {
+	ks := newTestKeystore(t) // reuse helper from nts_test.go
+	s := &Server{
+		Checker: &checker.SimpleChecker{ExpectedListeners: 1, ExpectedWorkers: 1},
+		Stats:   &stats.JSONStats{},
+		tasks:   make(chan task, 1),
+		Config:  Config{Workers: 1, TimestampType: timestamp.SWRX, Iface: "lo", Keystore: ks},
+	}
+	go s.startWorker()
+
+	conn := tryListenUDP(t)
+	defer conn.Close()
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	go s.startListener(conn)
+	time.Sleep(100 * time.Millisecond)
+
+	// build a real NTS request (helper already in nts_test.go)
+	uid := randBytes(t, nts.MinUniqueIdentifierLen)
+	req, s2c := buildNTSRequest(t, ks, ntp.AEADAESSIVCMAC512, uid, 2)
+
+	addr := net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", localAddr.Port))
+	sendConn, err := net.DialTimeout("udp", addr, time.Second)
+	require.NoError(t, err)
+	defer sendConn.Close()
+
+	_, err = sendConn.Write(req)
+	require.NoError(t, err)
+
+	buf := make([]byte, maxPacketSizeBytes)
+	require.NoError(t, sendConn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	n, err := sendConn.Read(buf)
+	require.NoError(t, err)
+
+	// open the response as the client would — proves the whole wiring works
+	inner, cleartext := openResponse(t, buf[:n], ntp.AEADAESSIVCMAC512, s2c)
+	require.Equal(t, 3, inner) // 1 + 2 placeholders
+	require.Zero(t, cleartext)
 }


### PR DESCRIPTION
Summary:
Wire processNTSRequest into the responder: parse NTS extension fields, verify
the request authenticator over the reconstructed associated data, and build the
NTS-protected response (UniqueID echo + fresh cookies sealed in the S2C
authenticator). The plain-NTP path stays zero-alloc via a per-worker buffer and
only parses trailing bytes as extension fields when NTS is enabled, so legacy
symmetric-key MAC packets are not dropped.

Reviewed By: vvfedorenko

Differential Revision: D112153068


