### PR TITLE
Add client-side NTS request/response helpers

### DIFF
--- a/ntp/ntske/client.go
+++ b/ntp/ntske/client.go
@@ -54,6 +54,10 @@ type HandshakeResult struct {
 	// CompliantExport reports whether the server echoed the chrony
 	// compliant-128-GCM-SIV-export record.
 	CompliantExport bool
+	// C2S and S2C are the directional session keys derived from the TLS session
+	// via the RFC 8915 exporter (C2S signs requests, S2C verifies responses).
+	C2S []byte
+	S2C []byte
 }
 
 // ClientTLSConfig builds a TLS 1.3 client config for NTS-KE. When caFile is
@@ -115,7 +119,24 @@ func (c *Client) Handshake(ctx context.Context, addr string, tlsConf *tls.Config
 	if err != nil {
 		return nil, fmt.Errorf("ntske: read response: %w", err)
 	}
-	return c.interpret(records)
+	res, err := c.interpret(records)
+	if err != nil {
+		return nil, err
+	}
+	// Derive the directional session keys from the TLS session using the same
+	// exporter label and context the server uses, so both ends agree on C2S/S2C.
+	keyLen, err := aeadIDToKeyLen(protocol.AEADAlgorithm(res.AEAD))
+	if err != nil {
+		return nil, fmt.Errorf("ntske: key length for aead %d: %w", res.AEAD, err)
+	}
+	cs := tlsConn.ConnectionState()
+	if res.C2S, err = exportKey(cs, res.AEAD, directionC2S, keyLen); err != nil {
+		return nil, fmt.Errorf("ntske: derive C2S: %w", err)
+	}
+	if res.S2C, err = exportKey(cs, res.AEAD, directionS2C, keyLen); err != nil {
+		return nil, fmt.Errorf("ntske: derive S2C: %w", err)
+	}
+	return res, nil
 }
 
 // writeRequest sends the NTS-KE request: Next Protocol NTPv4, the AEAD

--- a/ntp/ntske/client_test.go
+++ b/ntp/ntske/client_test.go
@@ -72,12 +72,12 @@ func clientFreePort(t *testing.T) string {
 
 // startTestKEServer spins up an in-process Server on an ephemeral port and
 // returns its address plus the CA PEM the client should trust.
-func startTestKEServer(t *testing.T, cookies uint16) (addr string, caPEM []byte) {
+func startTestKEServer(t *testing.T, cookies uint16) (addr string, ks *InMemoryKeystore, caPEM []byte) {
 	t.Helper()
 	certPEM, keyPEM := clientTestCert(t)
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	require.NoError(t, err)
-	ks, err := NewInMemoryKeystore(InMemoryKeystoreOptions{})
+	ks, err = NewInMemoryKeystore(InMemoryKeystoreOptions{})
 	require.NoError(t, err)
 	srv := &Server{
 		TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
@@ -95,16 +95,16 @@ func startTestKEServer(t *testing.T, cookies uint16) (addr string, caPEM []byte)
 		c, derr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
 		if derr == nil {
 			_ = c.Close()
-			return addr, certPEM
+			return addr, ks, certPEM
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("server at %s never became ready", addr)
-	return "", nil
+	return "", nil, nil
 }
 
 func TestClientHandshake(t *testing.T) {
-	addr, caPEM := startTestKEServer(t, 8)
+	addr, _, caPEM := startTestKEServer(t, 8)
 	caFile := filepath.Join(t.TempDir(), "ca.pem")
 	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
 
@@ -118,8 +118,35 @@ func TestClientHandshake(t *testing.T) {
 	require.Len(t, res.Cookies, 8)
 }
 
+func TestClientHandshakeDerivesMatchingKeys(t *testing.T) {
+	addr, ks, caPEM := startTestKEServer(t, 8)
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
+
+	tlsConf, err := ClientTLSConfig(caFile)
+	require.NoError(t, err)
+
+	res, err := (&Client{}).Handshake(context.Background(), addr, tlsConf)
+	require.NoError(t, err)
+
+	// Keys are present, correctly sized, and directional (C2S != S2C).
+	keyLen, err := aeadIDToKeyLen(protocol.AEADAlgorithm(res.AEAD))
+	require.NoError(t, err)
+	require.Len(t, res.C2S, keyLen)
+	require.Len(t, res.S2C, keyLen)
+	require.NotEqual(t, res.C2S, res.S2C)
+
+	// The server sealed its own exporter-derived keys into the cookie; opening it
+	// must yield the same keys the client derived, proving both ends agree.
+	aeadID, srvC2S, srvS2C, err := ks.OpenCookie(res.Cookies[0])
+	require.NoError(t, err)
+	require.Equal(t, protocol.AEADAlgorithm(res.AEAD), aeadID)
+	require.Equal(t, srvC2S, res.C2S)
+	require.Equal(t, srvS2C, res.S2C)
+}
+
 func TestClientHandshakeUntrustedCert(t *testing.T) {
-	addr, _ := startTestKEServer(t, 8)
+	addr, _, _ := startTestKEServer(t, 8)
 	otherPEM, _ := clientTestCert(t) // a CA that does not contain the server's cert
 	caFile := filepath.Join(t.TempDir(), "other.pem")
 	require.NoError(t, os.WriteFile(caFile, otherPEM, 0o600))

--- a/ntp/protocol/nts/client.go
+++ b/ntp/protocol/nts/client.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nts
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/facebook/time/ntp/protocol"
+)
+
+// RequestParams is everything a client needs to build one NTS-protected request.
+type RequestParams struct {
+	AEAD         protocol.AEADAlgorithm
+	C2S          []byte // client-to-server key from the KE handshake
+	Cookie       []byte // one cookie to spend
+	UniqueID     []byte // fresh nonce, >= MinUniqueIdentifierLen octets
+	Placeholders int    // NTSCookiePlaceholder EFs requesting extra fresh cookies
+}
+
+// BuildNTSRequest returns wire-ready bytes for an NTS-protected NTPv4 request:
+// header + UID -> Cookie -> N placeholders -> Authenticator (sealed with C2S).
+func BuildNTSRequest(base protocol.Packet, p RequestParams) ([]byte, error) {
+	if len(p.UniqueID) < MinUniqueIdentifierLen {
+		return nil, fmt.Errorf("nts: unique identifier must be >= %d octets", MinUniqueIdentifierLen)
+	}
+	if len(p.Cookie) == 0 {
+		return nil, errors.New("nts: cookie is required")
+	}
+	if p.Placeholders < 0 {
+		return nil, errors.New("nts: placeholders must be >= 0")
+	}
+	aead, err := NewAEAD(p.AEAD, p.C2S)
+	if err != nil {
+		return nil, fmt.Errorf("nts: building C2S AEAD: %w", err)
+	}
+
+	efs := make([]protocol.ExtensionField, 0, 3+p.Placeholders)
+	efs = append(efs, NewUniqueIdentifier(p.UniqueID), NewCookie(p.Cookie))
+	for range p.Placeholders {
+		efs = append(efs, NewCookiePlaceholder(len(p.Cookie)))
+	}
+	base.ExtensionFields = efs
+
+	// Associated data is the header plus every EF preceding the authenticator.
+	ad, err := base.AssociatedData(len(efs))
+	if err != nil {
+		return nil, fmt.Errorf("nts: reconstructing request associated data: %w", err)
+	}
+	// A request carries no encrypted extension fields, so the plaintext is empty.
+	auth, err := SealAuthenticator(aead, ad, nil)
+	if err != nil {
+		return nil, fmt.Errorf("nts: sealing request authenticator: %w", err)
+	}
+	base.ExtensionFields = append(base.ExtensionFields, auth)
+	return base.Bytes()
+}
+
+// VerifyNTSResponse checks the echoed UniqueIdentifier matches reqUID, verifies
+// the authenticator with S2C, and returns the packet plus the fresh cookies.
+func VerifyNTSResponse(resp []byte, aeadID protocol.AEADAlgorithm, s2c, reqUID []byte) (*protocol.Packet, [][]byte, error) {
+	pkt := &protocol.Packet{}
+	if err := pkt.UnmarshalBinary(resp); err != nil {
+		return nil, nil, fmt.Errorf("nts: parsing response: %w", err)
+	}
+
+	var (
+		uidBody []byte
+		authEF  *protocol.ExtensionField
+		authIdx = -1
+	)
+	for i := range pkt.ExtensionFields {
+		ef := &pkt.ExtensionFields[i]
+		if ef.Type == protocol.UniqueIdentifier {
+			uidBody = ef.Body
+		}
+		if ef.Type == protocol.NTSAuthenticator {
+			authEF = ef
+			authIdx = i
+			break
+		}
+	}
+	switch {
+	case uidBody == nil:
+		return nil, nil, errors.New("nts: response missing unique identifier")
+	case !bytes.Equal(uidBody, reqUID):
+		return nil, nil, errors.New("nts: response unique identifier does not match request")
+	case authEF == nil:
+		return nil, nil, errors.New("nts: response missing authenticator")
+	case authIdx != len(pkt.ExtensionFields)-1:
+		// RFC 8915 §5.6: the authenticator must be the last EF, otherwise any
+		// trailing extension fields would be returned unauthenticated.
+		return nil, nil, errors.New("nts: authenticator must be the last extension field")
+	}
+
+	ad, err := pkt.AssociatedData(authIdx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nts: reconstructing response associated data: %w", err)
+	}
+	aead, err := NewAEAD(aeadID, s2c)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nts: building S2C AEAD: %w", err)
+	}
+	// The fresh cookies travel encrypted inside the authenticator (RFC 8915 §5.7).
+	plaintext, err := OpenAuthenticator(aead, ad, *authEF)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nts: verifying response authenticator: %w", err)
+	}
+	encEFs, err := protocol.ParseExtensionFields(plaintext)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nts: parsing encrypted cookies: %w", err)
+	}
+	var cookies [][]byte
+	for _, ef := range encEFs {
+		if ef.Type == protocol.NTSCookie {
+			cookies = append(cookies, ef.Body)
+		}
+	}
+	return pkt, cookies, nil
+}

--- a/ntp/protocol/nts/client_test.go
+++ b/ntp/protocol/nts/client_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nts
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/facebook/time/ntp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+const testAEAD = protocol.AEADAES128GCMSIV // 16-octet keys
+
+func testKey(b byte) []byte { return bytes.Repeat([]byte{b}, 16) }
+func testUID() []byte       { return bytes.Repeat([]byte{9}, MinUniqueIdentifierLen) }
+
+// sealResponse mimics the server: UID echo in the clear + an authenticator that
+// encrypts the fresh cookies, sealed with the S2C key.
+func sealResponse(t *testing.T, aeadID protocol.AEADAlgorithm, s2c, uid []byte, cookies [][]byte) []byte {
+	t.Helper()
+	resp := &protocol.Packet{Settings: 0x24}
+	resp.ExtensionFields = []protocol.ExtensionField{NewUniqueIdentifier(uid)}
+	ad, err := resp.AssociatedData(1)
+	require.NoError(t, err)
+
+	cookieEFs := make([]protocol.ExtensionField, 0, len(cookies))
+	for _, c := range cookies {
+		cookieEFs = append(cookieEFs, NewCookie(c))
+	}
+	enc, err := protocol.MarshalExtensionFields(cookieEFs)
+	require.NoError(t, err)
+
+	aead, err := NewAEAD(aeadID, s2c)
+	require.NoError(t, err)
+	auth, err := SealAuthenticator(aead, ad, enc)
+	require.NoError(t, err)
+	resp.ExtensionFields = append(resp.ExtensionFields, auth)
+
+	b, err := resp.Bytes()
+	require.NoError(t, err)
+	return b
+}
+
+func TestBuildNTSRequestOrder(t *testing.T) {
+	base := protocol.Packet{Settings: 0x1B}
+	reqBytes, err := BuildNTSRequest(base, RequestParams{
+		AEAD: testAEAD, C2S: testKey(3), Cookie: []byte("a-cookie-value"),
+		UniqueID: testUID(), Placeholders: 2,
+	})
+	require.NoError(t, err)
+
+	pkt := &protocol.Packet{}
+	require.NoError(t, pkt.UnmarshalBinary(reqBytes))
+
+	got := make([]protocol.ExtensionFieldType, 0, len(pkt.ExtensionFields))
+	for _, ef := range pkt.ExtensionFields {
+		got = append(got, ef.Type)
+	}
+	require.Equal(t, []protocol.ExtensionFieldType{
+		protocol.UniqueIdentifier,
+		protocol.NTSCookie,
+		protocol.NTSCookiePlaceholder,
+		protocol.NTSCookiePlaceholder,
+		protocol.NTSAuthenticator,
+	}, got)
+}
+
+func TestBuildNTSRequestValidates(t *testing.T) {
+	base := protocol.Packet{}
+	_, err := BuildNTSRequest(base, RequestParams{
+		AEAD: testAEAD, C2S: testKey(3), Cookie: []byte("c"), UniqueID: []byte("short"),
+	})
+	require.Error(t, err)
+
+	_, err = BuildNTSRequest(base, RequestParams{
+		AEAD: testAEAD, C2S: testKey(3), Cookie: nil, UniqueID: testUID(),
+	})
+	require.Error(t, err)
+}
+
+func TestVerifyNTSResponseRoundTrip(t *testing.T) {
+	s2c := testKey(1)
+	uid := testUID()
+	fresh := [][]byte{[]byte("cookie-1"), []byte("cookie-2")}
+	resp := sealResponse(t, testAEAD, s2c, uid, fresh)
+
+	pkt, cookies, err := VerifyNTSResponse(resp, testAEAD, s2c, uid)
+	require.NoError(t, err)
+	require.NotNil(t, pkt)
+	require.Equal(t, fresh, cookies)
+}
+
+// TestNTPRoundTrip exercises both helpers for every supported AEAD: build a
+// request, confirm its authenticator verifies (server side), then verify a reply.
+func TestNTPRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		aead   protocol.AEADAlgorithm
+		keyLen int
+	}{
+		{"AES-128-GCM-SIV", protocol.AEADAES128GCMSIV, 16},
+		{"AES-SIV-CMAC-512", protocol.AEADAESSIVCMAC512, 64},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c2s := bytes.Repeat([]byte{3}, tc.keyLen)
+			s2c := bytes.Repeat([]byte{4}, tc.keyLen)
+			uid := testUID()
+
+			reqBytes, err := BuildNTSRequest(protocol.Packet{Settings: 0x23}, RequestParams{
+				AEAD: tc.aead, C2S: c2s, Cookie: []byte("a-cookie-value"),
+				UniqueID: uid, Placeholders: 1,
+			})
+			require.NoError(t, err)
+
+			// Server side: the request authenticator verifies under C2S.
+			req := &protocol.Packet{}
+			require.NoError(t, req.UnmarshalBinary(reqBytes))
+			authIdx := -1
+			for i := range req.ExtensionFields {
+				if req.ExtensionFields[i].Type == protocol.NTSAuthenticator {
+					authIdx = i
+					break
+				}
+			}
+			require.GreaterOrEqual(t, authIdx, 0)
+			reqAD, err := req.AssociatedData(authIdx)
+			require.NoError(t, err)
+			c2sAEAD, err := NewAEAD(tc.aead, c2s)
+			require.NoError(t, err)
+			_, err = OpenAuthenticator(c2sAEAD, reqAD, req.ExtensionFields[authIdx])
+			require.NoError(t, err)
+
+			// Client verifies the server's response.
+			fresh := [][]byte{[]byte("fresh-01"), []byte("fresh-02")}
+			resp := sealResponse(t, tc.aead, s2c, uid, fresh)
+			_, cookies, err := VerifyNTSResponse(resp, tc.aead, s2c, uid)
+			require.NoError(t, err)
+			require.Equal(t, fresh, cookies)
+		})
+	}
+}
+
+func TestVerifyNTSResponseRejects(t *testing.T) {
+	s2c := testKey(1)
+	uid := testUID()
+	resp := sealResponse(t, testAEAD, s2c, uid, [][]byte{[]byte("cookie-1")})
+
+	// UID that does not match the request.
+	_, _, err := VerifyNTSResponse(resp, testAEAD, s2c, bytes.Repeat([]byte{7}, MinUniqueIdentifierLen))
+	require.Error(t, err)
+
+	// Wrong S2C key fails authenticator verification.
+	_, _, err = VerifyNTSResponse(resp, testAEAD, testKey(2), uid)
+	require.Error(t, err)
+}
+
+func TestVerifyNTSResponseRejectsTrailingEF(t *testing.T) {
+	s2c := testKey(1)
+	uid := testUID()
+	resp := &protocol.Packet{Settings: 0x24}
+	resp.ExtensionFields = []protocol.ExtensionField{NewUniqueIdentifier(uid)}
+	ad, err := resp.AssociatedData(1)
+	require.NoError(t, err)
+	aead, err := NewAEAD(testAEAD, s2c)
+	require.NoError(t, err)
+	auth, err := SealAuthenticator(aead, ad, nil)
+	require.NoError(t, err)
+	// An extension field after the authenticator is unauthenticated and must be rejected.
+	resp.ExtensionFields = append(resp.ExtensionFields, auth, NewCookiePlaceholder(16))
+	b, err := resp.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = VerifyNTSResponse(b, testAEAD, s2c, uid)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Summary:
Adds reusable BuildNTPRequest and VerifyNTPResponse helpers, the client mirror of
the server's request path, so the smoke client (and future NTS clients) can build
authenticated NTPv4 requests and verify responses without duplicating the logic.

Reviewed By: vvfedorenko

Differential Revision: D113422499


