### PR TITLE
Add -enable-nts flag seeding shared keystore

### DIFF
--- a/ntp/responder/server/config.go
+++ b/ntp/responder/server/config.go
@@ -31,19 +31,21 @@ var DefaultServerIPs = MultiIPs{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
 
 // Config is a server config structure
 type Config struct {
-	ExtraOffset    time.Duration
-	Iface          string
-	IPs            MultiIPs
-	ManageLoopback bool
-	MonitoringPort int
-	Port           int
-	RefID          string
-	ShouldAnnounce bool
-	Stratum        int
-	TimestampType  timestamp.Timestamp
-	Workers        int
-	Keystore       ntske.Keystore // if non-nil enables NTS auth path.
-	phcOffset      time.Duration
+	ExtraOffset     time.Duration
+	Iface           string
+	IPs             MultiIPs
+	ManageLoopback  bool
+	MonitoringPort  int
+	Port            int
+	RefID           string
+	ShouldAnnounce  bool
+	Stratum         int
+	TimestampType   timestamp.Timestamp
+	Workers         int
+	Keystore        ntske.Keystore // if non-nil enables NTS auth path.
+	EnableNTS       bool           // when set, build an NTS keystore on startup and install it as Keystore
+	NTSKeystoreKeys int            // NTS cookie master-key ring size
+	phcOffset       time.Duration
 }
 
 // MultiIPs is a wrapper allowing to set multiple IPs with flag parser


### PR DESCRIPTION
Summary:
Adds an opt-in NTS path to the deployed responder binary. When -enable-nts is
set, the responder builds an in-memory keystore seeded with
ntske.SharedTestMasterKey and assigns it to Config.Keystore, which is the switch
that turns on NTS packet handling in the server. The same fixed key seeds the
standalone ntske (NTS-KE) job, so cookies it issues open here.

- New flags: -enable-nts (default false) and -nts-keystore-keys (default 2)
- Defaults off: no behavior change unless explicitly enabled
- NTS-KE remains a separate binary/job; no cert or KE listener added here

Reviewed By: pmazzini

Differential Revision: D113900828


