### PR TITLE
Change all metrics name flat

### DIFF
--- a/ntp/responder/server/nts_test.go
+++ b/ntp/responder/server/nts_test.go
@@ -580,9 +580,9 @@ func TestServeNTSStatsRouting(t *testing.T) {
 			tsk.serve(&ntp.Packet{}, 0)
 
 			counters := js.ToMap()
-			require.Equal(t, tc.wantOK, counters["nts.auth_ok"], "nts.auth_ok")
-			require.Equal(t, tc.wantAuth, counters["nts.auth_failed"], "nts.auth_failed")
-			require.Equal(t, tc.wantCookie, counters["nts.cookie_open_failed"], "nts.cookie_open_failed")
+			require.Equal(t, tc.wantOK, counters["nts_auth_ok"], "nts_auth_ok")
+			require.Equal(t, tc.wantAuth, counters["nts_auth_failed"], "nts_auth_failed")
+			require.Equal(t, tc.wantCookie, counters["nts_cookie_open_failed"], "nts_cookie_open_failed")
 			require.Equal(t, tc.wantInvalid, counters["invalidformat"], "invalidformat")
 		})
 	}

--- a/ntp/responder/stats/json.go
+++ b/ntp/responder/stats/json.go
@@ -58,9 +58,9 @@ func (j *JSONStats) ToMap() (export map[string]int64) {
 	export["workers"] = j.workers
 	export["readError"] = j.readError
 	export["announce"] = j.announce
-	export["nts.auth_ok"] = j.ntsAuthOK
-	export["nts.auth_failed"] = j.ntsAuthFailed
-	export["nts.cookie_open_failed"] = j.ntsCookieOpenFailed
+	export["nts_auth_ok"] = j.ntsAuthOK
+	export["nts_auth_failed"] = j.ntsAuthFailed
+	export["nts_cookie_open_failed"] = j.ntsCookieOpenFailed
 
 	return export
 }

--- a/ntp/responder/stats/json_test.go
+++ b/ntp/responder/stats/json_test.go
@@ -124,9 +124,9 @@ func TestJSONStatsToMap(t *testing.T) {
 	expectedMap["workers"] = 5
 	expectedMap["readError"] = 6
 	expectedMap["announce"] = 7
-	expectedMap["nts.auth_ok"] = 8
-	expectedMap["nts.auth_failed"] = 9
-	expectedMap["nts.cookie_open_failed"] = 10
+	expectedMap["nts_auth_ok"] = 8
+	expectedMap["nts_auth_failed"] = 9
+	expectedMap["nts_cookie_open_failed"] = 10
 
 	require.Equal(t, expectedMap, result)
 }


### PR DESCRIPTION
Summary:
Change following metrics names
    nts_auth_ok
    nts_auth_failed 
    nts_cookie_open_failed

Reviewed By: leoleovich

Differential Revision: D114070486


