### PR TITLE
Parse NTS-KE Server/Port Negotiation records in client (#572)

### DIFF
--- a/ntp/ntske/client.go
+++ b/ntp/ntske/client.go
@@ -58,6 +58,10 @@ type HandshakeResult struct {
 	// via the RFC 8915 exporter (C2S signs requests, S2C verifies responses).
 	C2S []byte
 	S2C []byte
+	// NTPServer is the NTPv4 server from a Server Negotiation record, or "".
+	NTPServer string
+	// NTPPort is the NTPv4 port from a Port Negotiation record, or 0.
+	NTPPort uint16
 }
 
 // ClientTLSConfig builds a TLS 1.3 client config for NTS-KE. When caFile is
@@ -166,6 +170,8 @@ func (c *Client) interpret(records []Record) (*HandshakeResult, error) {
 		res          HandshakeResult
 		sawNextProto bool
 		sawAEAD      bool
+		sawServer    bool
+		sawPort      bool
 	)
 	for _, r := range records {
 		switch r.Type {
@@ -199,6 +205,28 @@ func (c *Client) interpret(records []Record) (*HandshakeResult, error) {
 			res.Cookies = append(res.Cookies, r.Body)
 		case RecordCompliant128GCMExport:
 			res.CompliantExport = true
+		case RecordServerNegotiation:
+			if sawServer {
+				return nil, errors.New("multiple Server Negotiation records")
+			}
+			if len(r.Body) == 0 {
+				return nil, errors.New("empty Server Negotiation record")
+			}
+			res.NTPServer = string(r.Body)
+			sawServer = true
+		case RecordPortNegotiation:
+			if sawPort {
+				return nil, errors.New("multiple Port Negotiation records")
+			}
+			ports, err := ParseUint16s(r.Body)
+			if err != nil {
+				return nil, fmt.Errorf("malformed Port Negotiation body: %w", err)
+			}
+			if len(ports) == 0 {
+				return nil, errors.New("empty Port Negotiation record")
+			}
+			res.NTPPort = ports[0]
+			sawPort = true
 		}
 	}
 

--- a/ntp/ntske/client_test.go
+++ b/ntp/ntske/client_test.go
@@ -210,6 +210,58 @@ func TestClientInterpret(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, res.CompliantExport)
 	})
+	t.Run("server and port negotiation captured", func(t *testing.T) {
+		wantServer, wantPort := "ntp.example", uint16(4460)
+		res, err := c.interpret([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(uint16(protocol.AEADAES128GCMSIV)),
+			NewServerNegotiation(wantServer),
+			NewPortNegotiation(wantPort),
+			cookie(1),
+		})
+		require.NoError(t, err)
+		require.Equal(t, wantServer, res.NTPServer)
+		require.Equal(t, wantPort, res.NTPPort)
+	})
+	t.Run("empty server negotiation rejected", func(t *testing.T) {
+		_, err := c.interpret([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(uint16(protocol.AEADAES128GCMSIV)),
+			{Type: RecordServerNegotiation}, // present but empty body
+			cookie(1),
+		})
+		require.Error(t, err)
+	})
+	t.Run("duplicate server negotiation rejected", func(t *testing.T) {
+		_, err := c.interpret([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(uint16(protocol.AEADAES128GCMSIV)),
+			NewServerNegotiation("ntp1.example"),
+			NewServerNegotiation("ntp2.example"),
+			cookie(1),
+		})
+		require.Error(t, err)
+	})
+	t.Run("duplicate port negotiation rejected", func(t *testing.T) {
+		_, err := c.interpret([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(uint16(protocol.AEADAES128GCMSIV)),
+			NewPortNegotiation(4460),
+			NewPortNegotiation(4461),
+			cookie(1),
+		})
+		require.Error(t, err)
+	})
+	t.Run("no server or port negotiation", func(t *testing.T) {
+		res, err := c.interpret([]Record{
+			NewNextProtocol(NextProtocolNTPv4),
+			NewAEADAlgorithm(uint16(protocol.AEADAES128GCMSIV)),
+			cookie(1),
+		})
+		require.NoError(t, err)
+		require.Empty(t, res.NTPServer)
+		require.Zero(t, res.NTPPort)
+	})
 	t.Run("server error record", func(t *testing.T) {
 		_, err := c.interpret([]Record{NewError(1)})
 		require.Error(t, err)


### PR DESCRIPTION
Summary:

Capture the RFC 8915 Server Negotiation (6) and Port Negotiation (7)
records from the KE reply into HandshakeResult.NTPServer / NTPPort so
clients can target the KE-advertised NTP endpoint instead of guessing.

Reviewed By: pmazzini

Differential Revision: D114051165


