### PR TITLE
Expose C2S/S2C session keys from the KE handshake

### DIFF
--- a/ntp/ntske/client.go
+++ b/ntp/ntske/client.go
@@ -54,6 +54,10 @@ type HandshakeResult struct {
 	// CompliantExport reports whether the server echoed the chrony
 	// compliant-128-GCM-SIV-export record.
 	CompliantExport bool
+	// C2S and S2C are the directional session keys derived from the TLS session
+	// via the RFC 8915 exporter (C2S signs requests, S2C verifies responses).
+	C2S []byte
+	S2C []byte
 }
 
 // ClientTLSConfig builds a TLS 1.3 client config for NTS-KE. When caFile is
@@ -115,7 +119,24 @@ func (c *Client) Handshake(ctx context.Context, addr string, tlsConf *tls.Config
 	if err != nil {
 		return nil, fmt.Errorf("ntske: read response: %w", err)
 	}
-	return c.interpret(records)
+	res, err := c.interpret(records)
+	if err != nil {
+		return nil, err
+	}
+	// Derive the directional session keys from the TLS session using the same
+	// exporter label and context the server uses, so both ends agree on C2S/S2C.
+	keyLen, err := aeadIDToKeyLen(protocol.AEADAlgorithm(res.AEAD))
+	if err != nil {
+		return nil, fmt.Errorf("ntske: key length for aead %d: %w", res.AEAD, err)
+	}
+	cs := tlsConn.ConnectionState()
+	if res.C2S, err = exportKey(cs, res.AEAD, directionC2S, keyLen); err != nil {
+		return nil, fmt.Errorf("ntske: derive C2S: %w", err)
+	}
+	if res.S2C, err = exportKey(cs, res.AEAD, directionS2C, keyLen); err != nil {
+		return nil, fmt.Errorf("ntske: derive S2C: %w", err)
+	}
+	return res, nil
 }
 
 // writeRequest sends the NTS-KE request: Next Protocol NTPv4, the AEAD

--- a/ntp/ntske/client_test.go
+++ b/ntp/ntske/client_test.go
@@ -72,12 +72,12 @@ func clientFreePort(t *testing.T) string {
 
 // startTestKEServer spins up an in-process Server on an ephemeral port and
 // returns its address plus the CA PEM the client should trust.
-func startTestKEServer(t *testing.T, cookies uint16) (addr string, caPEM []byte) {
+func startTestKEServer(t *testing.T, cookies uint16) (addr string, ks *InMemoryKeystore, caPEM []byte) {
 	t.Helper()
 	certPEM, keyPEM := clientTestCert(t)
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	require.NoError(t, err)
-	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	ks, err = NewInMemoryKeystore(InMemoryKeystoreOptions{})
 	require.NoError(t, err)
 	srv := &Server{
 		TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
@@ -95,16 +95,16 @@ func startTestKEServer(t *testing.T, cookies uint16) (addr string, caPEM []byte)
 		c, derr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
 		if derr == nil {
 			_ = c.Close()
-			return addr, certPEM
+			return addr, ks, certPEM
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("server at %s never became ready", addr)
-	return "", nil
+	return "", nil, nil
 }
 
 func TestClientHandshake(t *testing.T) {
-	addr, caPEM := startTestKEServer(t, 8)
+	addr, _, caPEM := startTestKEServer(t, 8)
 	caFile := filepath.Join(t.TempDir(), "ca.pem")
 	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
 
@@ -118,8 +118,35 @@ func TestClientHandshake(t *testing.T) {
 	require.Len(t, res.Cookies, 8)
 }
 
+func TestClientHandshakeDerivesMatchingKeys(t *testing.T) {
+	addr, ks, caPEM := startTestKEServer(t, 8)
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
+
+	tlsConf, err := ClientTLSConfig(caFile)
+	require.NoError(t, err)
+
+	res, err := (&Client{}).Handshake(context.Background(), addr, tlsConf)
+	require.NoError(t, err)
+
+	// Keys are present, correctly sized, and directional (C2S != S2C).
+	keyLen, err := aeadIDToKeyLen(protocol.AEADAlgorithm(res.AEAD))
+	require.NoError(t, err)
+	require.Len(t, res.C2S, keyLen)
+	require.Len(t, res.S2C, keyLen)
+	require.NotEqual(t, res.C2S, res.S2C)
+
+	// The server sealed its own exporter-derived keys into the cookie; opening it
+	// must yield the same keys the client derived, proving both ends agree.
+	aeadID, srvC2S, srvS2C, err := ks.OpenCookie(res.Cookies[0])
+	require.NoError(t, err)
+	require.Equal(t, protocol.AEADAlgorithm(res.AEAD), aeadID)
+	require.Equal(t, srvC2S, res.C2S)
+	require.Equal(t, srvS2C, res.S2C)
+}
+
 func TestClientHandshakeUntrustedCert(t *testing.T) {
-	addr, _ := startTestKEServer(t, 8)
+	addr, _, _ := startTestKEServer(t, 8)
 	otherPEM, _ := clientTestCert(t) // a CA that does not contain the server's cert
 	caFile := filepath.Join(t.TempDir(), "other.pem")
 	require.NoError(t, os.WriteFile(caFile, otherPEM, 0o600))


### PR DESCRIPTION
Summary:
The KE handshake already derived the TLS-exporter session keys but threw them
away, leaving a client no way to sign NTPv4 requests or verify responses. Return
them from the handshake so the upcoming NTS NTPv4 client can use them. They are
derived with the same exporter inputs as the server, so both ends agree.

Reviewed By: vvfedorenko

Differential Revision: D113419245


