### PR TITLE
Hex-decode the NTS cookie master key read from file

### DIFF
--- a/ntp/ntske/master_key.go
+++ b/ntp/ntske/master_key.go
@@ -18,21 +18,29 @@ package ntske
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 )
 
-// LoadMasterKeyFromFile reads and length-validates the cookie master key. Bytes
-// are read verbatim (no trimming) so KE and NTP agree on the key; a read error or
-// under-length key is returned (fail closed) rather than starting with a bad key.
+// LoadMasterKeyFromFile reads the hex-encoded cookie master key and decodes it to
+// raw bytes. Surrounding whitespace (e.g. a trailing newline from secrets_tool) is
+// trimmed before decoding. A read error, malformed hex, or under-length key is
+// returned (fail closed) so a bad key never starts the server. KE and NTP decode
+// identically, so they agree on the raw key.
 func LoadMasterKeyFromFile(path string) ([]byte, error) {
-	master, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("ntske: read master key %q: %w", path, err)
 	}
+	master, err := hex.DecodeString(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return nil, fmt.Errorf("ntske: decode hex master key %q: %w", path, err)
+	}
 	if len(master) < masterKeyMinLength {
-		return nil, fmt.Errorf("%w: file %q has %d octets, need >= %d",
+		return nil, fmt.Errorf("%w: file %q decodes to %d octets, need >= %d",
 			ErrMasterKeyTooShort, path, len(master), masterKeyMinLength)
 	}
 	return master, nil

--- a/ntp/ntske/master_key_test.go
+++ b/ntp/ntske/master_key_test.go
@@ -18,12 +18,20 @@ package ntske
 
 import (
 	"bytes"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// hexKeyFile writes key hex-encoded (as the Keychain secret is stored) and returns
+// the path.
+func hexKeyFile(t *testing.T, key []byte) string {
+	t.Helper()
+	return writeKeyFile(t, []byte(hex.EncodeToString(key)))
+}
 
 func writeKeyFile(t *testing.T, data []byte) string {
 	t.Helper()
@@ -32,21 +40,27 @@ func writeKeyFile(t *testing.T, data []byte) string {
 	return path
 }
 
-// a valid-length key file loads verbatim.
+// a hex-encoded key file decodes to the raw key.
 func TestLoadMasterKeyFromFileValid(t *testing.T) {
 	want := bytes.Repeat([]byte{0x2a}, masterKeyLen)
-	got, err := LoadMasterKeyFromFile(writeKeyFile(t, want))
+	got, err := LoadMasterKeyFromFile(hexKeyFile(t, want))
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
 
-// bytes are read verbatim: a trailing newline is not stripped.
-func TestLoadMasterKeyFromFileVerbatim(t *testing.T) {
-	want := append(bytes.Repeat([]byte{0x2a}, masterKeyLen), '\n')
-	got, err := LoadMasterKeyFromFile(writeKeyFile(t, want))
+// surrounding whitespace (e.g. a trailing newline from secrets_tool) is trimmed
+// before decoding.
+func TestLoadMasterKeyFromFileTrimsWhitespace(t *testing.T) {
+	want := bytes.Repeat([]byte{0x2a}, masterKeyLen)
+	got, err := LoadMasterKeyFromFile(writeKeyFile(t, []byte(hex.EncodeToString(want)+"\n")))
 	require.NoError(t, err)
 	require.Equal(t, want, got)
-	require.Len(t, got, masterKeyLen+1)
+}
+
+// non-hex contents are rejected (fail closed).
+func TestLoadMasterKeyFromFileInvalidHex(t *testing.T) {
+	_, err := LoadMasterKeyFromFile(writeKeyFile(t, []byte("nothexZZ")))
+	require.Error(t, err)
 }
 
 // a missing file is a distinct not-exist error.
@@ -55,9 +69,9 @@ func TestLoadMasterKeyFromFileMissing(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
-// an under-length key is rejected (fail closed).
+// an under-length key (after decoding) is rejected (fail closed).
 func TestLoadMasterKeyFromFileTooShort(t *testing.T) {
-	_, err := LoadMasterKeyFromFile(writeKeyFile(t, bytes.Repeat([]byte{1}, masterKeyMinLength-1)))
+	_, err := LoadMasterKeyFromFile(hexKeyFile(t, bytes.Repeat([]byte{1}, masterKeyMinLength-1)))
 	require.ErrorIs(t, err, ErrMasterKeyTooShort)
 }
 
@@ -91,7 +105,7 @@ func TestNewKeystoreInMemoryFallback(t *testing.T) {
 
 // a master-key path selects the DerivedKeystore.
 func TestNewKeystoreDerived(t *testing.T) {
-	path := writeKeyFile(t, bytes.Repeat([]byte{0x2a}, masterKeyLen))
+	path := hexKeyFile(t, bytes.Repeat([]byte{0x2a}, masterKeyLen))
 	ks, err := NewKeystore(KeystoreConfig{MasterKeyPath: path})
 	require.NoError(t, err)
 	_, ok := ks.(*DerivedKeystore)


### PR DESCRIPTION
Summary:
The NTS cookie master key is stored in Keychain hex-encoded (secrets_tool
get_from_group NTS_COOKIE_MASTER_KEY TIME), so the Tupperware-materialized
file holds 128 hex chars, not the 64 raw octets the keystore needs.

Decode it in LoadMasterKeyFromFile: trim surrounding whitespace (e.g. a
trailing newline), hex-decode to raw bytes, then length-validate. Malformed
hex or an under-length decoded key fails closed so a bad key never starts the
server. KE and NTP decode identically, so they still agree on the raw key.

Reviewed By: leoleovich

Differential Revision: D115199117


