### PR TITLE
Fuzz RTCM3 frame validation

### DIFF
--- a/rtcm/rtcm_test.go
+++ b/rtcm/rtcm_test.go
@@ -225,3 +225,25 @@ func TestParseFrameExtraTrailingData(t *testing.T) {
 	// Raw should be only the frame, not the trailing bytes.
 	require.Len(t, frame.Raw, HeaderSize+20+CRCSize)
 }
+
+// FuzzParseFrame fuzzes RTCM3 frame validation. ParseFrame sits on the hot path
+// for every GNSS correction stream the daemon ingests (see cmd/ntripper), and
+// the input is untrusted network data, so no input may panic or hang it.
+func FuzzParseFrame(f *testing.F) {
+	for _, seed := range [][]byte{
+		{},
+		{0},
+		{9},
+		buildFrame(buildPayloadWithType(TypeStationARP, 20)),
+		buildFrame(buildPayloadWithType(TypeGPSMSM7, 100)),
+		buildFrame(buildPayloadWithType(TypeGLONASSBiases, 10)),
+		buildFrame(make([]byte, MaxPayloadLen)),
+		buildFrame(nil),
+		{0xD3, 0x00, 0x00, 0x00, 0x00, 0x00},
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, b []byte) {
+		_, _ = ParseFrame(b)
+	})
+}


### PR DESCRIPTION
## Summary
Adds a fuzz target for the `rtcm` package's `ParseFrame` entry point, which validates RTCM3 frame framing (preamble, 10-bit payload length) and CRC-24Q. `ParseFrame` is the core validator invoked by both `Scanner` and `MixedScanner`, the incremental scanners `cmd/ntripper` uses to ingest untrusted GNSS correction data from a socket.

The `rtcm` package is the one network-facing binary parser without fuzz coverage; this matches the repo's existing OSS-Fuzz targets (`ntp/protocol` `FuzzBytesToPacket`, `ptp/protocol` `FuzzDecodePacket`, `ntp/chrony` `FuzzDecodePacket`, `ntp/control` `FuzzNormalizeData`, `leaphash` `FuzzCompute`, `leapsectz` `FuzzParse`, `fbclock/daemon` `FuzzPrepareExpression`).

## Verification
- `go test ./rtcm/` passes (all existing tests)
- `go vet ./rtcm/` clean
- `go test -fuzz FuzzParseFrame -fuzztime=5s` — 460k execs across 24 workers, 0 crashes

## Type
tests